### PR TITLE
DROOLS-1946 Change implementation of moving rows

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
@@ -236,14 +236,7 @@ public class BaseGridData implements GridData {
         }
 
         this.rows.removeAll(rows);
-
-        if (index < oldBlockStart) {
-            this.rows.addAll(index,
-                             rows);
-        } else if (index > oldBlockStart) {
-            this.rows.addAll(index - rows.size() + 1,
-                             rows);
-        }
+        this.rows.addAll(index, rows);
 
         final Range oldBlockExtent = new Range(oldBlockStart,
                                                oldBlockEnd);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataIndexManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataIndexManager.java
@@ -614,6 +614,9 @@ public class BaseGridDataIndexManager {
                 updateMergeMetaData(oldBlockEnd + 1,
                                     _columnIndex);
             }
+            if (oldBlockEnd == rows.size() - 1) {
+                updateMergeMetaData(oldBlockEnd, _columnIndex);
+            }
         }
 
         //Update indexes for where rows were inserted

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridTest.java
@@ -19,6 +19,7 @@ import com.ait.lienzo.client.core.shape.Group;
 import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
@@ -27,6 +28,28 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.im
 import static org.junit.Assert.*;
 
 public abstract class BaseGridTest {
+
+    protected GridData gridData;
+
+    protected GridRow[] gridRows;
+
+    protected GridColumn<String>[] gridColumns;
+
+    protected void constructGridData(final int columnCount, final int rowCount) {
+        gridData = new BaseGridData();
+
+        gridColumns = new GridColumn[columnCount];
+        for (int i = 0; i < columnCount; i++) {
+            gridColumns[i] = new MockMergableGridColumn<>("col" + i, 100);
+            gridData.appendColumn(gridColumns[i]);
+        }
+
+        gridRows = new GridRow[rowCount];
+        for (int i = 0; i < rowCount; i++) {
+            gridRows[i] = new BaseGridRow();
+            gridData.appendRow(gridRows[i]);
+        }
+    }
 
     public void assertGridIndexes(final GridData data,
                                   final boolean[] expectedRowMergeStates,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTest.java
@@ -3272,7 +3272,7 @@ public class GridCellSelectionsTest extends BaseGridTest {
                                                                               0)));
 
         //Move rows
