### PR TITLE
Add JaCoCo to AppFormer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,9 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jboss.integration-platform</groupId>
-    <artifactId>jboss-integration-platform-bom</artifactId>
-    <!-- Keep in sync with the parent version of uberfire-bom/pom.xml -->
-    <version>8.0.0.CR3</version>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-parent</artifactId>
+    <version>7.6.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.uberfire</groupId>


### PR DESCRIPTION
To be able to use JaCoCo properly, it is first needed to increase the version of PowerMock. Otherwise, the `JAASAuthenticationServiceTest` test in the `org.uberfire.backend.server.security` package fails.

The version is increased in this PR: https://github.com/jboss-integration/jboss-integration-platform-bom/pull/414.