### PR TITLE
DROOLS-2303: [DMN Designer] Add column to whole row outline

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
@@ -69,6 +69,8 @@ public class BaseGridData implements GridData {
     public void appendColumn(final GridColumn<?> column) {
         column.setIndex(columns.size());
         columns.add(column);
+
+        selectionsManager.onInsertColumn(columns.size() - 1);
     }
 
     @Override
@@ -77,6 +79,8 @@ public class BaseGridData implements GridData {
         column.setIndex(columns.size());
         columns.add(index,
                     column);
+
+        selectionsManager.onInsertColumn(index);
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataSelectionsManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataSelectionsManager.java
@@ -18,12 +18,14 @@ package org.uberfire.ext.wires.core.grids.client.model.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.util.ColumnIndexUtilities;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowSelectionStrategy;
 
 /**
  * Helper class that manages "selected cell" meta-data following different mutations to {@link GridData}
@@ -49,6 +51,22 @@ public class BaseGridDataSelectionsManager {
                                      1);
             }
         }
+    }
+
+    public void onInsertColumn(final int index) {
+        final List<GridData.SelectedCell> selectedCells = gridData.getSelectedCells();
+        final List<Integer> rowsWithASelection = selectedCells.stream()
+                .filter(sc -> {
+                    final int ri = sc.getRowIndex();
+                    final int ci = sc.getColumnIndex();
+                    final int _ci = ColumnIndexUtilities.findUiColumnIndex(gridData.getColumns(), ci);
+                    final GridCell<?> cell = gridData.getCell(ri, _ci);
+                    return cell != null && cell.getSelectionManager() instanceof RowSelectionStrategy;
+                })
+                .map(GridData.SelectedCell::getRowIndex)
+                .collect(Collectors.toList());
+
+        rowsWithASelection.forEach(rowIndex -> onSelectCell(rowIndex, index));
     }
 
     public void onDeleteColumn(final int index) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTest.java
@@ -16,11 +16,15 @@
 package org.uberfire.ext.wires.core.grids.client.model.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.function.Consumer;
 
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.RowSelectionStrategy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1258,6 +1262,67 @@ public class GridCellSelectionsTest extends BaseGridTest {
                                                                               0)));
         assertFalse(data.getSelectedCells().contains(new GridData.SelectedCell(0,
                                                                                1)));
+        assertFalse(data.getSelectedCells().contains(new GridData.SelectedCell(1,
+                                                                               1)));
+        assertEquals(2,
+                     data.getSelectedCells().size());
+    }
+
+    @Test
+    public void testSelectCellAppendColumnWithRowSelected() {
+        doTestSelectCellWithRowSelected((data) -> data.appendColumn(new MockMergableGridColumn<String>("col1",
+                                                                                                       100)));
+    }
+
+    @Test
+    public void testSelectCellInsertColumnWithRowSelected() {
+        doTestSelectCellWithRowSelected((data) -> data.insertColumn(0,
+                                                                    new MockMergableGridColumn<String>("col1",
+                                                                                                       100)));
+    }
+
+    private void doTestSelectCellWithRowSelected(final Consumer<GridData> mutation) {
+        final GridData data = new BaseGridData();
+        final RowNumberColumn gc1 = new RowNumberColumn(Collections.singletonList(new BaseHeaderMetaData("#")),
+                                                        new MockMergableGridColumnRenderer<>());
+        data.appendColumn(gc1);
+
+        data.appendRow(new BaseGridRow());
+        data.appendRow(new BaseGridRow());
+
+        for (int rowIndex = 0; rowIndex < data.getRowCount(); rowIndex++) {
+            data.setCell(rowIndex,
+                         0,
+                         new BaseGridCellValue<>(rowIndex));
+            data.getCell(rowIndex,
+                         0).setSelectionManager(RowSelectionStrategy.INSTANCE);
+        }
+
+        assertGridIndexes(data,
+                          new boolean[]{false, false},
+                          new boolean[]{false, false},
+                          new Expected[][]{
+                                  {build(false,
+                                         1,
+                                         0)},
+                                  {build(false,
+                                         1,
+                                         1)}
+                          });
+
+        data.selectCell(0,
+                        0);
+        assertEquals(1,
+                     data.getSelectedCells().size());
+
+        mutation.accept(data);
+
+        assertTrue(data.getSelectedCells().contains(new GridData.SelectedCell(0,
+                                                                              0)));
+        assertFalse(data.getSelectedCells().contains(new GridData.SelectedCell(1,
+                                                                               0)));
+        assertTrue(data.getSelectedCells().contains(new GridData.SelectedCell(0,
+                                                                              1)));
         assertFalse(data.getSelectedCells().contains(new GridData.SelectedCell(1,
                                                                                1)));
         assertEquals(2,


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2303

@jomarko This fix also applies to Guided Decision Tables where it too was possible to select a "row" and then insert a new column that was then not included in the selected row.