-        data.moveRowsTo(4,
+        data.moveRowsTo(1,
                         new ArrayList<GridRow>() {{
                             add(row0);
                             add(row1);
@@ -3420,7 +3420,7 @@ public class GridCellSelectionsTest extends BaseGridTest {
                                                                               0)));
 
         //Move rows
-        data.moveRowsTo(4,
+        data.moveRowsTo(1,
                         new ArrayList<GridRow>() {{
                             add(row0);
                             add(row1);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridGroupingTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridGroupingTest.java
@@ -23,79 +23,60 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridTest.Expected.build;
 
 public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testInitialSetup() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 3);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            final GridRow row = data.getRow(rowIndex);
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            final GridRow row = gridData.getRow(rowIndex);
             assertFalse(row.isMerged());
             assertFalse(row.isCollapsed());
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                final GridCell<?> cell = data.getCell(rowIndex,
-                                                      columnIndex);
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final GridCell<?> cell = gridData.getCell(rowIndex,
+                                                          columnIndex);
                 assertFalse(cell.isMerged());
             }
         }
 
         assertEquals(3,
-                     data.getRowCount());
+                     gridData.getRowCount());
     }
 
     @Test
     public void testGroup() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 3);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("(0, 0)"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("(0, 0)"));
 
         //Group cells
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -117,10 +98,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup cells
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -146,25 +127,13 @@ public class GridGroupingTest extends BaseGridTest {
     public void testGroupNotCombineWhenCellsValuesUpdatedAbove() {
         //Tests that cells with the same value do not combine into existing collapsed blocks
         //Test #1 - Update cells above the existing collapsed block
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -174,15 +143,15 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,2) (1,3) ]
         // [ (0,4) (1,4) ]
 
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("(0, 2)"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("(0, 2)"));
 
         //Group cells
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, true, true, false},
                           new boolean[]{false, false, false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -214,11 +183,11 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Set cell above existing block (should not affect existing block)
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("(0, 2)"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("(0, 2)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, true, true, false},
                           new boolean[]{false, false, false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -250,11 +219,11 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Set cell above existing block (should create a new block)
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("(0, 2)"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("(0, 2)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -286,10 +255,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup cell (should result in a single block spanning 4 rows)
-        data.expandCell(2,
-                        0);
+        gridData.expandCell(2,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -325,25 +294,13 @@ public class GridGroupingTest extends BaseGridTest {
     public void testGroupNotCombineWhenCellsValuesUpdatedBelow() {
         //Tests that cells with the same value do not combine into existing collapsed blocks
         //Test #2 - Update cells below the existing collapsed block
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -353,15 +310,15 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3) (1,3) ]
         // [ (0,4) (1,4) ]
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
         //Group cells
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, false, false},
                           new boolean[]{false, false, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -393,11 +350,11 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Set cell below existing block (should not affect existing block)
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, false, false},
                           new boolean[]{false, false, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -429,11 +386,11 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Set cell below existing block (should create a new block)
-        data.setCell(4,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(4,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -465,10 +422,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup cell (should result in a single block spanning 4 rows)
-        data.expandCell(1,
-                        0);
+        gridData.expandCell(1,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -502,25 +459,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseBlockWithinParent() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -530,37 +475,37 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1    g2  ]      [   g1  (1,4) ]
         // [   g1  (1,4) ]
 
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(4,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(4,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g2
-        data.collapseCell(1,
-                          1);
+        gridData.collapseCell(1,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, true, true, false},
                           new BaseGridTest.Expected[][]{
@@ -592,10 +537,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g1
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, true, true},
                           new BaseGridTest.Expected[][]{
@@ -627,10 +572,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, true, true, false},
                           new BaseGridTest.Expected[][]{
@@ -664,25 +609,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseRightColumn_SingleCellOverlap_SplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -692,31 +625,31 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1  (1,3) ]      [   g1  (1,4) ]                           [   g1  (1,4) ]
         // [   g1  (1,4) ]
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(4,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(4,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(0,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(0,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g2 - should split g1
-        data.collapseCell(0,
-                          1);
+        gridData.collapseCell(0,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -748,10 +681,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g1
-        data.collapseCell(3,
-                          0);
+        gridData.collapseCell(3,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, true},
                           new BaseGridTest.Expected[][]{
@@ -783,10 +716,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(3,
-                        0);
+        gridData.expandCell(3,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -820,25 +753,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_SingleCellOverlap_SplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -848,31 +769,31 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)   g2  ]      [ (0,4)   g2  ]                           [ (0,4)   g2  ]
         // [ (0,4)   g2  ]
 
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1 - should split g2
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -904,10 +825,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g2
-        data.collapseCell(3,
-                          1);
+        gridData.collapseCell(3,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, true},
                           new BaseGridTest.Expected[][]{
@@ -939,10 +860,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g2
-        data.expandCell(3,
-                        1);
+        gridData.expandCell(3,
+                            1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -976,25 +897,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_ChildBlockCoversTableExtents() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -1004,34 +913,34 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)  g2 ]
         // [ (0,4)  g2 ]
 
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(0,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(0,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1063,10 +972,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1100,25 +1009,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_SingleCellOverlapMidTable_SplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -1128,28 +1025,28 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)    g2  ]
         // [ (0,4)    g2  ]
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1 - should split g2
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1181,10 +1078,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(1,
-                        0);
+        gridData.expandCell(1,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1218,25 +1115,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_SubExtentOverlap_NoSplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -1246,31 +1131,31 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)    g2  ]
         // [ (0,4)    g2  ]
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1 - doesn't need to split g2 since it spans all of g1
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1302,10 +1187,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(1,
-                        0);
+        gridData.expandCell(1,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1339,25 +1224,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_MultipleCellOverlap_SplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -1367,34 +1240,34 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)    g2  ]      [ (0,4)   g2  ]
         // [ (0,4)    g2  ]
 
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1 - should split g2
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1426,10 +1299,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1463,19 +1336,7 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseWholeTable() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
-
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
+        constructGridData(2, 5);
 
         // [   g1    g2  ]
         // [   g1    g2  ]
@@ -1483,20 +1344,20 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1    g2  ]
         // [   g1    g2  ]
 
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            data.setCell(rowIndex,
-                         0,
-                         new BaseGridCellValue<String>("g1"));
-            data.setCell(rowIndex,
-                         1,
-                         new BaseGridCellValue<String>("g2"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            gridData.setCell(rowIndex,
+                             0,
+                             new BaseGridCellValue<String>("g1"));
+            gridData.setCell(rowIndex,
+                             1,
+                             new BaseGridCellValue<String>("g2"));
         }
 
         //Group g1
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, true, true},
                           new BaseGridTest.Expected[][]{
@@ -1528,10 +1389,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1565,19 +1426,7 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseWholeTableExceptLastRow() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
-
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
+        constructGridData(2, 5);
 
         // [   g1    g2  ]
         // [   g1    g2  ]
@@ -1585,27 +1434,27 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1    g2  ]      [ (0,4) (1,4) ]
         // [ (0,4) (1,4) ]
 
-        for (int rowIndex = 0; rowIndex < data.getRowCount() - 1; rowIndex++) {
-            data.setCell(rowIndex,
-                         0,
-                         new BaseGridCellValue<String>("g1"));
-            data.setCell(rowIndex,
-                         1,
-                         new BaseGridCellValue<String>("g2"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount() - 1; rowIndex++) {
+            gridData.setCell(rowIndex,
+                             0,
+                             new BaseGridCellValue<String>("g1"));
+            gridData.setCell(rowIndex,
+                             1,
+                             new BaseGridCellValue<String>("g2"));
         }
 
-        data.setCell(4,
-                     0,
-                     new BaseGridCellValue<String>("(0, 4)"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("(1, 4)"));
+        gridData.setCell(4,
+                         0,
+                         new BaseGridCellValue<String>("(0, 4)"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("(1, 4)"));
 
         //Group g1
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, true, true, true, false},
                           new BaseGridTest.Expected[][]{
@@ -1637,10 +1486,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1674,25 +1523,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_SingleCellOverlapBottom_SplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -1702,31 +1539,31 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)   g2  ]      [ (0,4)   g2  ]                           [   g1    g2  ]
         // [ (0,4)   g2  ]                                                [ (0,3)   g2  ]
 
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1 - should split g2
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -1758,10 +1595,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g2
-        data.collapseCell(3,
-                          1);
+        gridData.collapseCell(3,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, true},
                           new BaseGridTest.Expected[][]{
@@ -1793,10 +1630,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1 - should not recombine g2 as it has been split and collapsed
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, true},
                           new BaseGridTest.Expected[][]{
@@ -1828,10 +1665,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g1 - check re-applying collapse preserves indexing
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, true},
                           new BaseGridTest.Expected[][]{
@@ -1863,10 +1700,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1 - check re-applying collapse preserves indexing
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, true},
                           new BaseGridTest.Expected[][]{
@@ -1900,25 +1737,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseRightColumn_ChildSubExtent() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -1928,37 +1753,37 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)   g2  ]                           [ (0,3)   g2  ]
         // [ (0,4)   g2  ]                           [ (0,4)   g2  ]
 
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(0,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(0,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g2
-        data.collapseCell(0,
-                          1);
+        gridData.collapseCell(0,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, true, true},
                           new BaseGridTest.Expected[][]{
@@ -1990,10 +1815,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1 - should result in g2 being split and collapsed
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, true},
                           new BaseGridTest.Expected[][]{
@@ -2025,10 +1850,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g2 - should restore to original configuration
-        data.expandCell(3,
-                        1);
+        gridData.expandCell(3,
+                            1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2062,25 +1887,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_MultipleCellOverlapTableExtent_SplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -2090,37 +1903,37 @@ public class GridGroupingTest extends BaseGridTest {
         // [ (0,3)   g2  ]      [ (0,4)   g2  ]      [ (0,3)   g2  ]
         // [ (0,4)   g2  ]                           [ (0,4)   g2  ]
 
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(0,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(0,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2152,10 +1965,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g2
-        data.expandCell(0,
-                        1);
+        gridData.expandCell(0,
+                            1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2187,10 +2000,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g2
-        data.collapseCell(0,
-                          1);
+        gridData.collapseCell(0,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, true, true},
                           new BaseGridTest.Expected[][]{
@@ -2224,25 +2037,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_SingleCellOverlapTop_SplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -2252,31 +2053,31 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1  (1,3) ]      [   g1    g2  ]      [   g1    g2  ]
         // [   g1  (1,4) ]
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(4,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(4,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(0,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(0,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
         //Group g1 - should split g2
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, true, true},
                           new BaseGridTest.Expected[][]{
@@ -2308,10 +2109,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g2
-        data.collapseCell(0,
-                          1);
+        gridData.collapseCell(0,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, false, true, true},
                           new BaseGridTest.Expected[][]{
@@ -2343,10 +2144,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1 - g2 should remain split
-        data.expandCell(2,
-                        0);
+        gridData.expandCell(2,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2378,10 +2179,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g2 - g2 should not be split
-        data.expandCell(0,
-                        1);
+        gridData.expandCell(0,
+                            1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2415,28 +2216,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseRightColumn_SingleCellOverlapBottom_NestedSplitBlocks() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        final GridColumn<String> gc3 = new MockMergableGridColumn<String>("col3",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
-        data.appendColumn(gc3);
+        constructGridData(3, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -2446,35 +2232,35 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1    g2  (2,3) ]      [ (0,4)   g2  (2,4) ]      [   g1    g2  (2,3) ]
         // [ (0,4)   g2  (2,4) ]
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
-        data.setCell(0,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
-        data.setCell(1,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
-        data.setCell(2,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
+        gridData.setCell(0,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
+        gridData.setCell(1,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
+        gridData.setCell(2,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
 
         //Check initial setup
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2516,10 +2302,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g3 - should split g1 and g2
-        data.collapseCell(0,
-                          2);
+        gridData.collapseCell(0,
+                              2);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2561,10 +2347,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g2
-        data.collapseCell(3,
-                          1);
+        gridData.collapseCell(3,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, true},
                           new BaseGridTest.Expected[][]{
@@ -2608,30 +2394,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_StaggeredSingleCellOverlapTop_NestedSplitBlocks() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        final GridColumn<String> gc3 = new MockMergableGridColumn<String>("col3",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
-        data.appendColumn(gc3);
+        constructGridData(3, 7);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -2643,38 +2412,38 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1  (1,5) (2,5) ]      [   g1    g2  (2,4) ]
         // [   g1  (1,6) (2,6) ]
 
-        data.setCell(4,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(5,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(6,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(4,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(5,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(6,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(2,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(3,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(4,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(2,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(3,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(4,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
-        data.setCell(0,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
-        data.setCell(1,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
-        data.setCell(2,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
+        gridData.setCell(0,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
+        gridData.setCell(1,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
+        gridData.setCell(2,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
 
         //Check initial setup
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true, true, true},
                           new boolean[]{false, false, false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -2730,10 +2499,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g1 - should split g2
-        data.collapseCell(4,
-                          0);
+        gridData.collapseCell(4,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true, true, true},
                           new boolean[]{false, false, false, false, false, true, true},
                           new BaseGridTest.Expected[][]{
@@ -2789,10 +2558,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g2 - should split g1
-        data.collapseCell(2,
-                          1);
+        gridData.collapseCell(2,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true, true, true},
                           new boolean[]{false, false, false, true, false, true, true},
                           new BaseGridTest.Expected[][]{
@@ -2848,10 +2617,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g3
-        data.collapseCell(0,
-                          2);
+        gridData.collapseCell(0,
+                              2);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true, true, true},
                           new boolean[]{false, true, false, true, false, true, true},
                           new BaseGridTest.Expected[][]{
@@ -2909,28 +2678,13 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupOverlap_CollapseLeftColumn_MultipleCellOverlap_NestedSplitBlocks() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        final GridColumn<String> gc3 = new MockMergableGridColumn<String>("col3",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
-        data.appendColumn(gc3);
+        constructGridData(3, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
@@ -2940,35 +2694,35 @@ public class GridGroupingTest extends BaseGridTest {
         // [   g1  (1,3) (2,3) ]      [   g1  (1,3) (2,3) ]      [ (0,4) (1,4) (2,4) ]
         // [ (0,4) (1,4) (2,4) ]      [ (0,4) (1,4) (2,4) ]
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("g1"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("g1"));
 
-        data.setCell(0,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
-        data.setCell(1,
-                     1,
-                     new BaseGridCellValue<String>("g2"));
+        gridData.setCell(0,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
+        gridData.setCell(1,
+                         1,
+                         new BaseGridCellValue<String>("g2"));
 
-        data.setCell(0,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
-        data.setCell(1,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
-        data.setCell(2,
-                     2,
-                     new BaseGridCellValue<String>("g3"));
+        gridData.setCell(0,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
+        gridData.setCell(1,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
+        gridData.setCell(2,
+                         2,
+                         new BaseGridCellValue<String>("g3"));
 
         //Check initial setup
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -3010,10 +2764,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g2 - should split g1 but not g3
-        data.collapseCell(0,
-                          1);
+        gridData.collapseCell(0,
+                              1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, true, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -3055,10 +2809,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g1 - should split g3
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, true, false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -3100,10 +2854,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Ungroup g1 - g3 should remain split as we don't merge into collapsed cells
-        data.expandCell(2,
-                        0);
+        gridData.expandCell(2,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, true, false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -3145,10 +2899,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Group g1 (again) - there should be no change in state, other than an additional collapsed row
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, true, false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -3192,35 +2946,25 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupUpdateCellValue() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 3);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("(0, 0)"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("(0, 0)"));
 
         //Group cells
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -3242,15 +2986,15 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Update cell value
-        data.setCell(0,
-                     0,
-                     new BaseGridCellValue<String>("<changed>"));
+        gridData.setCell(0,
+                         0,
+                         new BaseGridCellValue<String>("<changed>"));
 
         //Ungroup cells
-        data.expandCell(0,
-                        0);
+        gridData.expandCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -3274,35 +3018,25 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGroupMovedColumnUpdateCellValue() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 3);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("(0, 0)"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("(0, 0)"));
 
         //Group cells
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, true, false},
                           new BaseGridTest.Expected[][]{
@@ -3324,19 +3058,19 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Move column
-        data.moveColumnTo(1,
-                          gc1);
+        gridData.moveColumnTo(1,
+                              gridColumns[0]);
 
         //Update cell value
-        data.setCell(0,
-                     1,
-                     new BaseGridCellValue<String>("<changed>"));
+        gridData.setCell(0,
+                         1,
+                         new BaseGridCellValue<String>("<changed>"));
 
         //Ungroup cells
-        data.expandCell(0,
-                        1);
+        gridData.expandCell(0,
+                            1);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, false, false},
                           new BaseGridTest.Expected[][]{
@@ -3360,35 +3094,25 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testMergedDeleteCellValue() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 3);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("(0, 0)"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("(0, 0)"));
 
         //Group cells
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, true, false},
                           new Expected[][]{
@@ -3410,10 +3134,10 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Update cell value
-        data.deleteCell(0,
-                        0);
+        gridData.deleteCell(0,
+                            0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, false},
                           new boolean[]{false, false, false},
                           new Expected[][]{
@@ -3433,36 +3157,24 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testRemoveRowIndex0FromGroupedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -3493,10 +3205,10 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, true, true, false},
                           new Expected[][]{
@@ -3527,13 +3239,13 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        final GridData.Range rows = data.deleteRow(0);
+        final GridData.Range rows = gridData.deleteRow(0);
         assertEquals(0,
                      rows.getMinRowIndex());
         assertEquals(0,
                      rows.getMaxRowIndex());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, false},
                           new boolean[]{false, true, true, false},
                           new Expected[][]{
@@ -3562,36 +3274,24 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testRemoveRowIndex1FromGroupedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -3622,10 +3322,10 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, true, true, false},
                           new Expected[][]{
@@ -3656,13 +3356,13 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        final GridData.Range rows = data.deleteRow(1);
+        final GridData.Range rows = gridData.deleteRow(1);
         assertEquals(1,
                      rows.getMinRowIndex());
         assertEquals(3,
                      rows.getMaxRowIndex());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false},
                           new boolean[]{false, false},
                           new Expected[][]{
@@ -3681,36 +3381,24 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testRemoveRowIndex2FromGroupedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -3741,10 +3429,10 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, true, true, false},
                           new Expected[][]{
@@ -3775,13 +3463,13 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        final GridData.Range rows = data.deleteRow(2);
+        final GridData.Range rows = gridData.deleteRow(2);
         assertEquals(1,
                      rows.getMinRowIndex());
         assertEquals(3,
                      rows.getMaxRowIndex());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false},
                           new boolean[]{false, false},
                           new Expected[][]{
@@ -3800,36 +3488,24 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testRemoveRowIndex3FromGroupedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -3860,10 +3536,10 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, true, true, false},
                           new Expected[][]{
@@ -3894,13 +3570,13 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        final GridData.Range rows = data.deleteRow(3);
+        final GridData.Range rows = gridData.deleteRow(3);
         assertEquals(1,
                      rows.getMinRowIndex());
         assertEquals(3,
                      rows.getMaxRowIndex());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false},
                           new boolean[]{false, false},
                           new Expected[][]{
@@ -3919,34 +3595,22 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testRemoveRowIndex4FromGroupedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
-        data.setCell(3,
-                     0,
-                     new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
+        gridData.setCell(3,
+                         0,
+                         new BaseGridCellValue<String>("(0, 1)"));
 
         // (0, 0), (1, 0)
         // (0, 1), (1, 1)
@@ -3954,7 +3618,7 @@ public class GridGroupingTest extends BaseGridTest {
         // (0, 1), (1, 3)
         // (0, 4), (1, 4)
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -3985,10 +3649,10 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, true, true, false},
                           new Expected[][]{
@@ -4019,13 +3683,13 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 4)")}
                           });
 
-        final GridData.Range rows = data.deleteRow(4);
+        final GridData.Range rows = gridData.deleteRow(4);
         assertEquals(4,
                      rows.getMinRowIndex());
         assertEquals(4,
                      rows.getMaxRowIndex());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true},
                           new boolean[]{false, false, true, true},
                           new Expected[][]{
@@ -4054,25 +3718,17 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testRemoveOnlyRow() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 1);
 
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false},
                           new boolean[]{false},
                           new Expected[][]{
@@ -4083,46 +3739,36 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 0)")}
                           });
 
-        final GridData.Range rows = data.deleteRow(0);
+        final GridData.Range rows = gridData.deleteRow(0);
         assertEquals(0,
                      rows.getMinRowIndex());
         assertEquals(0,
                      rows.getMaxRowIndex());
 
         assertEquals(0,
-                     data.getRowCount());
+                     gridData.getRowCount());
     }
 
     @Test
     public void testRemoveAllRows() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col2",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 3);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("(" + columnIndex + ", " + rowIndex + ")"));
             }
         }
 
-        data.setCell(1,
-                     0,
-                     new BaseGridCellValue<String>("(0, 0)"));
-        data.setCell(2,
-                     0,
-                     new BaseGridCellValue<String>("(0, 0)"));
+        gridData.setCell(1,
+                         0,
+                         new BaseGridCellValue<String>("(0, 0)"));
+        gridData.setCell(2,
+                         0,
+                         new BaseGridCellValue<String>("(0, 0)"));
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true},
                           new boolean[]{false, false, false},
                           new Expected[][]{
@@ -4143,10 +3789,10 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 2)")}
                           });
 
-        data.collapseCell(0,
-                          0);
+        gridData.collapseCell(0,
+                              0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true},
                           new boolean[]{false, true, true},
                           new Expected[][]{
@@ -4167,43 +3813,26 @@ public class GridGroupingTest extends BaseGridTest {
                                                                             "(1, 2)")}
                           });
 
-        final GridData.Range rows = data.deleteRow(1);
+        final GridData.Range rows = gridData.deleteRow(1);
         assertEquals(0,
                      rows.getMinRowIndex());
         assertEquals(2,
                      rows.getMaxRowIndex());
 
         assertEquals(0,
-                     data.getRowCount());
+                     gridData.getRowCount());
     }
 
     @Test
     public void testGrouped_MoveUp_Rowsx3ToIndex0_Blockx3Rows() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 0 || rowIndex == 4 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -4213,7 +3842,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = a, 3 } Collapse (Child)
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -4245,16 +3874,16 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Collapse cell
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
         //Move row
-        data.moveRowsTo(0,
-                        new ArrayList<GridRow>() {{
-                            add(row1);
-                            add(row2);
-                            add(row3);
-                        }});
+        gridData.moveRowsTo(0,
+                            new ArrayList<GridRow>() {{
+                                add(gridRows[1]);
+                                add(gridRows[2]);
+                                add(gridRows[3]);
+                            }});
 
         // row0 = a, 1 } Collapse (Lead)
         // row1 = a, 2 } Collapse (Child)
@@ -4262,7 +3891,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = b, 0
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, true, true, false, false},
                           new Expected[][]{
@@ -4296,31 +3925,14 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGrouped_MoveUp_Rowsx2ToIndex1_Blockx2Rows() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 || rowIndex == 4 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -4330,7 +3942,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = a, 3 } Collapse (Child)
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -4362,15 +3974,15 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Collapse cell
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
         //Move row
-        data.moveRowsTo(1,
-                        new ArrayList<GridRow>() {{
-                            add(row2);
-                            add(row3);
-                        }});
+        gridData.moveRowsTo(1,
+                            new ArrayList<GridRow>() {{
+                                add(gridRows[2]);
+                                add(gridRows[3]);
+                            }});
 
         // row0 = a, 0 } Should remain unchanged
         // row1 = a, 2 } Collapse (Lead)
@@ -4378,7 +3990,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = b, 1
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, true, false, false},
                           new Expected[][]{
@@ -4412,33 +4024,14 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGrouped_MoveUp_Rowsx2ToIndex0_Blockx2Rows() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 6);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        final GridRow row5 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-        data.appendRow(row5);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 || rowIndex == 4 ? "a" : "b") : "c";
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -4449,7 +4042,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row4 = a, c
         // row5 = b, c
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true, true},
                           new boolean[]{false, false, false, false, false, false},
                           new Expected[][]{
@@ -4486,15 +4079,15 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Collapse cell
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
         //Move row
-        data.moveRowsTo(0,
-                        new ArrayList<GridRow>() {{
-                            add(row2);
-                            add(row3);
-                        }});
+        gridData.moveRowsTo(0,
+                            new ArrayList<GridRow>() {{
+                                add(gridRows[2]);
+                                add(gridRows[3]);
+                            }});
 
         // row0 = b, c } Collapse (Lead)
         // row1 = b, c } Collapse (Child)
@@ -4503,7 +4096,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row4 = a, c
         // row5 = b, c
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true, true},
                           new boolean[]{false, true, false, false, false, false},
                           new Expected[][]{
@@ -4542,33 +4135,14 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGrouped_MoveUp_Rowsx2ToIndex0_Blockx2Rows_MakeNewSplitBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 6);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        final GridRow row5 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-        data.appendRow(row5);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 || rowIndex == 4 ? "a" : "b") : (rowIndex == 0 ? "d" : "c");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -4579,7 +4153,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row4 = a, c
         // row5 = b, c
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true, true},
                           new boolean[]{false, false, false, false, false, false},
                           new Expected[][]{
@@ -4616,15 +4190,15 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Collapse cell
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
         //Move row
-        data.moveRowsTo(0,
-                        new ArrayList<GridRow>() {{
-                            add(row2);
-                            add(row3);
-                        }});
+        gridData.moveRowsTo(0,
+                            new ArrayList<GridRow>() {{
+                                add(gridRows[2]);
+                                add(gridRows[3]);
+                            }});
 
         // row0 = b, c } Collapse (Lead)
         // row1 = b, c } Collapse (Child)
@@ -4633,7 +4207,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row4 = a, c
         // row5 = b, c
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true, true},
                           new boolean[]{false, true, false, false, false, false},
                           new Expected[][]{
@@ -4672,33 +4246,14 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGrouped_MoveUp_Rowsx2ToIndex0_Blockx2Rows_MakeNewMergedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 6);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        final GridRow row5 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-        data.appendRow(row5);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 || rowIndex == 4 ? "a" : "b") : (rowIndex == 0 || rowIndex == 3 ? "d" : "c");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -4709,7 +4264,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row4 = a, c
         // row5 = b, c
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true, true},
                           new boolean[]{false, false, false, false, false, false},
                           new Expected[][]{
@@ -4746,15 +4301,15 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Collapse cell
-        data.collapseCell(2,
-                          0);
+        gridData.collapseCell(2,
+                              0);
 
         //Move row
-        data.moveRowsTo(0,
-                        new ArrayList<GridRow>() {{
-                            add(row2);
-                            add(row3);
-                        }});
+        gridData.moveRowsTo(0,
+                            new ArrayList<GridRow>() {{
+                                add(gridRows[2]);
+                                add(gridRows[3]);
+                            }});
 
         // row0 = b, c } Collapse (Lead)
         // row1 = b, d } Collapse (Child)
@@ -4763,7 +4318,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row4 = a, c
         // row5 = b, c
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true, true},
                           new boolean[]{false, true, false, false, false, false},
                           new Expected[][]{
@@ -4802,31 +4357,14 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGrouped_MoveDown_Rowsx3ToIndex4_Blockx3Rows_NewMergedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 0 || rowIndex == 4 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -4836,7 +4374,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = a, 3 } Collapse (Child)
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -4868,16 +4406,16 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Collapse cell
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
         //Move row
-        data.moveRowsTo(4,
-                        new ArrayList<GridRow>() {{
-                            add(row1);
-                            add(row2);
-                            add(row3);
-                        }});
+        gridData.moveRowsTo(2,
+                            new ArrayList<GridRow>() {{
+                                add(gridRows[1]);
+                                add(gridRows[2]);
+                                add(gridRows[3]);
+                            }});
 
         // row0 = b, 0
         // row1 = b, 4
@@ -4885,7 +4423,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = a, 2 } Collapse (Child)
         // row4 = a, 3 } Collapse (Child)
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, true, true},
                           new Expected[][]{
@@ -4919,31 +4457,14 @@ public class GridGroupingTest extends BaseGridTest {
 
     @Test
     public void testGrouped_MoveDown_Rowsx2ToIndex4_Blockx2Rows_NewMergedGroup() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 || rowIndex == 2 || rowIndex == 4 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -4953,7 +4474,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, false, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -4985,15 +4506,15 @@ public class GridGroupingTest extends BaseGridTest {
                           });
 
         //Collapse cell
-        data.collapseCell(1,
-                          0);
+        gridData.collapseCell(1,
+                              0);
 
         //Move row
-        data.moveRowsTo(4,
-                        new ArrayList<GridRow>() {{
-                            add(row1);
-                            add(row2);
-                        }});
+        gridData.moveRowsTo(3,
+                            new ArrayList<GridRow>() {{
+                                add(gridRows[1]);
+                                add(gridRows[2]);
+                            }});
 
         // row0 = a, 0
         // row1 = a, 3
@@ -5001,7 +4522,7 @@ public class GridGroupingTest extends BaseGridTest {
         // row3 = b, 1 } Collapse (Lead)
         // row4 = b, 2 } Collapse (Child)
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, true},
                           new Expected[][]{

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridRowsMergedTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridRowsMergedTest.java
@@ -15,36 +15,26 @@
  */
 package org.uberfire.ext.wires.core.grids.client.model.impl;
 
+import java.util.Arrays;
+
 import org.junit.Test;
-import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
-import org.uberfire.ext.wires.core.grids.client.model.GridData;
-import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
 public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testRemoveRow() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 5);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = (rowIndex > 0 && rowIndex < 4 ? "b" : "a");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -65,9 +55,9 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "a")}
                           });
 
-        data.deleteRow(2);
+        gridData.deleteRow(2);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, false},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -88,26 +78,18 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testAppendRow() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 4);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = (rowIndex < 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -125,9 +107,9 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "b")}
                           });
 
-        data.appendRow(new BaseGridRow());
+        gridData.appendRow(new BaseGridRow());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -151,26 +133,18 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testInsertRowAtZeroIndex() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 4);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = (rowIndex < 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -188,10 +162,10 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "b")}
                           });
 
-        data.insertRow(0,
-                       new BaseGridRow());
+        gridData.insertRow(0,
+                           new BaseGridRow());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -215,26 +189,18 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testInsertRowAtStartEndBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 4);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = (rowIndex < 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -252,10 +218,10 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "b")}
                           });
 
-        data.insertRow(2,
-                       new BaseGridRow());
+        gridData.insertRow(2,
+                           new BaseGridRow());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -279,25 +245,17 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testInsertRowAtMidBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 4);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("a"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("a"));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -315,10 +273,10 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "a")}
                           });
 
-        data.insertRow(2,
-                       new BaseGridRow());
+        gridData.insertRow(2,
+                           new BaseGridRow());
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -342,26 +300,18 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testDeleteRowAtZeroIndex() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 4);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = (rowIndex < 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -379,9 +329,9 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "b")}
                           });
 
-        data.deleteRow(0);
+        gridData.deleteRow(0);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true},
                           new boolean[]{false, false, false},
                           new Expected[][]{
@@ -399,26 +349,18 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testDeleteRowAtStartEndBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 4);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = (rowIndex < 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -436,9 +378,9 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "b")}
                           });
 
-        data.deleteRow(2);
+        gridData.deleteRow(2);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false},
                           new boolean[]{false, false, false},
                           new Expected[][]{
@@ -456,25 +398,17 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testDeleteRowAtMidBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
+        constructGridData(1, 4);
 
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-        data.appendRow(new BaseGridRow());
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>("a"));
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>("a"));
             }
         }
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true},
                           new boolean[]{false, false, false, false},
                           new Expected[][]{
@@ -492,9 +426,9 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "a")}
                           });
 
-        data.deleteRow(2);
+        gridData.deleteRow(2);
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true},
                           new boolean[]{false, false, false},
                           new Expected[][]{
@@ -512,31 +446,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowUp_Index4to3() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 4 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -546,7 +463,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -578,8 +495,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(3,
-                       row4);
+        gridData.moveRowTo(3,
+                           gridRows[4]);
 
         // row0 = a, 0
         // row1 = a, 1
@@ -587,7 +504,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = b, 4
         // row4 = a, 3
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, false, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -621,31 +538,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowUp_Index3to2() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 3 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -655,7 +555,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = b, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, false, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -687,8 +587,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(2,
-                       row3);
+        gridData.moveRowTo(2,
+                           gridRows[3]);
 
         // row0 = a, 0
         // row1 = a, 1
@@ -696,7 +596,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 2
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -730,31 +630,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowUp_Index2to1() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 2 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -764,7 +647,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -796,8 +679,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(1,
-                       row2);
+        gridData.moveRowTo(1,
+                           gridRows[2]);
 
         // row0 = a, 0
         // row1 = b, 2
@@ -805,7 +688,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -839,31 +722,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowUp_Index1to0() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -873,7 +739,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -905,8 +771,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(0,
-                       row1);
+        gridData.moveRowTo(0,
+                           gridRows[1]);
 
         // row0 = b, 1
         // row1 = a, 0
@@ -914,7 +780,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -948,31 +814,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowUp_Index2to1_NewMergedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex < 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -982,7 +831,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, b
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1014,8 +863,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(1,
-                       row2);
+        gridData.moveRowTo(1,
+                           gridRows[2]);
 
         // row0 = a, a
         // row1 = a, b
@@ -1023,7 +872,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, b
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1057,31 +906,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowUp_Index3to2_NewMergedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -1091,7 +923,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, b
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1123,8 +955,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(2,
-                       row3);
+        gridData.moveRowTo(2,
+                           gridRows[3]);
 
         // row0 = a, b
         // row1 = b, b
@@ -1132,7 +964,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, a
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1166,31 +998,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowDown_Index0to1() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 4 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -1200,7 +1015,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1232,8 +1047,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(1,
-                       row0);
+        gridData.moveRowTo(1,
+                           gridRows[0]);
 
         // row0 = a, 1
         // row1 = a, 0
@@ -1241,7 +1056,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = b, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1275,31 +1090,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowDown_Index1to2() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 3 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -1309,7 +1107,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = b, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, false, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1341,8 +1139,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(2,
-                       row1);
+        gridData.moveRowTo(2,
+                           gridRows[1]);
 
         // row0 = a, 0
         // row1 = a, 2
@@ -1350,7 +1148,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = b, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, false, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1384,31 +1182,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowDown_Index2to3() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 2 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -1418,7 +1199,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1450,8 +1231,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(3,
-                       row2);
+        gridData.moveRowTo(3,
+                           gridRows[2]);
 
         // row0 = a, 0
         // row1 = a, 1
@@ -1459,7 +1240,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = b, 2
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, false, false},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1493,31 +1274,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowDown_Index3to4() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : Integer.toString(rowIndex);
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -1527,7 +1291,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 3
         // row4 = a, 4
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1559,8 +1323,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(4,
-                       row3);
+        gridData.moveRowTo(4,
+                           gridRows[3]);
 
         // row0 = a, 0
         // row1 = b, 1
@@ -1568,7 +1332,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, 4
         // row4 = a, 3
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{false, false, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1602,31 +1366,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowDown_Index1to2_NewMergedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex < 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -1636,7 +1383,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, b
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1668,8 +1415,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(2,
-                       row1);
+        gridData.moveRowTo(2,
+                           gridRows[1]);
 
         // row0 = a, a
         // row1 = a, b
@@ -1677,7 +1424,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, b
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, false, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1711,31 +1458,14 @@ public class GridRowsMergedTest extends BaseGridTest {
 
     @Test
     public void testMergedBlock_MoveRowDown_Index2to3_NewMergedBlock() {
-        final GridData data = new BaseGridData();
-        final GridColumn<String> gc1 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        final GridColumn<String> gc2 = new MockMergableGridColumn<String>("col1",
-                                                                          100);
-        data.appendColumn(gc1);
-        data.appendColumn(gc2);
+        constructGridData(2, 5);
 
-        final GridRow row0 = new BaseGridRow();
-        final GridRow row1 = new BaseGridRow();
-        final GridRow row2 = new BaseGridRow();
-        final GridRow row3 = new BaseGridRow();
-        final GridRow row4 = new BaseGridRow();
-        data.appendRow(row0);
-        data.appendRow(row1);
-        data.appendRow(row2);
-        data.appendRow(row3);
-        data.appendRow(row4);
-
-        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
-            for (int columnIndex = 0; columnIndex < data.getColumnCount(); columnIndex++) {
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
                 final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
-                data.setCell(rowIndex,
-                             columnIndex,
-                             new BaseGridCellValue<String>(value));
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
             }
         }
 
@@ -1745,7 +1475,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, b
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1777,8 +1507,8 @@ public class GridRowsMergedTest extends BaseGridTest {
                           });
 
         //Move row
-        data.moveRowTo(3,
-                       row2);
+        gridData.moveRowTo(3,
+                           gridRows[2]);
 
         // row0 = a, b
         // row1 = b, b
@@ -1786,7 +1516,7 @@ public class GridRowsMergedTest extends BaseGridTest {
         // row3 = a, a
         // row4 = a, b
 
-        assertGridIndexes(data,
+        assertGridIndexes(gridData,
                           new boolean[]{true, true, true, true, true},
                           new boolean[]{false, false, false, false, false},
                           new Expected[][]{
@@ -1815,6 +1545,926 @@ public class GridRowsMergedTest extends BaseGridTest {
                                                   "a"), Expected.build(false,
                                                                        1,
                                                                        "b")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsDown_Indexes2and3to3() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, b
+        // row1 = b, b
+        // row2 = a, a
+        // row3 = a, b
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(3,
+                            Arrays.asList(gridRows[2], gridRows[3]));
+
+        // row0 = a, b
+        // row1 = b, b
+        // row2 = a, b
+        // row3 = a, a
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       3,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "b")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsDown_Indexes0and1and2to1() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, b
+        // row1 = b, b
+        // row2 = a, a
+        // row3 = a, b
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(1,
+                            Arrays.asList(gridRows[0], gridRows[1], gridRows[2]));
+
+        // row0 = a, b
+        // row1 = a, b
+        // row2 = b, b
+        // row3 = a, a
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(true,
+                                                  2,
+                                                  "a"), Expected.build(true,
+                                                                       3,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "b")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsDown_Indexes0and1to3() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, b
+        // row1 = b, b
+        // row2 = a, a
+        // row3 = a, b
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(3,
+                            Arrays.asList(gridRows[0], gridRows[1]));
+
+        // row0 = a, a
+        // row1 = a, b
+        // row2 = a, b
+        // row3 = a, b
+        // row4 = b, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(true,
+                                                  4,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       4,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsUp_Indexes3and4to1() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, b
+        // row1 = b, b
+        // row2 = a, a
+        // row3 = a, b
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(1,
+                            Arrays.asList(gridRows[3], gridRows[4]));
+
+        // row0 = a, b
+        // row1 = a, b
+        // row2 = a, b
+        // row3 = b, b
+        // row4 = a, a
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, false},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(true,
+                                                                       4,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsUp_Indexes2and3and4to1() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, b
+        // row1 = b, b
+        // row2 = a, a
+        // row3 = a, b
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(1,
+                            Arrays.asList(gridRows[2], gridRows[3], gridRows[4]));
+
+        // row0 = a, b
+        // row1 = a, a
+        // row2 = a, b
+        // row3 = a, b
+        // row4 = b, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(true,
+                                                  4,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       3,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsUp_Indexes2and3to0() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex == 1 ? "b" : "a") : (rowIndex == 2 ? "a" : "b");
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, b
+        // row1 = b, b
+        // row2 = a, a
+        // row3 = a, b
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       2,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(0,
+                            Arrays.asList(gridRows[2], gridRows[3]));
+
+        // row0 = a, a
+        // row1 = a, b
+        // row2 = a, b
+        // row3 = b, b
+        // row4 = a, b
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(true,
+                                                  3,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "a")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       4,
+                                                                       "b")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(true,
+                                                                       0,
+                                                                       "b")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(true,
+                                                                       0,
+                                                                       "b")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsUp_notAllRowsMergedAfterMoving() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex < 3 ? "b" : "a") : Integer.toString(rowIndex);
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = b, 0
+        // row1 = b, 1
+        // row2 = b, 2
+        // row3 = a, 3
+        // row4 = a, 4
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(true,
+                                                  3,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "2")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(0,
+                            Arrays.asList(gridRows[2], gridRows[3]));
+
+        // row0 = b, 2
+        // row1 = a, 3
+        // row2 = b, 0
+        // row3 = b, 1
+        // row4 = a, 4
+
+        assertGridIndexes(gridData,
+                          new boolean[]{false, false, true, true, false},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "2")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsUp_notAllRowsMergedBeforeMoving() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex % 2 == 1 ? "b" : "a") : Integer.toString(rowIndex);
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, 0
+        // row1 = b, 1
+        // row2 = a, 2
+        // row3 = b, 3
+        // row4 = a, 4
+
+        assertGridIndexes(gridData,
+                          new boolean[]{false, false, false, false, false},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "2")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(2,
+                            Arrays.asList(gridRows[3], gridRows[4]));
+
+        // row0 = a, 0
+        // row1 = b, 1
+        // row2 = b, 3
+        // row3 = a, 4
+        // row4 = a, 2
+
+        assertGridIndexes(gridData,
+                          new boolean[]{false, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "2")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsDown_notAllRowsMergedAfterMoving() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex < 3 ? "b" : "a") : Integer.toString(rowIndex);
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = b, 0
+        // row1 = b, 1
+        // row2 = b, 2
+        // row3 = a, 3
+        // row4 = a, 4
+
+        assertGridIndexes(gridData,
+                          new boolean[]{true, true, true, true, true},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(true,
+                                                  3,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "2")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(2,
+                            Arrays.asList(gridRows[0], gridRows[1]));
+
+        // row0 = b, 2
+        // row1 = a, 3
+        // row2 = b, 0
+        // row3 = b, 1
+        // row4 = a, 4
+
+        assertGridIndexes(gridData,
+                          new boolean[]{false, false, true, true, false},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "2")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")}
+                          });
+    }
+
+    @Test
+    public void testMergedBlock_MoveRowsDown_notAllRowsMergedBeforeMoving() {
+        constructGridData(2, 5);
+
+        for (int rowIndex = 0; rowIndex < gridData.getRowCount(); rowIndex++) {
+            for (int columnIndex = 0; columnIndex < gridData.getColumnCount(); columnIndex++) {
+                final String value = columnIndex == 0 ? (rowIndex % 2 == 1 ? "b" : "a") : Integer.toString(rowIndex);
+                gridData.setCell(rowIndex,
+                                 columnIndex,
+                                 new BaseGridCellValue<String>(value));
+            }
+        }
+
+        // row0 = a, 0
+        // row1 = b, 1
+        // row2 = a, 2
+        // row3 = b, 3
+        // row4 = a, 4
+
+        assertGridIndexes(gridData,
+                          new boolean[]{false, false, false, false, false},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "2")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")}
+                          });
+
+        //Move row
+        gridData.moveRowsTo(2,
+                            Arrays.asList(gridRows[0], gridRows[1], gridRows[2]));
+
+        // row3 = b, 3
+        // row4 = a, 4
+        // row0 = a, 0
+        // row1 = b, 1
+        // row2 = a, 2
+
+        assertGridIndexes(gridData,
+                          new boolean[]{false, true, true, false, false},
+                          new boolean[]{false, false, false, false, false},
+                          new Expected[][]{
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "3")},
+                                  {Expected.build(true,
+                                                  2,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "4")},
+                                  {Expected.build(true,
+                                                  0,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "0")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "b"), Expected.build(false,
+                                                                       1,
+                                                                       "1")},
+                                  {Expected.build(false,
+                                                  1,
+                                                  "a"), Expected.build(false,
+                                                                       1,
+                                                                       "2")}
                           });
     }
 }


### PR DESCRIPTION
@manstis I changed `org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData#moveRows` method a little bit and added couple of tests. However one test[1] is still failing. If I keep old implementation of `org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData#moveRows`  multiple added test will fail, could you please help?

[1]  
`org.uberfire.ext.wires.core.grids.client.model.impl.GridRowsMergedTest#testMergedBlock_MoveRowsUp_Indexes3and4to1`

Ensemble with:
- https://github.com/kiegroup/kie-wb-common/pull/1339
  