### PR TITLE
JBPM-6108 ObjectSelector should not appear in Form-modeler editor

### DIFF
--- a/appformer-bom/pom.xml
+++ b/appformer-bom/pom.xml
@@ -59,6 +59,16 @@
       </dependency>
       <dependency>
         <groupId>org.kie.appformer</groupId>
+        <artifactId>appformer-form-modeler-fields-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.appformer</groupId>
+        <artifactId>appformer-form-modeler-fields-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie.appformer</groupId>
         <artifactId>appformer-ala-wildfly-provider</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/appformer-form-modeler/appformer-form-modeler-codegen/appformer-form-modeler-codegen-impl/pom.xml
+++ b/appformer-form-modeler/appformer-form-modeler-codegen/appformer-form-modeler-codegen-impl/pom.xml
@@ -142,12 +142,17 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
-      <artifactId>kie-wb-common-forms-fields</artifactId>
+      <artifactId>kie-wb-common-forms-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
       <artifactId>kie-wb-common-dynamic-forms-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.appformer</groupId>
+      <artifactId>appformer-form-modeler-fields-api</artifactId>
     </dependency>
 
     <!-- test -->

--- a/appformer-form-modeler/appformer-form-modeler-codegen/appformer-form-modeler-codegen-impl/src/main/java/org/kie/appformer/formmodeler/codegen/view/impl/html/inputs/ObjectSelectorTemplateProvider.java
+++ b/appformer-form-modeler/appformer-form-modeler-codegen/appformer-form-modeler-codegen-impl/src/main/java/org/kie/appformer/formmodeler/codegen/view/impl/html/inputs/ObjectSelectorTemplateProvider.java
@@ -19,7 +19,7 @@ package org.kie.appformer.formmodeler.codegen.view.impl.html.inputs;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
 
 @Dependent

--- a/appformer-form-modeler/appformer-form-modeler-codegen/appformer-form-modeler-codegen-impl/src/test/java/org/kie/appformer/formmodeler/codegen/view/java/inputs/impl/ObjectSelectorBoxHelperTest.java
+++ b/appformer-form-modeler/appformer-form-modeler-codegen/appformer-form-modeler-codegen-impl/src/test/java/org/kie/appformer/formmodeler/codegen/view/java/inputs/impl/ObjectSelectorBoxHelperTest.java
@@ -20,15 +20,15 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.runner.RunWith;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
 import org.kie.appformer.formmodeler.codegen.view.impl.java.inputs.InputCreatorHelper;
 import org.kie.appformer.formmodeler.codegen.view.impl.java.inputs.impl.ObjectSelectorBoxHelper;
 import org.kie.appformer.formmodeler.codegen.view.java.inputs.AbstractInputHelperTest;
 import org.kie.appformer.formmodeler.codegen.view.java.test.util.InputCreatorHelpersProvider;
