### PR TITLE
[DO NOT MERGE] KIE Lienzo modules integration tests 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1189,10 +1189,38 @@
         <version>${version.ch.qos.logback}</version>
       </dependency>
 
+      <!-- Lienzo Charts -->
       <dependency>
         <groupId>com.ahome-it</groupId>
         <artifactId>lienzo-charts</artifactId>
         <version>${version.com.ahome-it.lienzo-charts}</version>
+      </dependency>
+
+      <!-- KIE Lienzo modules -->
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-core</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-core</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-tests</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-tests</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
       </dependency>
 
       <dependency>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-api/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-api/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 
@@ -63,7 +63,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-tests</artifactId>
       <scope>test</scope>
       <exclusions>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-scratchpad/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-scratchpad/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-trees/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-trees/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
FYI @mbiarnes @tiagodolphine @manstis 
Found that the decision table depends on some `uberfire-wires` artifact, so finally updated wires dependencies for using the KIE Lienzo modules as well.