### PR TITLE
[RHDM-306, RHDM-307, RHDM-309]: Fixed filtering issues and duplicated assets in different projects. Only include not null sort fields.

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/elasticsearch/ComplexFieldsTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/elasticsearch/ComplexFieldsTest.java
@@ -113,13 +113,38 @@ public class ComplexFieldsTest extends BaseIndexTest {
                               });
         }
         waitForCountDown(5000);
-        List<KObject> result = config.getIndexProvider().findByQuery(Arrays.asList("elastic_complex_fields_test"),
-                                                                     new WildcardQuery(new Term("file",
-                                                                                                "default://master@files/kie")),
-                                                                     null,
-                                                                     0);
 
-        assertEquals(2,
-                     result.size());
+        {
+            List<KObject> result = config.getIndexProvider().findByQuery(Arrays.asList("elastic_complex_fields_test"),
+                                                                         new WildcardQuery(new Term("file",
+                                                                                                    "default://master@files/kie")),
+                                                                         null,
+                                                                         0);
+
+            assertEquals(1,
+                         result.size());
+        }
+
+        {
+            List<KObject> result = config.getIndexProvider().findByQuery(Arrays.asList("elastic_complex_fields_test"),
+                                                                         new WildcardQuery(new Term("file",
+                                                                                                    "default://master@file/kie")),
+                                                                         null,
+                                                                         0);
+
+            assertEquals(1,
+                         result.size());
+        }
+
+        {
+            List<KObject> result = config.getIndexProvider().findByQuery(Arrays.asList("elastic_complex_fields_test"),
+                                                                         new WildcardQuery(new Term("file",
+                                                                                                    "default://master@notFound")),
+                                                                         null,
+                                                                         0);
+
+            assertEquals(0,
+                         result.size());
+        }
     }
 }


### PR DESCRIPTION
With @paulovmr fixed the issues below:

https://issues.jboss.org/browse/RHDM-306
https://issues.jboss.org/browse/RHDM-307
https://issues.jboss.org/browse/RHDM-309

There was a problem with colons in urls (it seems it's an ES problem with query strings). So now every project have their own assets.

It also fixes a problem with an error that appeared when creating some assets. It was a sort that contains a null field. In lucene that enables the "sort by doc number", but in ES that is by default so we omitted those sort field that are null.

@ederign could you review?