### PR TITLE
upgraded to 2.2.1-SNAPSHOT

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-cdi</artifactId>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-sql-tests</artifactId>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-navigation-backend</artifactId>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-backend</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-services</artifactId>

--- a/dashbuilder/dashbuilder-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-cms-client</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-common-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-common-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-common-client</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-dataset-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-client</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-dataset-editor/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-dataset-editor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-dataset-editor</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-client</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-editor/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-editor/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-editor</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-screen/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-screen/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-screen</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-navigation-client</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-chartjs/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-chartjs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-renderers</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-default/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-renderers</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-renderer-default</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-google/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-google/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-renderers</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-renderer-google</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-lienzo/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-lienzo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-renderers</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-client</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-renderers</artifactId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-widgets/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-widgets/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-client</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder/dashbuilder-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder/dashbuilder-distros/pom.xml
+++ b/dashbuilder/dashbuilder-distros/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder/dashbuilder-packaging/dashbuilder-all/pom.xml
+++ b/dashbuilder/dashbuilder-packaging/dashbuilder-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-all</artifactId>

--- a/dashbuilder/dashbuilder-packaging/dashbuilder-client-all/pom.xml
+++ b/dashbuilder/dashbuilder-packaging/dashbuilder-client-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-client-all</artifactId>

--- a/dashbuilder/dashbuilder-packaging/dashbuilder-server-all/pom.xml
+++ b/dashbuilder/dashbuilder-packaging/dashbuilder-server-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-server-all</artifactId>

--- a/dashbuilder/dashbuilder-packaging/pom.xml
+++ b/dashbuilder/dashbuilder-packaging/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-displayer-api</artifactId>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-navigation-api</artifactId>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-services-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-services-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-shared</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>dashbuilder-services-api</artifactId>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-validations/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-validations/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>dashbuilder-shared</artifactId>
     <groupId>org.dashbuilder</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/dashbuilder/dashbuilder-shared/pom.xml
+++ b/dashbuilder/dashbuilder-shared/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.dashbuilder</groupId>
     <artifactId>dashbuilder-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dashbuilder/pom.xml
+++ b/dashbuilder/pom.xml
@@ -7,12 +7,12 @@
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
     <!-- Keep in sync with the parent version of dashbuilder-bom/pom.xml -->
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.dashbuilder</groupId>
   <artifactId>dashbuilder-parent</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Dashbuilder Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>org.uberfire</groupId>
   <artifactId>uberfire-parent</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>UberFire parent</name>

--- a/uberfire-api/pom.xml
+++ b/uberfire-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-archetype/pom.xml
+++ b/uberfire-archetype/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-archetype/uberfire-project-archetype/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-archetype</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-project-archetype</artifactId>

--- a/uberfire-asset-mgmt/pom.xml
+++ b/uberfire-asset-mgmt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>uberfire-parent</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-asset-mgmt/uberfire-asset-mgmt-api/pom.xml
+++ b/uberfire-asset-mgmt/uberfire-asset-mgmt-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-asset-mgmt</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-asset-mgmt-api</artifactId>

--- a/uberfire-asset-mgmt/uberfire-asset-mgmt-backend/pom.xml
+++ b/uberfire-asset-mgmt/uberfire-asset-mgmt-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>uberfire-asset-mgmt</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-asset-mgmt/uberfire-asset-mgmt-client/pom.xml
+++ b/uberfire-asset-mgmt/uberfire-asset-mgmt-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-asset-mgmt</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
 

--- a/uberfire-backend/pom.xml
+++ b/uberfire-backend/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-backend/uberfire-backend-api/pom.xml
+++ b/uberfire-backend/uberfire-backend-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-backend</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-backend-api</artifactId>

--- a/uberfire-backend/uberfire-backend-cdi/pom.xml
+++ b/uberfire-backend/uberfire-backend-cdi/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-backend</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-backend-cdi</artifactId>

--- a/uberfire-backend/uberfire-backend-server/pom.xml
+++ b/uberfire-backend/uberfire-backend-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-backend</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-backend-server</artifactId>

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>org.uberfire</groupId>
   <artifactId>uberfire-bom</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>UberFire BOM (Bill Of Materials)</name>

