### PR TITLE
DROOLS-2218: Log NPE during weld cleanup

### DIFF
--- a/uberfire-test-utils/src/main/java/org/guvnor/test/CDITestSetup.java
+++ b/uberfire-test-utils/src/main/java/org/guvnor/test/CDITestSetup.java
@@ -22,6 +22,7 @@ import javax.enterprise.inject.spi.BeanManager;
 
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
+import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
@@ -47,7 +48,12 @@ public class CDITestSetup {
 
     public void cleanup() {
         if (weld != null) {
-            weld.shutdown();
+            try {
+                weld.shutdown();
+            } catch (NullPointerException npeException) {
+                LoggerFactory.getLogger(CDITestSetup.class)
+                        .warn("Problem occured during weld clean up: " + npeException.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Running tests which use the CDITestSetup on jenkins sometimes cause NPE in the weld cleanup. Such class and NPE:
- org.drools.workbench.screens.dtablexls.backend.server.DecisionTableXLSServiceImplCDITest
- https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/drools-wb-pullrequests-7.5.x/46/testReport/org.drools.workbench.screens.dtablexls.backend.server/DecisionTableXLSServiceImplCDITest/testValidateColumnsNotInStandardOrder/

@manstis please have a look,
Ensemble with:
kiegroup/drools-wb#794