### PR TITLE
[DO NOT MERGE] JBPM-6806: Included KIE Lienzo artifacts into the dependency management.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1191,10 +1191,38 @@
         <version>${version.ch.qos.logback}</version>
       </dependency>
 
+      <!-- Lienzo Charts -->
       <dependency>
         <groupId>com.ahome-it</groupId>
         <artifactId>lienzo-charts</artifactId>
         <version>${version.com.ahome-it.lienzo-charts}</version>
+      </dependency>
+
+      <!-- KIE Lienzo modules -->
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-core</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-core</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-tests</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>lienzo-tests</artifactId>
+        <version>${version.org.kie}</version>
+        <classifier>sources</classifier>
       </dependency>
 
       <dependency>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
@@ -83,7 +83,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-api/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-api/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 
@@ -63,7 +63,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-tests</artifactId>
       <scope>test</scope>
       <exclusions>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-scratchpad/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-scratchpad/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-trees/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-trees/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
     </dependency>
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -106,7 +106,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.ahome-it</groupId>
+      <groupId>org.kie</groupId>
       <artifactId>lienzo-core</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Hey @mbiarnes @tiagodolphine @manstis 

Created ticket and branches with same names for doing the right Jenkins integration tests. 
See https://issues.jboss.org/browse/JBPM-6806

NOTE: Found that the decision tables depend on some `uberfire-wires` artifacts, so finally updated wires dependencies for using the KIE Lienzo modules as well.

Please **DO NOT MERGE** yet.

Thanks!