### PR TITLE
Fix a test that fails when using custom Maven settings

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepositoryTest.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepositoryTest.java
@@ -17,6 +17,8 @@
 
 package org.guvnor.m2repo.backend.server.repositories;
 
+import java.io.File;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -27,7 +29,8 @@ public class LocalArtifactRepositoryTest {
     public void testGetRootDir() throws Exception {
         LocalArtifactRepository repository = new LocalArtifactRepository("test");
         String rootDir = repository.getRootDir();
-        assertEquals(System.getProperty("user.home") + "/.m2/repository",
-                     rootDir);
+        assertNotNull(rootDir);
+        File rootDirFile = new File(rootDir);
+        assertTrue(rootDirFile.isDirectory());
     }
 }


### PR DESCRIPTION
Custom Maven settings can change the location of local Maven repository.
Therefore it's not safe to always assert it's `${user.home}/.m2/repository`.