--- a/uberfire-client-api/pom.xml
+++ b/uberfire-client-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-commons/pom.xml
+++ b/uberfire-commons/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-distro/pom.xml
+++ b/uberfire-distro/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/pom.xml
+++ b/uberfire-extensions/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-apps/pom.xml
+++ b/uberfire-extensions/uberfire-apps/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-apps/uberfire-apps-api/pom.xml
+++ b/uberfire-extensions/uberfire-apps/uberfire-apps-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-apps</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-apps-api</artifactId>

--- a/uberfire-extensions/uberfire-apps/uberfire-apps-backend/pom.xml
+++ b/uberfire-extensions/uberfire-apps/uberfire-apps-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-apps</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-apps-backend</artifactId>

--- a/uberfire-extensions/uberfire-apps/uberfire-apps-client/pom.xml
+++ b/uberfire-extensions/uberfire-apps/uberfire-apps-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-apps</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-apps-client</artifactId>

--- a/uberfire-extensions/uberfire-commons-editor/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-commons-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-commons-editor-api</artifactId>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-commons-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-commons-editor-backend</artifactId>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-commons-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-commons-editor-client</artifactId>

--- a/uberfire-extensions/uberfire-layout-editor/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-layout-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-layout-editor-api</artifactId>

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-layout-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-layout-editor-backend</artifactId>

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-layout-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-layout-editor-client</artifactId>

--- a/uberfire-extensions/uberfire-metadata/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-api/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-metadata</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-metadata-api</artifactId>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-metadata</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-metadata-backends</artifactId>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-metadata-backends</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-metadata-backends</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-metadata-backend-lucene</artifactId>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-metadata</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-metadata-commons-io</artifactId>

--- a/uberfire-extensions/uberfire-preferences-ui-client/pom.xml
+++ b/uberfire-extensions/uberfire-preferences-ui-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-preferences-ui-client</artifactId>

--- a/uberfire-extensions/uberfire-runtime-plugins/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-runtime-plugins</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-runtime-plugins-api</artifactId>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-runtime-plugins</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-runtime-plugins-backend</artifactId>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-runtime-plugins</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-runtime-plugins-client</artifactId>

--- a/uberfire-extensions/uberfire-security/pom.xml
+++ b/uberfire-extensions/uberfire-security/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-extensions</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-security-management</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-security-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-servlet-security</artifactId>

--- a/uberfire-extensions/uberfire-simple-docks/pom.xml
+++ b/uberfire-extensions/uberfire-simple-docks/pom.xml
@@ -21,7 +21,7 @@
    <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-simple-docks</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-simple-docks-client</artifactId>

--- a/uberfire-extensions/uberfire-social-activities/pom.xml
+++ b/uberfire-extensions/uberfire-social-activities/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-api/pom.xml
+++ b/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-social-activities</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-social-activities-api</artifactId>

--- a/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-backend/pom.xml
+++ b/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-social-activities</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-social-activities-backend</artifactId>

--- a/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-client/pom.xml
+++ b/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-social-activities</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-social-activities-client</artifactId>

--- a/uberfire-extensions/uberfire-widgets/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-commons</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-core</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets-core</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-core-client</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-properties-editor</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets-properties-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-properties-editor-api</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-backend/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets-properties-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-properties-editor-backend</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets-properties-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-properties-editor-client</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-sandbox/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-sandbox/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-sandbox</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-sandbox/uberfire-widget-markdown/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-sandbox/uberfire-widget-markdown/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets-sandbox</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widget-markdown</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-widgets</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>uberfire-widgets-service</artifactId>
     <packaging>pom</packaging>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-api/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets-service</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>uberfire-widgets-service-api</artifactId>
   <packaging>jar</packaging>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets-service</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <name>Uberfire Widgets Commons Services Backend</name>
   <description>Uberfire Widgets Commons Services Backend</description>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-widgets</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-widgets-table</artifactId>

