### PR TITLE
[7.5.x] AF-972: Wrong order of the validation messages

### DIFF
--- a/uberfire-message-console/uberfire-message-console-client/pom.xml
+++ b/uberfire-message-console/uberfire-message-console-client/pom.xml
@@ -118,6 +118,12 @@
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/uberfire-message-console/uberfire-message-console-client/src/main/java/org/guvnor/messageconsole/client/console/MessageConsoleService.java
+++ b/uberfire-message-console/uberfire-message-console-client/src/main/java/org/guvnor/messageconsole/client/console/MessageConsoleService.java
@@ -19,6 +19,7 @@ package org.guvnor.messageconsole.client.console;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -44,16 +45,9 @@ import org.uberfire.rpc.SessionInfo;
 @ApplicationScoped
 public class MessageConsoleService {
 
-    @Inject
     private SyncBeanManager iocManager;
-
-    @Inject
     private PlaceManager placeManager;
-
-    @Inject
     private SessionInfo sessionInfo;
-
-    @Inject
     private User identity;
 
     private ListDataProvider<MessageConsoleServiceRow> dataProvider = new ListDataProvider<MessageConsoleServiceRow>();
@@ -62,6 +56,21 @@ public class MessageConsoleService {
     private static final String MESSAGE_CONSOLE = "org.kie.workbench.common.screens.messageconsole.MessageConsole";
 
     private String currentPerspective;
+
+    public MessageConsoleService() {
+        //CDI proxy
+    }
+
+    @Inject
+    public MessageConsoleService(final SyncBeanManager iocManager,
+                                 final PlaceManager placeManager,
+                                 final SessionInfo sessionInfo,
+                                 final User identity) {
+        this.iocManager = iocManager;
+        this.placeManager = placeManager;
+        this.sessionInfo = sessionInfo;
+        this.identity = identity;
+    }
 
     public void publishMessages(final @Observes PublishMessagesEvent publishEvent) {
         publishMessages(publishEvent.getSessionId(),
@@ -131,6 +140,7 @@ public class MessageConsoleService {
 
         list.addAll(index,
                     newRows);
+        list.sort(MessageConsoleServiceRow.DESC_ORDER);
     }
 
     private void unpublishMessages(final String sessionId,
@@ -227,5 +237,10 @@ public class MessageConsoleService {
 
     private Collection<SyncBeanDef<MessageConsoleWhiteList>> getAvailableWhiteLists() {
         return iocManager.lookupBeans(MessageConsoleWhiteList.class);
+    }
+
+    //This is required for Unit Testing
+    ListDataProvider<MessageConsoleServiceRow> getDataProvider() {
+        return dataProvider;
     }
 }

--- a/uberfire-message-console/uberfire-message-console-client/src/main/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceRow.java
+++ b/uberfire-message-console/uberfire-message-console-client/src/main/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceRow.java
@@ -16,6 +16,8 @@
 
 package org.guvnor.messageconsole.client.console;
 
+import java.util.Comparator;
+
 import org.guvnor.common.services.shared.message.Level;
 import org.guvnor.messageconsole.events.SystemMessage;
 import org.uberfire.backend.vfs.Path;
@@ -23,11 +25,19 @@ import org.uberfire.paging.AbstractPageRow;
 
 public class MessageConsoleServiceRow extends AbstractPageRow {
 
-    String sessionId;
+    private static int COUNTER = 0;
 
-    String userId;
+    private final long sequence;
 
-    SystemMessage message;
+    private String sessionId;
+
+    private String userId;
+
+    private SystemMessage message;
+
+    static final Comparator<MessageConsoleServiceRow> NATURAL_ORDER = Comparator.comparingLong(row -> row.sequence);
+
+    static final Comparator<MessageConsoleServiceRow> DESC_ORDER = NATURAL_ORDER.reversed();
 
     public MessageConsoleServiceRow(String sessionId,
                                     String userId,
@@ -35,6 +45,7 @@ public class MessageConsoleServiceRow extends AbstractPageRow {
         this.sessionId = sessionId;
         this.userId = userId;
         this.message = message;
+        this.sequence = COUNTER++;
     }
 
     public String getSessionId() {
@@ -91,5 +102,15 @@ public class MessageConsoleServiceRow extends AbstractPageRow {
 
     public String getMessageText() {
         return getMessage() != null ? getMessage().getText() : null;
+    }
+
+    //This is required for Unit Testing
+    static void resetSequence() {
+        COUNTER = 0;
+    }
+
+    //This is required for Unit Testing
+    long getSequence() {
+        return sequence;
     }
 }

--- a/uberfire-message-console/uberfire-message-console-client/src/test/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceRowTest.java
+++ b/uberfire-message-console/uberfire-message-console-client/src/test/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceRowTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.guvnor.messageconsole.client.console;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.guvnor.messageconsole.events.SystemMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MessageConsoleServiceRowTest {
+
+    private static final String SESSION_ID = "sessionId";
+
+    private static final String USER_ID = "userId";
+
+    private static final int ROWS = 5;
+
+    @Mock
+    private SystemMessage message;
+
+    protected List<MessageConsoleServiceRow> rows;
+
+    @Before
+    public void setup() {
+        this.rows = new ArrayList<>();
+        MessageConsoleServiceRow.resetSequence();
+        IntStream.range(0, ROWS).forEach(i -> rows.add(new MessageConsoleServiceRow(SESSION_ID,
+                                                                                    USER_ID,
+                                                                                    message)));
+    }
+
+    @Test
+    public void testSequence() {
+        IntStream.range(0, ROWS).forEach(i -> assertEquals(i,
+                                                           rows.get(i).getSequence()));
+    }
+
+    @Test
+    public void testComparator() {
+        rows.sort(MessageConsoleServiceRow.DESC_ORDER);
+
+        IntStream.range(0, ROWS).forEach(i -> assertEquals(ROWS - i - 1,
+                                                           rows.get(i).getSequence()));
+    }
+}

--- a/uberfire-message-console/uberfire-message-console-client/src/test/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceTest.java
+++ b/uberfire-message-console/uberfire-message-console-client/src/test/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.guvnor.messageconsole.client.console;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gwt.view.client.ListDataProvider;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.guvnor.messageconsole.events.PublishMessagesEvent;
+import org.guvnor.messageconsole.events.SystemMessage;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.rpc.SessionInfo;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class MessageConsoleServiceTest {
+
+    @Mock
+    private SyncBeanManager iocManager;
+
+    @Mock
+    private PlaceManager placeManager;
+
+    @Mock
+    private SessionInfo sessionInfo;
+
+    @Mock
+    private User identity;
+
+    private MessageConsoleService service;
+
+    @Before
+    public void setup() {
+        this.service = new MessageConsoleService(iocManager,
+                                                 placeManager,
+                                                 sessionInfo,
+                                                 identity);
+    }
+
+    @Test
+    public void testPublishMessagesSortsMessagesInReverseOrder() {
+        final PublishMessagesEvent event = new PublishMessagesEvent();
+        final SystemMessage systemMessage1 = new SystemMessage();
+        final SystemMessage systemMessage2 = new SystemMessage();
+        event.setMessagesToPublish(Arrays.asList(systemMessage1, systemMessage2));
+
+        service.publishMessages(event);
+
+        final ListDataProvider<MessageConsoleServiceRow> dataProvider = service.getDataProvider();
+        final List<MessageConsoleServiceRow> data = dataProvider.getList();
+
+        assertEquals(2,
+                     data.size());
+        assertEquals(1,
+                     data.get(0).getSequence());
+        assertEquals(0,
+                     data.get(1).getSequence());
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/AF-972

(Product JIRA https://issues.jboss.org/browse/RHDM-295)

This is the corollary of https://github.com/kiegroup/appformer/pull/144 for 7.5.x

(cherry picked from commit 52ee57a846d4e84106d6a89d4f3f98168ff17e7f)

(cherry picked from commit 58a72d1b036cf1a5f0cfd28ec5079afd83b2be76)