### PR TITLE
[7.5.x] RHDM-233: Do not register the KC security management authentication client interceptor by default

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/BearerAuthenticationInterceptor.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/BearerAuthenticationInterceptor.java
@@ -18,16 +18,12 @@ package org.uberfire.ext.security.management.keycloak.client.auth;
 
 import java.lang.reflect.Method;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.ext.Provider;
 
-import org.jboss.resteasy.annotations.interception.ClientInterceptor;
 import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.spi.interception.AcceptedByMethod;
 import org.jboss.resteasy.spi.interception.ClientExecutionContext;
 import org.jboss.resteasy.spi.interception.ClientExecutionInterceptor;
 
-@Provider
-@ClientInterceptor
 /**
  * A Resteasy client interceptor used for Keycloak's client authentication based on the Bearer authentication method.
  * It does not intercept the "grantToken" and "refreshToken" calls from the token service endpoint (those requests are basic authentication based).


### PR DESCRIPTION
Hey @ederign 

This is the fix for [RHDM-233](https://issues.jboss.org/browse/RHDM-233). It's just removing the resteasy annotations for that interceptor, this way it will not intercept other requests rather than the keycloak admin area related ones (as it's already being registered programatically for that kind of requests [here](https://github.com/kiegroup/appformer/blob/master/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/Keycloak.java#L45))

@tomasdavidorg As you was facing with this issue, probably you can give it a look as well, if you have a chance.

PS: This is a critical issue targeted for RHDM 7.0.GA. So creating the PR for `7.5.x`, next step will be creating it for `master` once this PR is merged.

Thanks guys!