--- a/uberfire-extensions/uberfire-wires/pom.xml
+++ b/uberfire-extensions/uberfire-wires/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-extensions</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-bayesian-network</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-bayesian-network</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-parser/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-parser/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-bayesian-parser</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-parser/uberfire-wires-bayesian-parser-api/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-parser/uberfire-wires-bayesian-parser-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-bayesian-parser</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-bayesian-parser-api</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-parser/uberfire-wires-bayesian-parser-backend/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-parser/uberfire-wires-bayesian-parser-backend/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-bayesian-parser</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-bayesian-parser-backend</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-wires</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-api/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-wires-bpmn</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-wires-bpmn</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>uberfire-wires-bpmn</artifactId>
     <groupId>org.uberfire</groupId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-core</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-api/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-core</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-core-api</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-core</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-core-client</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-core</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-core-grids</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-scratchpad/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-scratchpad/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-core</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-trees/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-trees/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires-core</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-wires</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-wires-webapp</artifactId>

--- a/uberfire-io/pom.xml
+++ b/uberfire-io/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-js/pom.xml
+++ b/uberfire-js/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-m2repo-editor/pom.xml
+++ b/uberfire-m2repo-editor/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <!-- UberFire M2_REPO editor-->

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-api/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-m2repo-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-m2repo-editor-api</artifactId>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-m2repo-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-m2repo-editor-backend</artifactId>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-m2repo-editor</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-m2repo-editor-client</artifactId>

--- a/uberfire-message-console/pom.xml
+++ b/uberfire-message-console/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-message-console</artifactId>

--- a/uberfire-message-console/uberfire-message-console-api/pom.xml
+++ b/uberfire-message-console/uberfire-message-console-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-message-console</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-message-console-api</artifactId>

--- a/uberfire-message-console/uberfire-message-console-backend/pom.xml
+++ b/uberfire-message-console/uberfire-message-console-backend/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-message-console</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-message-console-backend</artifactId>

--- a/uberfire-message-console/uberfire-message-console-client/pom.xml
+++ b/uberfire-message-console/uberfire-message-console-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-message-console</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-message-console-client</artifactId>

--- a/uberfire-nio2-backport/pom.xml
+++ b/uberfire-nio2-backport/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-nio2-backport</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-nio2-api</artifactId>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-nio2-backport</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-nio2-impls</artifactId>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-nio2-impls</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-nio2-fs</artifactId>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-nio2-impls</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-nio2-jgit</artifactId>

--- a/uberfire-nio2-backport/uberfire-nio2-model/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-model/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-nio2-backport</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-nio2-model</artifactId>

--- a/uberfire-organizationalunit-manager/pom.xml
+++ b/uberfire-organizationalunit-manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-packaging/pom.xml
+++ b/uberfire-packaging/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-packaging/uberfire-all/pom.xml
+++ b/uberfire-packaging/uberfire-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-all</artifactId>

--- a/uberfire-packaging/uberfire-client-all/pom.xml
+++ b/uberfire-packaging/uberfire-client-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-client-all</artifactId>

--- a/uberfire-packaging/uberfire-client-backend/pom.xml
+++ b/uberfire-packaging/uberfire-client-backend/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-client-backend</artifactId>

--- a/uberfire-packaging/uberfire-client/pom.xml
+++ b/uberfire-packaging/uberfire-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-client</artifactId>

--- a/uberfire-packaging/uberfire-server-all/pom.xml
+++ b/uberfire-packaging/uberfire-server-all/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-packaging</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-server-all</artifactId>

--- a/uberfire-preferences/pom.xml
+++ b/uberfire-preferences/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>uberfire-preferences</artifactId>
   <packaging>pom</packaging>

--- a/uberfire-preferences/uberfire-preferences-api/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-preferences</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>uberfire-preferences-api</artifactId>
   <packaging>jar</packaging>

--- a/uberfire-preferences/uberfire-preferences-backend/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-backend/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-preferences</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <name>Uberfire Preferences Backend</name>
   <description>Uberfire Preferences Backend</description>

--- a/uberfire-preferences/uberfire-preferences-client/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-preferences</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-preferences-client</artifactId>

--- a/uberfire-preferences/uberfire-preferences-processors/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-processors/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-preferences</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-preferences-processors</artifactId>

--- a/uberfire-project/pom.xml
+++ b/uberfire-project/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-project</artifactId>

--- a/uberfire-project/uberfire-project-api/pom.xml
+++ b/uberfire-project/uberfire-project-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-project</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-project-api</artifactId>

