### PR TITLE
AF-467: Security management - Show a warning notification if user has no assignments set.

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementWidgetsConstants.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementWidgetsConstants.java
@@ -96,6 +96,8 @@ public interface UsersManagementWidgetsConstants extends Messages {
 
     String ensureRemoveGroup();
 
+    String ensureUserHasGroupsOrRoles();
+
     String genericError();
 
     String remove();

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupCreationWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupCreationWorkflow.java
@@ -132,7 +132,7 @@ public class GroupCreationWorkflow implements IsWidget {
     }
 
     public void clear() {
-        view.clearNotification();
+        view.clearNotifications();
         createEntity.clear();
         groupUsersAssignment.clear();
         group = null;

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflow.java
@@ -148,7 +148,7 @@ public class GroupEditorWorkflow implements IsWidget {
 
     public void clear() {
         groupEditor.clear();
-        view.clearNotification();
+        view.clearNotifications();
         group = null;
     }
 
@@ -266,7 +266,7 @@ public class GroupEditorWorkflow implements IsWidget {
         if (isDirty) {
             view.showNotification(UsersManagementWidgetsConstants.INSTANCE.groupModified(group.getName()));
         } else {
-            view.clearNotification();
+            view.clearNotifications();
         }
     }
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/role/workflow/BaseRoleEditorWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/role/workflow/BaseRoleEditorWorkflow.java
@@ -112,7 +112,7 @@ public abstract class BaseRoleEditorWorkflow implements IsWidget {
          ****************************************************************************************************** */
 
     public void clear() {
-        view.clearNotification();
+        view.clearNotifications();
         roleEditor.clear();
         isDirty = false;
         role = null;
@@ -190,7 +190,7 @@ public abstract class BaseRoleEditorWorkflow implements IsWidget {
         if (isDirty) {
             view.showNotification(UsersManagementWidgetsConstants.INSTANCE.roleModified(BaseRoleEditorWorkflow.this.role.getName()));
         } else {
-            view.clearNotification();
+            view.clearNotifications();
         }
     }
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserCreationWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserCreationWorkflow.java
@@ -176,6 +176,7 @@ public class UserCreationWorkflow extends BaseUserEditorWorkflow {
 
         // Configure the workflow's view.
         doShowEditorView();
+        setDirty(false);
 
         // Edit the instance using the user editor's driver.
         edit();
@@ -268,7 +269,7 @@ public class UserCreationWorkflow extends BaseUserEditorWorkflow {
                                         if (throwable instanceof UserNotFoundException) {
                                             // User not found, so identifier is valid.
                                             callback.valid();
-                                        } else  if (throwable instanceof InvalidEntityIdentifierException) {
+                                        } else if (throwable instanceof InvalidEntityIdentifierException) {
                                             callback.invalid(new SecurityManagementException(getUserNameNotValidMessage((InvalidEntityIdentifierException) throwable),
                                                                                              throwable));
                                         } else {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/workflow/EntityWorkflowView.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/workflow/EntityWorkflowView.java
@@ -38,7 +38,7 @@ public interface EntityWorkflowView extends IsWidget {
 
     EntityWorkflowView showNotification(final String text);
 
-    EntityWorkflowView clearNotification();
+    EntityWorkflowView clearNotifications();
 
     interface Callback {
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/workflow/EntityWorkflowViewImpl.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/workflow/EntityWorkflowViewImpl.java
@@ -27,19 +27,18 @@ import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
-import org.gwtbootstrap3.client.ui.Alert;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Column;
-import org.gwtbootstrap3.client.ui.html.Text;
+import org.gwtbootstrap3.client.ui.ListGroup;
+import org.gwtbootstrap3.client.ui.ListGroupItem;
+import org.gwtbootstrap3.client.ui.constants.ListGroupItemType;
 
 @Dependent
 public class EntityWorkflowViewImpl extends Composite implements EntityWorkflowView {
 
     private static UserEditorWorkflowViewBinder uiBinder = GWT.create(UserEditorWorkflowViewBinder.class);
     @UiField
-    Alert notifications;
-    @UiField
-    Text notificationLabel;
+    ListGroup notificationsList;
     @UiField
     Column content;
     @UiField
@@ -94,15 +93,18 @@ public class EntityWorkflowViewImpl extends Composite implements EntityWorkflowV
 
     @Override
     public EntityWorkflowView showNotification(final String text) {
-        notificationLabel.setText(text);
-        notifications.setVisible(true);
+        final ListGroupItem item = new ListGroupItem();
+        item.setText(text);
+        item.setType(ListGroupItemType.WARNING);
+        notificationsList.add(item);
+        notificationsList.setVisible(true);
         return this;
     }
 
     @Override
-    public EntityWorkflowView clearNotification() {
-        notificationLabel.setText("");
-        notifications.setVisible(false);
+    public EntityWorkflowView clearNotifications() {
+        notificationsList.clear();
+        notificationsList.setVisible(false);
         return this;
     }
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/workflow/EntityWorkflowViewImpl.ui.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/workflow/EntityWorkflowViewImpl.ui.xml
@@ -17,7 +17,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-             xmlns:bhtml="urn:import:org.gwtbootstrap3.client.ui.html">
+             xmlns:g="urn:import:com.google.gwt.user.client.ui">
 
   <ui:with field="i18n" type="org.uberfire.ext.security.management.client.resources.i18n.UsersManagementWidgetsConstants"/>
 
@@ -31,10 +31,7 @@
 
     <b:Row>
       <b:Column size="MD_12">
-        <b:Alert ui:field="notifications" type="WARNING" dismissable="false">
-          <b:Icon type="WARNING" marginRight="10"/>
-          <bhtml:Text ui:field="notificationLabel"/>
-        </b:Alert>
+        <b:ListGroup ui:field="notificationsList"/>
       </b:Column>
     </b:Row>
     

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/resources/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementWidgetsConstants.properties
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/resources/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementWidgetsConstants.properties
@@ -49,6 +49,7 @@ add=Add
 confirmAction=Please confirm the action
 ensureRemoveUser=Are you sure you want to remove the user?
 ensureRemoveGroup=Are you sure you want to remove the group?
+ensureUserHasGroupsOrRoles=No assignments present, the user could be not able to log into the application
 genericError=Error
 remove=Remove
 ensureRemoveAttribute=Are you sure you want to remove the attribute?

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupCreationWorkflowTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupCreationWorkflowTest.java
@@ -76,7 +76,7 @@ public class GroupCreationWorkflowTest extends AbstractSecurityManagementTest {
         super.setup();
         when(group.getName()).thenReturn("group1");
         when(view.setWidget(any(IsWidget.class))).thenReturn(view);
-        when(view.clearNotification()).thenReturn(view);
+        when(view.clearNotifications()).thenReturn(view);
         when(view.setCallback(any(EntityWorkflowView.Callback.class))).thenReturn(view);
         when(view.setCancelButtonVisible(anyBoolean())).thenReturn(view);
         when(view.setSaveButtonEnabled(anyBoolean())).thenReturn(view);
@@ -108,7 +108,7 @@ public class GroupCreationWorkflowTest extends AbstractSecurityManagementTest {
         verify(groupUsersAssignment,
                times(1)).clear();
         verify(view,
-               times(1)).clearNotification();
+               times(1)).clearNotifications();
         verify(view,
                times(0)).setCancelButtonVisible(anyBoolean());
         verify(view,
@@ -151,7 +151,7 @@ public class GroupCreationWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(1)).setSaveButtonEnabled(true);
         verify(view,
-               times(1)).clearNotification();
+               times(1)).clearNotifications();
     }
 
     @Test
@@ -173,7 +173,7 @@ public class GroupCreationWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(1)).setSaveButtonEnabled(false);
         verify(view,
-               times(0)).clearNotification();
+               times(0)).clearNotifications();
     }
 
     @Test
@@ -272,6 +272,6 @@ public class GroupCreationWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(1)).setSaveButtonEnabled(true);
         verify(view,
-               times(1)).clearNotification();
+               times(1)).clearNotifications();
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflowTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflowTest.java
@@ -100,7 +100,7 @@ public class GroupEditorWorkflowTest extends AbstractSecurityManagementTest {
         when(groupEditor.getAclSettings()).thenReturn(aclSettings);
         when(group.getName()).thenReturn("group1");
         when(view.setWidget(any(IsWidget.class))).thenReturn(view);
-        when(view.clearNotification()).thenReturn(view);
+        when(view.clearNotifications()).thenReturn(view);
         when(view.setCallback(any(EntityWorkflowView.Callback.class))).thenReturn(view);
         when(view.setCancelButtonVisible(anyBoolean())).thenReturn(view);
         when(view.setSaveButtonEnabled(anyBoolean())).thenReturn(view);
@@ -133,7 +133,7 @@ public class GroupEditorWorkflowTest extends AbstractSecurityManagementTest {
         verify(groupEditor,
                times(0)).show(any(Group.class));
         verify(view,
-               times(1)).clearNotification();
+               times(1)).clearNotifications();
         verify(view,
                times(0)).setCancelButtonVisible(anyBoolean());
         verify(view,
@@ -169,7 +169,7 @@ public class GroupEditorWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(0)).showNotification(anyString());
         verify(view,
-               times(1)).clearNotification();
+               times(1)).clearNotifications();
         verify(groupEditorDriver,
                times(1)).edit(group,
                               groupEditor);
@@ -249,6 +249,6 @@ public class GroupEditorWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(0)).showNotification(anyString());
         verify(view,
-               times(0)).clearNotification();
+               times(0)).clearNotifications();
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/role/workflow/RoleEditorWorkflowTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/role/workflow/RoleEditorWorkflowTest.java
@@ -92,7 +92,7 @@ public class RoleEditorWorkflowTest extends AbstractSecurityManagementTest {
         when(roleEditor.getAclSettings()).thenReturn(aclSettings);
         when(role.getName()).thenReturn("role1");
         when(view.setWidget(any(IsWidget.class))).thenReturn(view);
-        when(view.clearNotification()).thenReturn(view);
+        when(view.clearNotifications()).thenReturn(view);
         when(view.setCallback(any(EntityWorkflowView.Callback.class))).thenReturn(view);
         when(view.setCancelButtonVisible(anyBoolean())).thenReturn(view);
         when(view.setSaveButtonEnabled(anyBoolean())).thenReturn(view);
@@ -123,7 +123,7 @@ public class RoleEditorWorkflowTest extends AbstractSecurityManagementTest {
         verify(roleEditor,
                never()).show(any(Role.class));
         verify(view,
-               atLeastOnce()).clearNotification();
+               atLeastOnce()).clearNotifications();
         verify(view,
                never()).setCancelButtonVisible(true);
         verify(view,
@@ -152,7 +152,7 @@ public class RoleEditorWorkflowTest extends AbstractSecurityManagementTest {
         verify(view).setSaveButtonEnabled(false);
         verify(view,
                never()).showNotification(anyString());
-        verify(view).clearNotification();
+        verify(view).clearNotifications();
         verify(roleEditorDriver).edit(role,
                                       roleEditor);
         verify(roleEditor).clear();

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserCreationWorkflowTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserCreationWorkflowTest.java
@@ -35,6 +35,7 @@ import org.uberfire.ext.security.management.client.widgets.management.ChangePass
 import org.uberfire.ext.security.management.client.widgets.management.CreateEntity;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAssignedGroupsEditor;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAssignedGroupsExplorer;
+import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAssignedRolesExplorer;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAttributesEditor;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserEditor;
 import org.uberfire.ext.security.management.client.widgets.management.editor.workflow.EntityWorkflowView;
@@ -55,7 +56,15 @@ import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.events.NotificationEvent;
 
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
@@ -89,6 +98,8 @@ public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
     @Mock
     UserAssignedGroupsEditor userAssignedGroupsEditor;
     @Mock
+    UserAssignedRolesExplorer userAssignedRolesExplorer;
+    @Mock
     User user;
     private UserCreationWorkflow tested;
 
@@ -102,7 +113,7 @@ public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
         when(user.getIdentifier()).thenReturn("user1");
         when(user.getGroups()).thenReturn(groups);
         when(view.setWidget(any(IsWidget.class))).thenReturn(view);
-        when(view.clearNotification()).thenReturn(view);
+        when(view.clearNotifications()).thenReturn(view);
         when(view.setCallback(any(EntityWorkflowView.Callback.class))).thenReturn(view);
         when(view.setCancelButtonVisible(anyBoolean())).thenReturn(view);
         when(view.setSaveButtonEnabled(anyBoolean())).thenReturn(view);
@@ -115,6 +126,7 @@ public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
         when(userEditor.attributesEditor()).thenReturn(userAttributesEditor);
         when(userEditor.groupsExplorer()).thenReturn(userAssignedGroupsExplorer);
         when(userEditor.groupsEditor()).thenReturn(userAssignedGroupsEditor);
+        when(userEditor.rolesExplorer()).thenReturn(userAssignedRolesExplorer);
         tested = new UserCreationWorkflow(userSystemManager,
                                           errorEvent,
                                           workbenchNotification,
@@ -153,7 +165,7 @@ public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(1)).setSaveButtonEnabled(true);
         verify(view,
-               times(2)).clearNotification();
+               times(2)).clearNotifications();
     }
 
     @Test
@@ -171,9 +183,9 @@ public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
 
     @Test
     public void testDoEdit() {
-        tested.isDirty = false;
         tested.user = user;
         tested.doEdit();
+        assertFalse(tested.isDirty);
         verify(userManagerService,
                times(0)).get(anyString());
         verify(view,
@@ -187,11 +199,11 @@ public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(3)).setSaveButtonVisible(true);
         verify(view,
-               times(2)).setSaveButtonEnabled(false);
+               times(4)).setSaveButtonEnabled(false);
         verify(view,
                times(1)).setSaveButtonEnabled(true);
         verify(view,
-               times(0)).clearNotification();
+               times(2)).clearNotifications();
         verify(userEditor,
                times(0)).clear();
         verify(userEditorDriver,
@@ -353,6 +365,6 @@ public class UserCreationWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(1)).setSaveButtonEnabled(true);
         verify(view,
-               times(1)).showNotification(anyString());
+               times(2)).showNotification(anyString());
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserEditorWorkflowTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserEditorWorkflowTest.java
@@ -35,6 +35,7 @@ import org.uberfire.ext.security.management.client.widgets.management.ChangePass
 import org.uberfire.ext.security.management.client.widgets.management.editor.acl.ACLViewer;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAssignedGroupsEditor;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAssignedGroupsExplorer;
+import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAssignedRolesExplorer;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserAttributesEditor;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.UserEditor;
 import org.uberfire.ext.security.management.client.widgets.management.editor.workflow.EntityWorkflowView;
@@ -54,7 +55,13 @@ import org.uberfire.ext.security.management.client.widgets.popup.LoadingBox;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class UserEditorWorkflowTest extends AbstractSecurityManagementTest {
@@ -86,6 +93,8 @@ public class UserEditorWorkflowTest extends AbstractSecurityManagementTest {
     @Mock
     UserAssignedGroupsEditor userAssignedGroupsEditor;
     @Mock
+    UserAssignedRolesExplorer userAssignedRolesExplorer;
+    @Mock
     User user;
     private UserEditorWorkflow tested;
 
@@ -95,6 +104,7 @@ public class UserEditorWorkflowTest extends AbstractSecurityManagementTest {
         when(userEditor.attributesEditor()).thenReturn(userAttributesEditor);
         when(userEditor.groupsExplorer()).thenReturn(userAssignedGroupsExplorer);
         when(userEditor.groupsEditor()).thenReturn(userAssignedGroupsEditor);
+        when(userEditor.rolesExplorer()).thenReturn(userAssignedRolesExplorer);
         when(userEditor.getACLViewer()).thenReturn(aclViewer);
         final Set<Group> groups = new HashSet<Group>();
         final Group group1 = mock(Group.class);
@@ -135,11 +145,11 @@ public class UserEditorWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(1)).setSaveButtonVisible(true);
         verify(view,
-               times(1)).setSaveButtonEnabled(false);
+               times(2)).setSaveButtonEnabled(false);
         verify(view,
-               times(0)).showNotification(anyString());
+               times(1)).showNotification(anyString());
         verify(view,
-               times(0)).clearNotification();
+               times(1)).clearNotifications();
         verify(loadingBox,
                times(0)).show();
         verify(loadingBox,
@@ -232,6 +242,6 @@ public class UserEditorWorkflowTest extends AbstractSecurityManagementTest {
         verify(view,
                times(1)).setSaveButtonEnabled(true);
         verify(view,
-               times(1)).showNotification(anyString());
+               times(2)).showNotification(anyString());
     }
 }


### PR DESCRIPTION
Hey @ederign @tomasdavidorg 

See details in [the JIRA ticket](https://issues.jboss.org/browse/AF-467). The change is just about being able to show several notifications in the user editor, rather than a single one (as before this commit), and finally checking the current user assignments in order to display a notification.

Thanks!
Roger