### PR TITLE
AF-483: Security Management - Show friendly message when an operation is not authorized

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/src/main/java/org/uberfire/ext/security/management/api/exception/RealmManagementNotAuthorizedException.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/src/main/java/org/uberfire/ext/security/management/api/exception/RealmManagementNotAuthorizedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.api.exception;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class RealmManagementNotAuthorizedException
+        extends SecurityManagementException {
+
+    private final String realmResource;
+
+    public RealmManagementNotAuthorizedException(final @MapsTo("realmResource") String realmResource) {
+        this.realmResource = realmResource;
+    }
+
+    public String getRealmResource() {
+        return realmResource;
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/src/main/java/org/uberfire/ext/security/management/service/UserManagerServiceImpl.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/src/main/java/org/uberfire/ext/security/management/service/UserManagerServiceImpl.java
@@ -17,6 +17,7 @@
 package org.uberfire.ext.security.management.service;
 
 import java.util.Collection;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -85,18 +86,11 @@ public class UserManagerServiceImpl implements UserManagerService {
     @Override
     public SearchResponse<User> search(SearchRequest request) {
         final UserManager serviceImpl = getService();
-
         // Delegate to the current service provider implementation.
-        SearchResponse<User> response = null;
-        try {
-            if (request.getPage() == 0) {
-                throw new IllegalArgumentException("First page must be 1.");
-            }
-            response = serviceImpl.search(request);
-        } catch (RuntimeException e) {
-            throw new SecurityManagementException(e);
+        if (request.getPage() == 0) {
+            throw new IllegalArgumentException("First page must be 1.");
         }
-        return response;
+        return serviceImpl.search(request);
     }
 
     @Override

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/java/org/uberfire/ext/security/management/client/ClientSecurityExceptionMessageResolver.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/java/org/uberfire/ext/security/management/client/ClientSecurityExceptionMessageResolver.java
@@ -21,12 +21,14 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.uberfire.ext.security.management.api.exception.EntityNotFoundException;
 import org.uberfire.ext.security.management.api.exception.GroupNotFoundException;
 import org.uberfire.ext.security.management.api.exception.NoImplementationAvailableException;
+import org.uberfire.ext.security.management.api.exception.RealmManagementNotAuthorizedException;
 import org.uberfire.ext.security.management.api.exception.SecurityManagementException;
 import org.uberfire.ext.security.management.api.exception.UnsupportedServiceCapabilityException;
 import org.uberfire.ext.security.management.api.exception.UserAlreadyExistsException;
@@ -63,6 +65,9 @@ public class ClientSecurityExceptionMessageResolver {
         register(UserAlreadyExistsException.class,
                  e -> getArgMessage(UsersManagementClientConstants.INSTANCE.userAlreadyExists(),
                                     e.getUserId()));
+        register(RealmManagementNotAuthorizedException.class,
+                 e -> getArgMessage(UsersManagementClientConstants.INSTANCE.realmManagementNotAuthorized(),
+                                    e.getRealmResource()));
     }
 
     /**

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/java/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementClientConstants.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/java/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementClientConstants.java
@@ -47,4 +47,6 @@ public interface UsersManagementClientConstants extends ConstantsWithLookup {
     String userNotFound();
 
     String groupNotFound();
+
+    String realmManagementNotAuthorized();
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/resources/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementClientConstants.properties
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/resources/org/uberfire/ext/security/management/client/resources/i18n/UsersManagementClientConstants.properties
@@ -25,3 +25,4 @@ roleAlreadyExists=Role already exists
 entityNotFound=Entity not found
 userNotFound=User not found
 groupNotFound=Group not found
+realmManagementNotAuthorized=Not authorized to manage the realm

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/test/java/org/uberfire/ext/security/management/client/ClientSecurityExceptionMessageResolverTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/test/java/org/uberfire/ext/security/management/client/ClientSecurityExceptionMessageResolverTest.java
@@ -26,6 +26,7 @@ import org.uberfire.ext.security.management.api.Capability;
 import org.uberfire.ext.security.management.api.exception.EntityNotFoundException;
 import org.uberfire.ext.security.management.api.exception.GroupNotFoundException;
 import org.uberfire.ext.security.management.api.exception.NoImplementationAvailableException;
+import org.uberfire.ext.security.management.api.exception.RealmManagementNotAuthorizedException;
 import org.uberfire.ext.security.management.api.exception.SecurityManagementException;
 import org.uberfire.ext.security.management.api.exception.UnsupportedServiceCapabilityException;
 import org.uberfire.ext.security.management.api.exception.UserAlreadyExistsException;
@@ -34,7 +35,10 @@ import org.uberfire.ext.security.management.api.exception.UserNotFoundException;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ClientSecurityExceptionMessageResolverTest {
@@ -80,6 +84,12 @@ public class ClientSecurityExceptionMessageResolverTest {
                                        c5);
         verify(c5,
                times(1)).accept(contains("aUser"));
+
+        final Consumer<String> c6 = mock(Consumer.class);
+        tested.consumeExceptionMessage(new RealmManagementNotAuthorizedException("aRealm"),
+                                       c6);
+        verify(c6,
+               times(1)).accept(contains("aRealm"));
     }
 
     @Test

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/README.md
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/README.md
@@ -39,21 +39,25 @@ So the following JAXRS, RestEasy and Keycloak dependencies must be present in th
         <dependency>
           <groupId>org.keycloak</groupId>
           <artifactId>keycloak-core</artifactId>
-          <version>1.9.0.Final</version>
+          <version>...</version>
         </dependency>
         
        <dependency>
          <groupId>org.jboss.resteasy</groupId>
          <artifactId>resteasy-jaxrs</artifactId>
-         <version>2.3.10.Final</version>
+         <version>...</version>
          <version>
        </dependency>
    
        <dependency>
          <groupId>org.jboss.resteasy</groupId>
          <artifactId>resteasy-jackson-provider</artifactId>
-         <version>2.3.10.Final</version>
+         <version>...</version>
        </dependency>
+
+Run the following command in order to figure out the versions to use for each of the above artifacts:
+
+    mvn dependency:list
 
 **Note about JBoss Wildfly / EAP**
 If you are deploying the application in a Wildfly 8.x or an EAP 6.4, you can use the server's RestEasy provided modules instead 
@@ -144,12 +148,12 @@ Follow these steps in order to update or enable the Keycloak users and group man
 
 1.- Ensure the following libraries on `WEB-INF/lib`                
 
-* Add if no present the uberfire-security-management-api-0.X.Y.jar                             
-* Add if no present the uberfire-security-management-backend-0.X.Y.jar                             
-* Add if no present the uberfire-security-management-keycloak-0.X.Y.jar                             
-* Add keycloak-core-1.9.0.Final.jar                
-* Add keycloak-common-1.9.0.Final.jar                    
-* Remove any existing provider implementation, if any (ex: uberfire-security-management-wildfly-0.X.Y.jar, remove uberfire-security-management-tomcat-0.X.Y.jar,etc)                   
+* Add if no present the uberfire-security-management-api-X.Y.Z.jar                             
+* Add if no present the uberfire-security-management-backend-X.Y.Z.jar                             
+* Add if no present the uberfire-security-management-keycloak-X.Y.Z.jar                             
+* Add keycloak-core-X.Y.Z.Final.jar
+* Add keycloak-common-X.Y.Z.Final.jar
+* Remove any existing provider implementation, if any (ex: uberfire-security-management-wildfly-X.Y.Z.jar, remove uberfire-security-management-tomcat-X.Y.Z.jar,etc)                   
 
 2.- Replace the whole content for file `WEB-INF/classes/security-management.properties`, if not present, create it:                    
 
@@ -168,7 +172,7 @@ Follow these steps in order to update or enable the Keycloak users and group man
 
 Note: Use the concrete values for your environment.           
 
-3.- Ensure on file `/WEB-INF/jboss-deployment-structure.xml`:                
+3.- Ensure on file `/META-INF/jboss-deployment-structure.xml`:
 
 * Dependency to `org.jboss.resteasy.resteasy-jackson-provider` module          
      
@@ -211,4 +215,4 @@ The KeyCloak provider for users and groups management services provides the foll
 Notes
 -----
 * Java8+                   
-* This implementation has been tested for a KeyCloak version `1.9.0.Final`.                
+* This implementation has been tested for a KeyCloak version `3.4.0.Final`                

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
@@ -21,7 +21,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.core.Response;
+
 import org.jboss.resteasy.client.ClientResponse;
+import org.jboss.resteasy.client.ClientResponseFailure;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.keycloak.representations.idm.RoleRepresentation;
@@ -37,7 +40,8 @@ import org.uberfire.ext.security.management.keycloak.client.resource.UserResourc
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * <p>It provides a default set of users and roles for mocking a keycloak service.</p>
@@ -133,6 +137,15 @@ public abstract class DefaultKeyCloakTest extends BaseKeyCloakTest {
         ClientResponse response = mock(ClientResponse.class);
         when(response.getStatus()).thenReturn(200);
         when(usersResource.create(any(UserRepresentation.class))).thenReturn(response);
+    }
+
+    protected ClientResponseFailure mockForbiddenResponse() {
+        ClientResponseFailure error = mock(ClientResponseFailure.class);
+        ClientResponse response = mock(ClientResponse.class);
+        Response.Status responseStatus = Response.Status.FORBIDDEN;
+        when(error.getResponse()).thenReturn(response);
+        when(response.getResponseStatus()).thenReturn(responseStatus);
+        return error;
     }
 
     private List<UserRepresentation> getUserRepresentations(String pattern,

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakUserManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakUserManagerTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.jboss.errai.security.shared.api.Group;
 import org.jboss.errai.security.shared.api.Role;
@@ -32,7 +33,6 @@ import org.junit.runner.RunWith;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
@@ -40,27 +40,41 @@ import org.uberfire.ext.security.management.api.AbstractEntityManager;
 import org.uberfire.ext.security.management.api.Capability;
 import org.uberfire.ext.security.management.api.CapabilityStatus;
 import org.uberfire.ext.security.management.api.UserManager;
+import org.uberfire.ext.security.management.api.exception.RealmManagementNotAuthorizedException;
 import org.uberfire.ext.security.management.api.exception.UserNotFoundException;
+import org.uberfire.ext.security.management.keycloak.client.resource.RealmResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleMappingResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleScopeResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.UserResource;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KeyCloakUserManagerTest extends DefaultKeyCloakTest {
 
-    @Spy
-    private KeyCloakUserManager usersManager = new KeyCloakUserManager();
+    private KeyCloakUserManager usersManager;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setup() throws Exception {
         super.setup();
-        doReturn(keycloakMock).when(usersManager).getKeyCloakInstance();
-        doReturn(realmResource).when(usersManager).getRealmResource();
-        usersManager.initialize(userSystemManager);
+        initUserManager();
+        doAnswer(invocationOnMock -> {
+            ((Consumer<RealmResource>) invocationOnMock.getArguments()[0]).accept(realmResource);
+            return null;
+        }).when(usersManager).consumeRealm(any(Consumer.class));
     }
 
     @Test
@@ -97,6 +111,13 @@ public class KeyCloakUserManagerTest extends DefaultKeyCloakTest {
         Collection<UserManager.UserAttribute> attributes = usersManager.getSettings().getSupportedAttributes();
         assertEquals(attributes,
                      USER_ATTRIBUTES);
+    }
+
+    @Test(expected = RealmManagementNotAuthorizedException.class)
+    public void testUserNotAuthorized() throws Exception {
+        initUserManager();
+        doThrow(mockForbiddenResponse()).when(keycloakMock).realm();
+        usersManager.get(USERNAME);
     }
 
     @Test
@@ -337,5 +358,11 @@ public class KeyCloakUserManagerTest extends DefaultKeyCloakTest {
         assertNotNull(email);
         assertEquals(email,
                      username + "@jboss.org");
+    }
+
+    private void initUserManager() throws Exception {
+        usersManager = spy(new KeyCloakUserManager());
+        doReturn(keycloakMock).when(usersManager).getKeyCloakInstance();
+        usersManager.initialize(userSystemManager);
     }
 }


### PR DESCRIPTION
Hey @ederign @tomasdavidorg 

See [this JIRA ticket](https://issues.jboss.org/browse/AF-483). This commit improves the security management by handling the exceptions when a user is not authorized to manage some realm, and it  displays a user friendly message (instead of the exception). 

Tested in a Keycloak SSO environment as well.

Thanks!