--- a/uberfire-project/uberfire-project-backend/pom.xml
+++ b/uberfire-project/uberfire-project-backend/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-project</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-project-backend</artifactId>

--- a/uberfire-project/uberfire-project-builder/pom.xml
+++ b/uberfire-project/uberfire-project-builder/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-project</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-project-builder</artifactId>

--- a/uberfire-project/uberfire-project-client/pom.xml
+++ b/uberfire-project/uberfire-project-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-project</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-project-client</artifactId>

--- a/uberfire-rest/pom.xml
+++ b/uberfire-rest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-rest</artifactId>

--- a/uberfire-rest/uberfire-rest-backend/pom.xml
+++ b/uberfire-rest/uberfire-rest-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-rest</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-rest-backend</artifactId>

--- a/uberfire-rest/uberfire-rest-client/pom.xml
+++ b/uberfire-rest/uberfire-rest-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-rest</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-rest-client</artifactId>

--- a/uberfire-security/pom.xml
+++ b/uberfire-security/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-security/uberfire-security-api/pom.xml
+++ b/uberfire-security/uberfire-security-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-security</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-security-api</artifactId>

--- a/uberfire-security/uberfire-security-client/pom.xml
+++ b/uberfire-security/uberfire-security-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-security</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-security-client</artifactId>

--- a/uberfire-security/uberfire-security-codegen/pom.xml
+++ b/uberfire-security/uberfire-security-codegen/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-security</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-security-codegen</artifactId>

--- a/uberfire-server/pom.xml
+++ b/uberfire-server/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-services/pom.xml
+++ b/uberfire-services/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-services</artifactId>

--- a/uberfire-services/uberfire-services-api/pom.xml
+++ b/uberfire-services/uberfire-services-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-services</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-services/uberfire-services-backend/pom.xml
+++ b/uberfire-services/uberfire-services-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-services</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-showcase/pom.xml
+++ b/uberfire-showcase/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-showcase/showcase-distribution-wars/pom.xml
+++ b/uberfire-showcase/showcase-distribution-wars/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-showcase</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>showcase-distribution-wars</artifactId>

--- a/uberfire-showcase/uberfire-client-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-client-webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-showcase</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-client-webapp</artifactId>

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-showcase</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-webapp</artifactId>

--- a/uberfire-structure/pom.xml
+++ b/uberfire-structure/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-structure</artifactId>

--- a/uberfire-structure/uberfire-structure-api/pom.xml
+++ b/uberfire-structure/uberfire-structure-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-structure</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-structure-api</artifactId>

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-structure</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-structure-backend</artifactId>

--- a/uberfire-structure/uberfire-structure-client/pom.xml
+++ b/uberfire-structure/uberfire-structure-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-structure</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-structure-client</artifactId>

--- a/uberfire-test-utils/pom.xml
+++ b/uberfire-test-utils/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-test-utils</artifactId>

--- a/uberfire-testing-utils/pom.xml
+++ b/uberfire-testing-utils/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-workbench/pom.xml
+++ b/uberfire-workbench/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/uberfire-workbench/uberfire-workbench-client-backend/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-backend/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-client-backend</artifactId>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-client-views-patternfly</artifactId>

--- a/uberfire-workbench/uberfire-workbench-client/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-client</artifactId>

--- a/uberfire-workbench/uberfire-workbench-processors-tests/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-processors-tests</artifactId>

--- a/uberfire-workbench/uberfire-workbench-processors/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-processors/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-workbench</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workbench-processors</artifactId>

--- a/uberfire-workingset/pom.xml
+++ b/uberfire-workingset/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>uberfire-workingset</artifactId>

--- a/uberfire-workingset/uberfire-workingset-api/pom.xml
+++ b/uberfire-workingset/uberfire-workingset-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-workingset</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/uberfire-workingset/uberfire-workingset-client/pom.xml
+++ b/uberfire-workingset/uberfire-workingset-client/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.uberfire</groupId>
     <artifactId>uberfire-workingset</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
during kie 7.5.0.Final release appformer was upgraded by error to 2.2.0.Final instead of 2.1.0.Final. So 2.2.0.Final is existing. We should upgrade the appformer develop version to 2.2.1-SNAPSHOT 