-import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
 import org.kie.workbench.common.forms.model.FieldDefinition;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ObjectSelectorBoxHelperTest extends AbstractInputHelperTest {

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/pom.xml
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>appformer-form-modeler-fields</artifactId>
+    <groupId>org.kie.appformer</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <description>AppFormer::Form Modeler::Fields Api</description>
+
+  <artifactId>appformer-form-modeler-fields-api</artifactId>
+  <dependencies>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-fields</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-api</artifactId>
+    </dependency>
+
+    <!-- tests -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/definition/ObjectSelectorFieldDefinition.java
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/definition/ObjectSelectorFieldDefinition.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.definition;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.jboss.errai.databinding.client.api.Bindable;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.type.ObjectSelectorFieldType;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormDefinition;
+import org.kie.workbench.common.forms.adf.definitions.annotations.FormField;
+import org.kie.workbench.common.forms.adf.definitions.annotations.i18n.I18nSettings;
+import org.kie.workbench.common.forms.fields.shared.AbstractFieldDefinition;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.EntityRelationField;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.HasMask;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+
+@Portable
+@Bindable
+@FormDefinition(
+        i18n = @I18nSettings(keyPreffix = "FieldProperties"),
+        startElement = "label"
+)
+public class ObjectSelectorFieldDefinition extends AbstractFieldDefinition implements EntityRelationField,
+                                                                                      HasMask {
+
+    public static final ObjectSelectorFieldType FIELD_TYPE = new ObjectSelectorFieldType();
+
+    /*
+    Expression to mask the value based on the object properties. The object properties should be surrounded by '{' and
+    '}', for example {propertyName}.
+    For example, an expression to mask a user object could be like: "{lastName}, {name}", when a given user instance is
+    masked it will result on a text like "Shakespeare, William".
+     */
+    @FormField(
+            labelKey = "mask",
+            afterElement = "label"
+    )
+    protected String mask = "";
+
+    public ObjectSelectorFieldDefinition() {
+        super(Object.class.getName());
+    }
+
+    @Override
+    public ObjectSelectorFieldType getFieldType() {
+        return FIELD_TYPE;
+    }
+
+    @Override
+    public String getMask() {
+        return mask;
+    }
+
+    @Override
+    public void setMask(String mask) {
+        this.mask = mask;
+    }
+
+    @Override
+    protected void doCopyFrom(FieldDefinition other) {
+        if (other instanceof HasMask) {
+            setMask(((HasMask) other).getMask());
+        }
+    }
+}

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/provider/ObjectSelectorFieldProvider.java
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/provider/ObjectSelectorFieldProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.provider;
+
+import javax.enterprise.context.Dependent;
+
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.type.ObjectSelectorFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.EntityRelationField;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.ModelTypeFieldProvider;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.TypeInfo;
+import org.kie.workbench.common.forms.model.TypeKind;
+
+@Dependent
+public class ObjectSelectorFieldProvider implements ModelTypeFieldProvider<ObjectSelectorFieldDefinition> {
+
+    @Override
+    public Class<ObjectSelectorFieldType> getFieldType() {
+        return ObjectSelectorFieldType.class;
+    }
+
+    @Override
+    public String getFieldTypeName() {
+        return ObjectSelectorFieldDefinition.FIELD_TYPE.getTypeName();
+    }
+
+    @Override
+    public ObjectSelectorFieldDefinition getDefaultField() {
+        return new ObjectSelectorFieldDefinition();
+    }
+
+    @Override
+    public ObjectSelectorFieldDefinition getFieldByType(TypeInfo typeInfo) {
+        if (typeInfo.getType().equals(TypeKind.OBJECT)) {
+            return getDefaultField();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCompatible(FieldDefinition field) {
+        return field instanceof EntityRelationField;
+    }
+}

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/type/ObjectSelectorFieldType.java
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/type/ObjectSelectorFieldType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.type;
+
+import org.kie.workbench.common.forms.model.FieldType;
+
+public class ObjectSelectorFieldType implements FieldType {
+
+    public static final String NAME = "ObjectSelector";
+
+    @Override
+    public String getTypeName() {
+        return NAME;
+    }
+}

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/resources/ErraiApp.properties
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/resources/org/kie/appformer/form/modeler/fields/FormModelerFieldsShared.gwt.xml
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/main/resources/org/kie/appformer/form/modeler/fields/FormModelerFieldsShared.gwt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+
+  <inherits name="org.kie.workbench.common.forms.fields.BasicFormFields"/>
+
+  <source path="shared"/>
+</module>

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/test/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/provider/ObjectSelectorFieldProviderTest.java
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-api/src/test/java/org/kie/appformer/form/modeler/fields/shared/fieldTypes/relations/objectSelector/provider/ObjectSelectorFieldProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.provider;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.type.ObjectSelectorFieldType;
+import org.kie.workbench.common.forms.fields.shared.fieldTypes.relations.EntityRelationField;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.model.TypeInfo;
+import org.kie.workbench.common.forms.model.TypeKind;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ObjectSelectorFieldProviderTest extends TestCase {
+
+    private ObjectSelectorFieldProvider provider;
+
+    @Mock
+    private TypeInfo typeInfo;
+
+    @Before
+    public void initTest() {
+        provider = new ObjectSelectorFieldProvider();
+    }
+
+    @Test
+    public void testGetFieldType() {
+        Class type = provider.getFieldType();
+        assertSame(ObjectSelectorFieldType.class,
+                   type);
+    }
+
+    @Test
+    public void testGetFieldTypeName() {
+        String typeName = provider.getFieldTypeName();
+        assertSame(ObjectSelectorFieldDefinition.FIELD_TYPE.getTypeName(),
+                   typeName);
+    }
+
+    @Test
+    public void testGetDefaultField() {
+        FieldDefinition defaultField = provider.getDefaultField();
+        assertTrue(defaultField instanceof ObjectSelectorFieldDefinition);
+    }
+
+    @Test
+    public void testGetFieldByTypeEnum() {
+        testGetFieldByType(true);
+    }
+
+    @Test
+    public void testGetFieldByTypeNotEnum() {
+        testGetFieldByType(false);
+    }
+
+    private void testGetFieldByType(boolean isEnum) {
+        when(typeInfo.getType()).thenReturn(isEnum ? TypeKind.ENUM : TypeKind.OBJECT);
+        FieldDefinition field = provider.getFieldByType(typeInfo);
+        assertEquals(isEnum,
+                     field == null);
+    }
+
+    @Test
+    public void testIsCompatible() {
+        FieldDefinition field = mock(FieldDefinition.class,
+                                     withSettings().extraInterfaces(EntityRelationField.class));
+        boolean isCompatible = provider.isCompatible(field);
+        assertTrue(isCompatible);
+    }
+
+    @Test
+    public void testIsCompatibleNot() {
+        FieldDefinition field = mock(FieldDefinition.class);
+        boolean isCompatible = provider.isCompatible(field);
+        assertFalse(isCompatible);
+    }
+}

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/pom.xml
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>appformer-form-modeler-fields</artifactId>
+    <groupId>org.kie.appformer</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <description>AppFormer::Form Modeler::Fields Client</description>
+
+  <artifactId>appformer-form-modeler-fields-client</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.kie.appformer</groupId>
+      <artifactId>appformer-form-modeler-fields-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-dynamic-forms-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-adf-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- tests -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/java/org/kie/appformer/form/modeler/fields/client/rendering/renderers/relations/selector/ObjectSelectorFieldRenderer.java
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/java/org/kie/appformer/form/modeler/fields/client/rendering/renderers/relations/selector/ObjectSelectorFieldRenderer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.appformer.form.modeler.fields.client.rendering.renderers.relations.selector;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.gwtbootstrap3.extras.typeahead.client.base.Dataset;
+import org.gwtbootstrap3.extras.typeahead.client.base.SuggestionCallback;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.flatViews.impl.ObjectFlatView;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.typeahead.BindableTypeAhead;
+import org.kie.workbench.common.forms.dynamic.client.rendering.FieldRenderer;
+
+@Dependent
+public class ObjectSelectorFieldRenderer extends FieldRenderer<ObjectSelectorFieldDefinition> {
+
+    @Inject
+    protected BindableTypeAhead widget;
+
+    protected Dataset dataset = new Dataset() {
+        @Override
+        public void findMatches(String query,
+                                SuggestionCallback callback) {
+
+        }
+    };
+
+    @Override
+    public String getName() {
+        return ObjectSelectorFieldDefinition.FIELD_TYPE.getTypeName();
+    }
+
+    @Override
+    public void initInputWidget() {
+        widget.init(field.getMask(),
+                    dataset);
+    }
+
+    @Override
+    public IsWidget getInputWidget() {
+        return widget;
+    }
+
+    @Override
+    public IsWidget getPrettyViewWidget() {
+        return new ObjectFlatView(field.getMask());
+    }
+
+    @Override
+    public String getSupportedCode() {
+        return ObjectSelectorFieldDefinition.FIELD_TYPE.getTypeName();
+    }
+
+    @Override
+    protected void setReadOnly(boolean readOnly) {
+        widget.setReadOnly(readOnly);
+    }
+}

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/resources/ErraiApp.properties
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/resources/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/resources/META-INF/beans.xml
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="none">
+  <scan>
+    <exclude name="org.kie.appformer.form.modeler.fields.client.**"/>
+  </scan>
+</beans>

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/resources/org/kie/appformer/form/modeler/fields/FormModelerFieldsClient.gwt.xml
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/main/resources/org/kie/appformer/form/modeler/fields/FormModelerFieldsClient.gwt.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+
+  <inherits name="org.kie.appformer.form.modeler.fields.FormModelerFieldsShared"/>
+  <inherits name="org.kie.workbench.common.forms.dynamic.DynamicFormsClient"/>
+
+  <source path="client"/>
+</module>

--- a/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/test/java/org/kie/appformer/form/modeler/fields/client/rendering/renderers/relations/selector/ObjectSelectorFieldRendererTest.java
+++ b/appformer-form-modeler/appformer-form-modeler-fields/appformer-form-modeler-fields-client/src/test/java/org/kie/appformer/form/modeler/fields/client/rendering/renderers/relations/selector/ObjectSelectorFieldRendererTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.appformer.form.modeler.fields.client.rendering.renderers.relations.selector;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwtmockito.GwtMock;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.appformer.form.modeler.fields.shared.fieldTypes.relations.objectSelector.definition.ObjectSelectorFieldDefinition;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.flatViews.impl.ObjectFlatView;
+import org.kie.workbench.common.forms.common.rendering.client.widgets.typeahead.BindableTypeAhead;
+import org.kie.workbench.common.forms.dynamic.client.helper.MapModelBindingHelper;
+import org.kie.workbench.common.forms.processing.engine.handling.FieldChangeHandler;
+import org.kie.workbench.common.forms.processing.engine.handling.FormHandler;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ObjectSelectorFieldRendererTest extends TestCase {
+
+    public static final String FIELD_MASK = "Random: {mask}";
+
+    private ObjectSelectorFieldRenderer fieldRenderer;
+
+    @GwtMock
+    private BindableTypeAhead widgetMock;
+
+    @Mock
+    private ObjectSelectorFieldDefinition fieldMock;
+
+    @Mock
+    private FieldChangeHandler changeHandler;
+
+    @Mock
+    private FormHandler formHandler;
+
+    @Mock
+    private MapModelBindingHelper helper;
+
+    @Before
+    public void initTest() {
+        when(fieldMock.getMask()).thenReturn(FIELD_MASK);
+        fieldRenderer = new ObjectSelectorFieldRenderer() {
+            {
+                widget = widgetMock;
+                field = fieldMock;
+            }
+        };
+    }
+
+    @Test
+    public void testGetName() {
+        String name = fieldRenderer.getName();
+        assertEquals(ObjectSelectorFieldDefinition.FIELD_TYPE.getTypeName(),
+                     name);
+    }
+
+    @Test
+    public void testInitInputWidget() {
+        fieldRenderer.initInputWidget();
+        verify(widgetMock).init(anyString(),
+                                any());
+    }
+
+    @Test
+    public void testGetInputWidget() {
+        IsWidget widget = fieldRenderer.getInputWidget();
+        assertSame(widgetMock,
+                   widget);
+    }
+
+    @Test
+    public void testGetSupportedCode() {
+        String name = fieldRenderer.getSupportedCode();
+        assertEquals(ObjectSelectorFieldDefinition.FIELD_TYPE.getTypeName(),
+                     name);
+    }
+
+    @Test
+    public void testSetReadOnlyTrue() {
+        testSetReadOnly(true);
+    }
+
+    @Test
+    public void testSetReadOnlyFalse() {
+        testSetReadOnly(false);
+    }
+
+    public void testSetReadOnly(boolean value) {
+        fieldRenderer.setReadOnly(value);
+        verify(widgetMock).setReadOnly(eq(value));
+    }
+
+    @Test
+    public void testGetPrettyViewWidget() {
+        IsWidget widget = fieldRenderer.getPrettyViewWidget();
+        assertTrue(widget instanceof ObjectFlatView);
+    }
+
+    @Test
+    public void testDatasetFindMatches() {
+        fieldRenderer.dataset.findMatches(null,
+                                          null);
+    }
+}

--- a/appformer-form-modeler/appformer-form-modeler-fields/pom.xml
+++ b/appformer-form-modeler/appformer-form-modeler-fields/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>appformer-form-modeler</artifactId>
+    <groupId>org.kie.appformer</groupId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <description>AppFormer::Form Modeler::Fields</description>
+
+  <artifactId>appformer-form-modeler-fields</artifactId>
+  <packaging>pom</packaging>
+  <modules>
+    <module>appformer-form-modeler-fields-api</module>
+    <module>appformer-form-modeler-fields-client</module>
+  </modules>
+</project>

--- a/appformer-form-modeler/appformer-form-modeler-rendering/appformer-form-modeler-rendering-api/pom.xml
+++ b/appformer-form-modeler/appformer-form-modeler-rendering/appformer-form-modeler-rendering-api/pom.xml
@@ -62,7 +62,7 @@
     </dependency>
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
 
     <dependency>

--- a/appformer-form-modeler/pom.xml
+++ b/appformer-form-modeler/pom.xml
@@ -19,6 +19,7 @@
     <module>appformer-form-modeler-codegen</module>
     <module>appformer-form-modeler-rendering</module>
     <module>appformer-form-modeler-editor</module>
+    <module>appformer-form-modeler-fields</module>
   </modules>
 
 </project>

--- a/appformer-showcase/appformer-webapp/pom.xml
+++ b/appformer-showcase/appformer-webapp/pom.xml
@@ -156,7 +156,7 @@
     </dependency>
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -1250,6 +1250,17 @@
       <artifactId>appformer-form-modeler-codegen-data-modeller</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.appformer</groupId>
+      <artifactId>appformer-form-modeler-fields-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.appformer</groupId>
+      <artifactId>appformer-form-modeler-fields-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Required to correctly build AppFormer apps -->
     <dependency>
       <groupId>org.kie.appformer</groupId>
@@ -1535,6 +1546,8 @@
               <compileSourcesArtifact>org.kie.appformer:appformer-flow-api</compileSourcesArtifact>
               <!-- FIXME We shouldn't have to depend on this but do because of the StandaloneFormWrapper -->
               <compileSourcesArtifact>org.kie.appformer:appformer-flow-client</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.appformer:appformer-form-modeler-fields-api</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.appformer:appformer-form-modeler-fields-client</compileSourcesArtifact>
 
               <!-- Data sources management -->
               <compileSourcesArtifact>org.kie.workbench.screens:kie-wb-common-datasource-mgmt-api</compileSourcesArtifact>

--- a/appformer-showcase/appformer-webapp/src/main/resources/org/kie/appformer/AppFormer.gwt.xml
+++ b/appformer-showcase/appformer-webapp/src/main/resources/org/kie/appformer/AppFormer.gwt.xml
@@ -75,6 +75,9 @@
   <inherits name="org.kie.workbench.common.forms.editor.FormModelerEditorClient"/>
   <inherits name="org.kie.workbench.common.forms.data.modeller.FormDataModellerIntegrationClient"/>
 
+  <!-- Form Modeler Fields -->
+  <inherits name="org.kie.appformer.form.modeler.fields.FormModelerFieldsClient"/>
+
   <!-- Start AppFormer Modules -->
   <inherits name="org.kie.appformer.provisioning.AppFormerProvisioningAPI"/>
   <inherits name="org.kie.appformer.provisioning.AppFormerProvisioningClient"/>


### PR DESCRIPTION
**WARNING**: to be merged with https://github.com/kiegroup/kie-wb-common/pull/1024 and https://github.com/kiegroup/kie-wb-common/pull/1025

Added ObjectSelector related code, which was removed from kie-wb-common

@pefernan @jsoltes can you give a look?