### PR TITLE
[RHDM-308]: Fixed issue with thread names

### DIFF
--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceExecutorService.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceExecutorService.java
@@ -131,7 +131,6 @@ public class WorkspaceExecutorService implements ExecutorService {
         String workspace = getWorkspaceName();
         return () -> {
             WorkspaceContext.set(workspace);
-            Thread.currentThread().setName(workspace);
             runnable.run();
         };
     }
@@ -141,7 +140,6 @@ public class WorkspaceExecutorService implements ExecutorService {
         String workspace = getWorkspaceName();
         return () -> {
             WorkspaceContext.set(workspace);
-            Thread.currentThread().setName(workspace);
             return callable.call();
         };
     }

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScopeContext.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScopeContext.java
@@ -75,7 +75,6 @@ public class WorkspaceScopeContext implements Context {
                              bean.getBeanClass(),
                              workspace.getName());
             }
-            Thread.currentThread().setName("WorkspaceScopeContext" + "-" + workspace.getName());
             return instance;
         }
     }

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/WorkspaceBuilderServiceImpl.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/WorkspaceBuilderServiceImpl.java
@@ -46,6 +46,7 @@ public class WorkspaceBuilderServiceImpl implements
         try {
             logger.info("Building {} ...",
                         gav);
+            logger.info("Thread name: " + Thread.currentThread().getName());
             Thread.currentThread().sleep(5000l);
             logger.info("Building finished {}",
                         gav);


### PR DESCRIPTION
Threads used to contain usernames to debug what workspace was running there. I removed those debug names.

@ederign, can you review it please?