### PR TITLE
[7.5.x] [Content Management] HTML panel causes errors when saving & when adding page to navigation tree

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/pom.xml
@@ -123,6 +123,11 @@
       <artifactId>uberfire-commons-editor-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-widgets</artifactId>
+    </dependency>
+
     <!-- GWT and GWT Extensions -->
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/NavigationManager.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/NavigationManager.java
@@ -31,6 +31,8 @@ public interface NavigationManager {
 
     NavTree getNavTree();
 
+    boolean hasNavTree();
+
     void saveNavTree(NavTree navTree, Command afterSave);
 
     NavTree secure(NavTree navTree, boolean removeEmptyGroups);

--- a/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/impl/NavigationManagerImpl.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/impl/NavigationManagerImpl.java
@@ -16,6 +16,8 @@
 package org.dashbuilder.client.navigation.impl;
 
 import java.util.List;
+import java.util.Optional;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -78,7 +80,12 @@ public class NavigationManagerImpl implements NavigationManager {
 
     @Override
     public NavTree getNavTree() {
-        return navTree == null ? defaultNavTree : navTree;
+        return !hasNavTree() ? defaultNavTree : navTree;
+    }
+
+    @Override
+    public boolean hasNavTree() {
+        return Optional.ofNullable(navTree).isPresent();
     }
 
     @Override

--- a/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/editor/NavTreeEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/editor/NavTreeEditor.java
@@ -16,6 +16,7 @@
 package org.dashbuilder.client.navigation.widget.editor;
 
 import java.util.Optional;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -26,6 +27,7 @@ import org.dashbuilder.client.navigation.event.NavItemEditCancelledEvent;
 import org.dashbuilder.client.navigation.event.NavItemEditStartedEvent;
 import org.dashbuilder.client.navigation.plugin.PerspectivePluginManager;
 import org.dashbuilder.client.navigation.resources.i18n.NavigationConstants;
+import org.dashbuilder.client.widgets.common.LoadingBox;
 import org.dashbuilder.navigation.NavFactory;
 import org.dashbuilder.navigation.NavGroup;
 import org.dashbuilder.navigation.NavTree;
@@ -54,6 +56,7 @@ public class NavTreeEditor extends NavItemEditor {
     NavTree navTree;
     Command onSaveCommand;
     Optional<NavItemEditor> currentlyEditedItem = Optional.empty();
+    LoadingBox loadingBox;
 
     @Inject
     public NavTreeEditor(NavTreeEditorView view,
@@ -64,7 +67,8 @@ public class NavTreeEditor extends NavItemEditor {
                          TargetPerspectiveEditor targetPerspectiveEditor,
                          PerspectivePluginManager perspectivePluginManager,
                          Event<NavItemEditStartedEvent> navItemEditStartedEvent,
-                         Event<NavItemEditCancelledEvent> navItemEditCancelledEvent) {
+                         Event<NavItemEditCancelledEvent> navItemEditCancelledEvent,
+                         LoadingBox loadingBox) {
 
         super(view, beanManager,
                 placeManager,
@@ -76,6 +80,7 @@ public class NavTreeEditor extends NavItemEditor {
 
         this.view = view;
         this.navigationManager = navigationManager;
+        this.loadingBox = loadingBox;
         this.view.init(this);
 
         super.setChildEditorClass(NavItemDefaultEditor.class);
@@ -124,7 +129,26 @@ public class NavTreeEditor extends NavItemEditor {
     // View actions
 
     void onNewTreeClicked() {
-        this.newGroup();
+        saveDefaultNavTree();
+        newGroup();
+    }
+
+    void saveDefaultNavTree() {
+
+        final boolean hasNoSavedTree = !navigationManager.hasNavTree();
+
+        if (hasNoSavedTree) {
+            showLoading();
+            navigationManager.saveNavTree(navigationManager.getNavTree(), this::hideLoading);
+        }
+    }
+
+    void showLoading() {
+        loadingBox.show();
+    }
+
+    void hideLoading() {
+        loadingBox.hide();
     }
 
     void onSaveClicked() {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/htmleditor/HtmlEditorPresenter.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/htmleditor/HtmlEditorPresenter.java
@@ -48,6 +48,10 @@ public class HtmlEditorPresenter {
         view.setContent(content);
     }
 
+    public void destroy() {
+        view.destroy();
+    }
+
     public interface View extends UberElement<HtmlEditorPresenter>,
                                   BaseEditorView {
 
@@ -56,5 +60,7 @@ public class HtmlEditorPresenter {
         void setContent(String content);
 
         void load();
+
+        void destroy();
     }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/ConfigurationContext.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/ConfigurationContext.java
@@ -75,4 +75,20 @@ public class ConfigurationContext {
     public LayoutTemplate getCurrentLayoutTemplate() {
         return currentLayoutTemplateSupplier.get();
     }
+
+    public Command getConfigurationCanceled() {
+        return configurationCanceled;
+    }
+
+    public void setConfigurationCanceled(final Command configurationCanceled) {
+        this.configurationCanceled = configurationCanceled;
+    }
+
+    public Command getConfigurationFinish() {
+        return configurationFinish;
+    }
+
+    public void setConfigurationFinish(final Command configurationFinish) {
+        this.configurationFinish = configurationFinish;
+    }
 }

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/popups/EditHTMLPresenter.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/popups/EditHTMLPresenter.java
@@ -65,6 +65,7 @@ public class EditHTMLPresenter {
 
     void cancelClick() {
         view.hide();
+        destroyHtmlEditor();
         modalConfigurationContext.configurationCancelled();
     }
 
@@ -72,7 +73,12 @@ public class EditHTMLPresenter {
         view.hide();
         modalConfigurationContext.setComponentProperty(HTMLLayoutDragComponent.HTML_CODE_PARAMETER,
                                                        htmlEditor.getContent());
+        destroyHtmlEditor();
         modalConfigurationContext.configurationFinished();
+    }
+
+    public void destroyHtmlEditor() {
+        htmlEditor.destroy();
     }
 
     public HtmlEditorPresenter.View getHtmlEditorView() {

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/popups/EditHTMLView.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/popups/EditHTMLView.java
@@ -74,6 +74,7 @@ public class EditHTMLView implements EditHTMLPresenter.View {
             if (ButtonPressed.CLOSE.equals(buttonPressed)) {
                 presenter.closeClick();
             }
+            presenter.destroyHtmlEditor();
         });
 
         modal.setWidth("960px");

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/popups/EditHTMLPresenterTest.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/popups/EditHTMLPresenterTest.java
@@ -22,7 +22,12 @@ import org.uberfire.ext.editor.commons.client.htmleditor.HtmlEditorPresenter;
 import org.uberfire.ext.layout.editor.client.api.ModalConfigurationContext;
 import org.uberfire.ext.plugin.client.perspective.editor.layout.editor.HTMLLayoutDragComponent;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class EditHTMLPresenterTest {
 
@@ -86,6 +91,7 @@ public class EditHTMLPresenterTest {
         presenter.okClick();
 
         verify(view).hide();
+        verify(presenter).destroyHtmlEditor();
         verify(modalConfigurationContext,
                never()).configurationCancelled();
         verify(modalConfigurationContext).configurationFinished();
@@ -97,6 +103,7 @@ public class EditHTMLPresenterTest {
         presenter.cancelClick();
 
         verify(view).hide();
+        verify(presenter).destroyHtmlEditor();
         verify(modalConfigurationContext).configurationCancelled();
         verify(modalConfigurationContext,
                never()).configurationFinished();


### PR DESCRIPTION
See: https://issues.jboss.org/browse/RHDM-219

---

![demo](https://user-images.githubusercontent.com/1079279/34846091-2f707c1e-f6fe-11e7-8556-246bf8d31f0d.gif)

---

Regarding the [ignored exception](https://github.com/Voog/wysihtml/blob/26a85fc0e51bde077c23bcdcbdc0549f34341e0c/lib/rangy/rangy-core.js#L1318), it was introduced by the `wysihtml` [version update](https://github.com/kiegroup/appformer/commit/24423b31654e74739f2e2af0c0c3f0f26eecce34#diff-620e02db07d901ae62cd35ca89329df4). Since everything still works as expected and the lib is in a beta version, I think that we can wait for a more stable API and ignore the exception for now.

The fix refers to loading and destroying the `wysihtml` editor everytime we show and hide the modal, respectively.

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/134
- https://github.com/kiegroup/kie-wb-distributions/pull/668