### PR TITLE
AF-819: Renaming assets discards changes

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-dataset-editor/src/main/java/org/dashbuilder/dataset/editor/client/screens/DataSetDefEditorPresenter.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-dataset-editor/src/main/java/org/dashbuilder/dataset/editor/client/screens/DataSetDefEditorPresenter.java
@@ -47,6 +47,7 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.editor.commons.client.BaseEditor;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
@@ -72,7 +73,7 @@ import static org.uberfire.workbench.events.NotificationEvent.NotificationType.S
 
 @Dependent
 @WorkbenchEditor(identifier = "DataSetDefEditor", supportedTypes = {DataSetDefType.class}, priority = Integer.MAX_VALUE)
-public class DataSetDefEditorPresenter extends BaseEditor {
+public class DataSetDefEditorPresenter extends BaseEditor<DataSetDef, DefaultMetadata> {
 
     @Inject
     SyncBeanManager beanManager;

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/file/DefaultMetadata.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/file/DefaultMetadata.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.file;
+
+/*
+ * This is the default metadata interface for Editors that extend `BaseEditor`
+ * but don't depend on any metadata to persist an asset.
+ */
+public interface DefaultMetadata {
+
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/htmleditor/HtmlEditorService.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/htmleditor/HtmlEditorService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.service.htmleditor;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
+import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
+import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
+import org.uberfire.ext.editor.commons.service.support.SupportsRead;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+@Remote
+public interface HtmlEditorService extends SupportsCopy,
+                                           SupportsDelete,
+                                           SupportsRead<String>,
+                                           SupportsSaveAndRename<String, DefaultMetadata> {
+
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/support/SupportsSaveAndRename.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/service/support/SupportsSaveAndRename.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.service.support;
+
+import org.uberfire.backend.vfs.Path;
+
+public interface SupportsSaveAndRename<T, M> extends SupportsRename,
+                                                     SupportsUpdate<T, M> {
+
+    Path saveAndRename(final Path path,
+                       final String newFileName,
+                       final M metadata,
+                       final T content,
+                       final String comment);
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/resources/org/uberfire/ext/editor/commons/UberfireCommonsEditorAPI.gwt.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/resources/org/uberfire/ext/editor/commons/UberfireCommonsEditorAPI.gwt.xml
@@ -22,7 +22,7 @@
   <inherits name="org.uberfire.UberfireAPI"/>
   <inherits name="org.uberfire.java.nio.UberfireNIO2Model"/>
 
-  <source path='file/exports'/>
+  <source path='file'/>
   <source path='readonly'/>
   <source path='version'/>
   <source path='service'/>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/SaveAndRenameServiceImpl.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/SaveAndRenameServiceImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service;
+
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+public class SaveAndRenameServiceImpl<T, M> implements SupportsSaveAndRename<T, M> {
+
+    private SupportsSaveAndRename<T, M> updateService;
+
+    public void init(final SupportsSaveAndRename<T, M> updateService) {
+        this.updateService = updateService;
+    }
+
+    @Override
+    public Path rename(final Path path,
+                       final String newFileName,
+                       final String comment) {
+        return updateService.rename(path, newFileName, comment);
+    }
+
+    @Override
+    public Path save(final Path path,
+                     final T content,
+                     final M metadata,
+                     final String comment) {
+        return updateService.save(path, content, metadata, comment);
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final M metadata,
+                              final T content,
+                              final String comment) {
+
+        final Path savedPath = save(path, content, metadata, comment);
+        final Path renamedPath = rename(savedPath, newFileName, comment);
+
+        return renamedPath;
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/htmleditor/HtmlEditorServiceImpl.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/service/htmleditor/HtmlEditorServiceImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service.htmleditor;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.VFSService;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
+import org.uberfire.ext.editor.commons.service.CopyService;
+import org.uberfire.ext.editor.commons.service.DeleteService;
+import org.uberfire.ext.editor.commons.service.RenameService;
+import org.uberfire.ext.editor.commons.service.htmleditor.HtmlEditorService;
+
+public class HtmlEditorServiceImpl implements HtmlEditorService {
+
+    private VFSService vfsServices;
+
+    private DeleteService deleteService;
+
+    private RenameService renameService;
+
+    private CopyService copyService;
+
+    private SaveAndRenameServiceImpl<String, DefaultMetadata> saveAndRenameService;
+
+    @Inject
+    public HtmlEditorServiceImpl(final VFSService vfsServices,
+                                 final DeleteService deleteService,
+                                 final RenameService renameService,
+                                 final CopyService copyService,
+                                 final SaveAndRenameServiceImpl<String, DefaultMetadata> saveAndRenameService) {
+        this.vfsServices = vfsServices;
+        this.deleteService = deleteService;
+        this.renameService = renameService;
+        this.copyService = copyService;
+        this.saveAndRenameService = saveAndRenameService;
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
+    }
+
+    @Override
+    public void delete(final Path path,
+                       final String comment) {
+        deleteService.delete(path, comment);
+    }
+
+    @Override
+    public Path rename(final Path path,
+                       final String newName,
+                       final String comment) {
+        return renameService.rename(path, newName, comment);
+    }
+
+    @Override
+    public Path save(final Path path,
+                     final String content,
+                     final DefaultMetadata _metadata,
+                     final String _comment) {
+        return vfsServices.write(path, content);
+    }
+
+    @Override
+    public Path copy(final Path path,
+                     final String newName,
+                     final String comment) {
+        return copyService.copy(path, newName, comment);
+    }
+
+    @Override
+    public Path copy(final Path path,
+                     final String newName,
+                     final Path targetDirectory,
+                     final String comment) {
+        return copyService.copy(path, newName, targetDirectory, comment);
+    }
+
+    @Override
+    public String load(final Path path) {
+        return vfsServices.readAllString(path);
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final DefaultMetadata metadata,
+                              final String content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/SaveAndRenameServiceImplTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/SaveAndRenameServiceImplTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SaveAndRenameServiceImplTest {
+
+    @Mock
+    private SupportsSaveAndRename<String, DefaultMetadata> supportsSaveAndRename;
+
+    private SaveAndRenameServiceImpl<String, DefaultMetadata> service;
+
+    @Before
+    public void setup() throws Exception {
+        service = spy(new SaveAndRenameServiceImpl<String, DefaultMetadata>() {{
+            init(supportsSaveAndRename);
+        }});
+    }
+
+    @Test
+    public void testRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final String comment = "comment";
+
+        service.rename(path, newFileName, comment);
+
+        verify(supportsSaveAndRename).rename(path, newFileName, comment);
+    }
+
+    @Test
+    public void testSave() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String content = "content";
+        final DefaultMetadata metadata = mock(DefaultMetadata.class);
+        final String comment = "comment";
+
+        service.save(path, content, metadata, comment);
+
+        verify(supportsSaveAndRename).save(path, content, metadata, comment);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path path = mock(Path.class);
+        final String newFileName = "newFileName";
+        final DefaultMetadata metadata = mock(DefaultMetadata.class);
+        final String content = "content";
+        final String comment = "comment";
+
+        doReturn(path).when(service).save(path, content, metadata, comment);
+
+        service.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(service).save(path, content, metadata, comment);
+        verify(service).rename(path, newFileName, comment);
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/htmleditor/HtmlEditorServiceImplTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/service/htmleditor/HtmlEditorServiceImplTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.backend.service.htmleditor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.VFSService;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
+import org.uberfire.ext.editor.commons.service.CopyService;
+import org.uberfire.ext.editor.commons.service.DeleteService;
+import org.uberfire.ext.editor.commons.service.RenameService;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HtmlEditorServiceImplTest {
+
+    @Mock
+    private VFSService vfsServices;
+
+    @Mock
+    private DeleteService deleteService;
+
+    @Mock
+    private RenameService renameService;
+
+    @Mock
+    private CopyService copyService;
+
+    @Mock
+    private SaveAndRenameServiceImpl<String, DefaultMetadata> saveAndRenameService;
+
+    @Mock
+    private Path path;
+
+    @Mock
+    private DefaultMetadata metadata;
+
+    private String content = "content";
+
+    private String comment = "comment";
+
+    private String newFileName = "newFileName";
+
+    @Spy
+    @InjectMocks
+    private HtmlEditorServiceImpl htmlEditorService;
+
+    @Test
+    public void testInit() throws Exception {
+
+        htmlEditorService.init();
+
+        verify(saveAndRenameService).init(htmlEditorService);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+
+        htmlEditorService.delete(path, comment);
+
+        verify(deleteService).delete(path, comment);
+    }
+
+    @Test
+    public void testRename() throws Exception {
+
+        final Path expectedPath = mock(Path.class);
+        doReturn(expectedPath).when(renameService).rename(path, newFileName, comment);
+
+        final Path actualPath = htmlEditorService.rename(path, newFileName, comment);
+
+        verify(renameService).rename(path, newFileName, comment);
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void testSave() throws Exception {
+
+        final Path expectedPath = mock(Path.class);
+        doReturn(expectedPath).when(vfsServices).write(path, content);
+
+        final Path actualPath = htmlEditorService.save(path, content, metadata, comment);
+
+        verify(vfsServices).write(path, content);
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void testCopyWithoutTargetDirectory() throws Exception {
+
+        final Path expectedPath = mock(Path.class);
+        doReturn(expectedPath).when(copyService).copy(path, newFileName, comment);
+
+        final Path actualPath = htmlEditorService.copy(path, newFileName, comment);
+
+        verify(copyService).copy(path, newFileName, comment);
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void testCopyWithTargetDirectory() throws Exception {
+
+        final Path targetDirectory = mock(Path.class);
+        final Path expectedPath = mock(Path.class);
+
+        doReturn(expectedPath).when(copyService).copy(path, newFileName, targetDirectory, comment);
+
+        final Path actualPath = htmlEditorService.copy(path, newFileName, targetDirectory, comment);
+
+        verify(copyService).copy(path, newFileName, targetDirectory, comment);
+        assertEquals(expectedPath, actualPath);
+    }
+
+    @Test
+    public void testLoad() throws Exception {
+
+        final String expectedString = "string";
+
+        doReturn(expectedString).when(vfsServices).readAllString(path);
+
+        final String actualString = htmlEditorService.load(path);
+
+        verify(vfsServices).readAllString(path);
+        assertEquals(expectedString, actualString);
+    }
+
+    @Test
+    public void testSaveAndRename() throws Exception {
+
+        final Path expectedPath = mock(Path.class);
+        doReturn(expectedPath).when(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
+
+        final Path actualPath = htmlEditorService.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
+        assertEquals(expectedPath, actualPath);
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/CommonModalBuilder.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/CommonModalBuilder.java
@@ -22,6 +22,7 @@ import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.jboss.errai.ui.shared.TemplateUtil;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 
 public class CommonModalBuilder {
@@ -43,6 +44,13 @@ public class CommonModalBuilder {
         return this;
     }
 
+    public CommonModalBuilder addBody(final elemental2.dom.HTMLElement htmlElement) {
+
+        final FlowPanel flowPanel = buildPanel(htmlElement, makeModalBody());
+        getModal().add(flowPanel);
+        return this;
+    }
+
     public CommonModalBuilder addFooter(ModalFooter footer) {
         modal.add(footer);
         return this;
@@ -54,13 +62,42 @@ public class CommonModalBuilder {
         return this;
     }
 
+    public CommonModalBuilder addFooter(final elemental2.dom.HTMLElement htmlElement) {
+
+        final FlowPanel flowPanel = buildPanel(htmlElement, makeModalFooter());
+        getModal().add(flowPanel);
+        return this;
+    }
+
     public BaseModal build() {
+        return getModal();
+    }
+
+    BaseModal getModal() {
         return modal;
     }
 
-    private FlowPanel buildPanel(HTMLElement element,
-                                 FlowPanel panel) {
-        panel.add(build(element));
+    ModalBody makeModalBody() {
+        return new ModalBody();
+    }
+
+    ModalFooter makeModalFooter() {
+        return new ModalFooter();
+    }
+
+    FlowPanel buildPanel(final elemental2.dom.HTMLElement element,
+                         final FlowPanel panel) {
+
+        final HTMLElement htmlElement = TemplateUtil.asErraiElement(element);
+        panel.add(build(htmlElement));
+        return panel;
+    }
+
+    private FlowPanel buildPanel(final HTMLElement element,
+                                 final FlowPanel panel) {
+
+        final HTMLElement htmlElement = TemplateUtil.asErraiElement(element);
+        panel.add(build(htmlElement));
         return panel;
     }
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RenamePopUpPresenter.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RenamePopUpPresenter.java
@@ -21,13 +21,12 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.uberfire.backend.vfs.Path;
-import org.uberfire.client.mvp.UberElement;
+import org.uberfire.client.mvp.UberElemental;
 import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
 import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
 import org.uberfire.ext.editor.commons.client.file.popups.commons.ToggleCommentPresenter;
 import org.uberfire.ext.editor.commons.client.validation.ValidationErrorReason;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
-import org.uberfire.ext.editor.commons.client.validation.ValidatorCallback;
 import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
@@ -35,60 +34,95 @@ import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull
 @Dependent
 public class RenamePopUpPresenter {
 
-    private String originalFileName;
+    private static final boolean DEFAULT_DIRTY_STATUS = false;
+
+    private static final String DEFAULT_FILE_NAME = "";
+
+    private static final CommandWithFileNameAndCommitMessage DEFAULT_COMMAND = (c) -> {
+    };
+
+    private final View view;
+
+    private final ToggleCommentPresenter toggleCommentPresenter;
+
     private Path path;
+
     private Validator validator;
-    private CommandWithFileNameAndCommitMessage command;
-    private ToggleCommentPresenter toggleCommentPresenter;
-    private View view;
+
+    private CommandWithFileNameAndCommitMessage renameCommand;
+
+    private CommandWithFileNameAndCommitMessage saveAndRenameCommand;
+
+    private String originalFileName;
+
+    private boolean isDirty;
 
     @Inject
-    public RenamePopUpPresenter(View view,
-                                ToggleCommentPresenter toggleCommentPresenter) {
+    public RenamePopUpPresenter(final View view,
+                                final ToggleCommentPresenter toggleCommentPresenter) {
         this.view = view;
         this.toggleCommentPresenter = toggleCommentPresenter;
     }
 
     public void show(final Path path,
                      final Validator validator,
-                     final CommandWithFileNameAndCommitMessage command,
+                     final CommandWithFileNameAndCommitMessage renameCommand,
+                     final CommandWithFileNameAndCommitMessage saveAndRenameCommand,
+                     final boolean isDirty,
                      final String originalFileName) {
-        this.validator = checkNotNull("validator",
-                                      validator);
-        this.path = checkNotNull("path",
-                                 path);
-        this.command = checkNotNull("command",
-                                    command);
-        this.originalFileName = originalFileName;
 
-        view.setOriginalFileName(originalFileName);
+        this.validator = checkNotNull("validator", validator);
+        this.path = checkNotNull("path", path);
+        this.renameCommand = checkNotNull("renameCommand", renameCommand);
+        this.saveAndRenameCommand = checkNotNull("saveAndRenameCommand", saveAndRenameCommand);
+        this.originalFileName = checkNotNull("originalFileName", originalFileName);
+        this.isDirty = checkNotNull("isDirty", isDirty);
+
+        setupView();
+        showView();
+    }
+
+    void setupView() {
+        enablePrimaryButton();
+        hideSaveAndRenameIfAssetIsNotDirty();
+    }
+
+    void showView() {
+        view.setOriginalFileName(getOriginalFileName());
         view.show();
     }
 
     public void show(final Path path,
-                     final CommandWithFileNameAndCommitMessage copyPopupCommand,
+                     final CommandWithFileNameAndCommitMessage renameCommand,
                      final String originalFileName) {
-        show(path,
-             defaultValidator(),
-             copyPopupCommand,
-             originalFileName);
+
+        final Validator validator = defaultValidator();
+
+        show(path, validator, renameCommand, DEFAULT_COMMAND, DEFAULT_DIRTY_STATUS, originalFileName);
     }
 
     public void show(final Path path,
                      final Validator validator,
-                     final CommandWithFileNameAndCommitMessage command) {
-        show(path,
-             validator,
-             command,
-             "");
+                     final CommandWithFileNameAndCommitMessage renameCommand) {
+
+        show(path, validator, renameCommand, DEFAULT_COMMAND, DEFAULT_DIRTY_STATUS, DEFAULT_FILE_NAME);
     }
 
     public void show(final Path path,
-                     final CommandWithFileNameAndCommitMessage renamePopupCommand) {
-        show(path,
-             defaultValidator(),
-             renamePopupCommand,
-             "");
+                     final Validator validator,
+                     final boolean isDirty,
+                     final CommandWithFileNameAndCommitMessage renameCommand,
+                     final CommandWithFileNameAndCommitMessage saveAndRenameCommand) {
+
+        show(path, validator, renameCommand, saveAndRenameCommand, isDirty, DEFAULT_FILE_NAME);
+    }
+
+    public void show(final Path path,
+                     final CommandWithFileNameAndCommitMessage renameCommand) {
+
+        final Validator validator = defaultValidator();
+
+        show(path, validator, renameCommand, DEFAULT_COMMAND, DEFAULT_DIRTY_STATUS, DEFAULT_FILE_NAME);
     }
 
     @PostConstruct
@@ -97,12 +131,28 @@ public class RenamePopUpPresenter {
     }
 
     public void rename(final String newName) {
-        final String extension = extension(path.getFileName());
-        final String fileName = newName + extension;
 
-        validator.validate(fileName,
-                           validatorCallback(toggleCommentPresenter.getComment(),
-                                             newName));
+        final String fileName = newFileName(newName);
+        final String comment = toggleCommentPresenter.getComment();
+        final ValidatorWithReasonCallback callback = validatorCallback(comment, newName, renameCommand);
+
+        validator.validate(fileName, callback);
+    }
+
+    public void saveAndRename(final String newName) {
+
+        final String fileName = newFileName(newName);
+        final String comment = toggleCommentPresenter.getComment();
+        final ValidatorWithReasonCallback callback = validatorCallback(comment, newName, saveAndRenameCommand);
+
+        validator.validate(fileName, callback);
+    }
+
+    private String newFileName(final String newName) {
+
+        final String extension = extension(path.getFileName());
+
+        return newName + extension;
     }
 
     private String extension(final String fileName) {
@@ -110,8 +160,11 @@ public class RenamePopUpPresenter {
     }
 
     private ValidatorWithReasonCallback validatorCallback(final String comment,
-                                                          final String baseFileName) {
+                                                          final String baseFileName,
+                                                          final CommandWithFileNameAndCommitMessage onSuccess) {
+
         return new ValidatorWithReasonCallback() {
+
             @Override
             public void onFailure(final String reason) {
                 if (ValidationErrorReason.DUPLICATED_NAME.name().equals(reason)) {
@@ -123,17 +176,18 @@ public class RenamePopUpPresenter {
                 }
             }
 
-            @Override
             public void onSuccess() {
-                command.execute(new FileNameAndCommitMessage(baseFileName,
-                                                             comment));
+                onSuccess.execute(new FileNameAndCommitMessage(baseFileName, comment));
             }
 
-            @Override
             public void onFailure() {
                 view.handleInvalidFileName();
             }
         };
+    }
+
+    boolean isDirty() {
+        return isDirty;
     }
 
     public void cancel() {
@@ -149,13 +203,7 @@ public class RenamePopUpPresenter {
     }
 
     private Validator defaultValidator() {
-        return new Validator() {
-            @Override
-            public void validate(final String value,
-                                 final ValidatorCallback callback) {
-                callback.onSuccess();
-            }
-        };
+        return (value, callback) -> callback.onSuccess();
     }
 
     Path getPath() {
@@ -166,11 +214,27 @@ public class RenamePopUpPresenter {
         return validator;
     }
 
-    CommandWithFileNameAndCommitMessage getCommand() {
-        return command;
+    CommandWithFileNameAndCommitMessage getRenameCommand() {
+        return renameCommand;
     }
 
-    public interface View extends UberElement<RenamePopUpPresenter> {
+    String getOriginalFileName() {
+        return originalFileName;
+    }
+
+    void hideSaveAndRenameIfAssetIsNotDirty() {
+        view.hideSaveAndRename(!isDirty());
+    }
+
+    void enablePrimaryButton() {
+        if (isDirty()) {
+            view.saveAndRenameAsPrimary();
+        } else {
+            view.renameAsPrimary();
+        }
+    }
+
+    public interface View extends UberElemental<RenamePopUpPresenter> {
 
         void show();
 
@@ -180,8 +244,14 @@ public class RenamePopUpPresenter {
 
         void handleInvalidFileName();
 
-        void setOriginalFileName(String fileName);
+        void setOriginalFileName(final String fileName);
 
         void handleRenameNotAllowed();
+
+        void renameAsPrimary();
+
+        void saveAndRenameAsPrimary();
+
+        void hideSaveAndRename(final boolean hidden);
     }
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RenamePopUpView.html
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RenamePopUpView.html
@@ -13,16 +13,25 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
+<div>
+    <div data-field="modal-view">
+        <div data-field="modal-body">
+            <div data-field="error" class="alert alert-danger alert-dismissable">
+                <span class="pficon pficon-error-circle-o"></span>
+                <span data-field="errorMessage"></span>
+            </div>
+            <div>
+                <label class="col-sm-3 form-control-label" data-i18n-key="AssetName"></label>
+                <div class="col-sm-9">
+                    <input type="text" class="form-control" data-field="newNameTextBox"/>
+                </div>
+            </div>
+        </div>
 
-<div data-field="body">
-    <div data-field="error" class="alert alert-danger alert-dismissable">
-        <span class="pficon pficon-error-circle-o"></span>
-        <span data-field="errorMessage"></span>
-    </div>
-    <div>
-        <label class="col-sm-3 form-control-label" data-i18n-key="AssetName"></label>
-        <div class="col-sm-9">
-            <input type="text" class="form-control" data-field="newNameTextBox"/>
+        <div data-field="modal-footer">
+            <button class="kie-btn btn btn-default" data-field="cancel" data-i18n-key="Cancel"></button>
+            <button class="kie-btn btn btn-default" data-field="rename" data-i18n-key="Rename"></button>
+            <button class="kie-btn btn btn-default" data-field="saveAndRename" data-i18n-key="SaveAndRename"></button>
         </div>
     </div>
 </div>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RenamePopUpView.less
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RenamePopUpView.less
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.modal-dialog {
+  .kie-btn[hidden] {
+    display: none;
+  }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/commons/ToggleCommentPresenter.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/commons/ToggleCommentPresenter.java
@@ -21,7 +21,8 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.Element;
-import org.uberfire.client.mvp.UberElement;
+import org.jboss.errai.ui.shared.TemplateUtil;
+import org.uberfire.client.mvp.UberElemental;
 
 @Dependent
 public class ToggleCommentPresenter {
@@ -29,7 +30,7 @@ public class ToggleCommentPresenter {
     private View view;
 
     @Inject
-    public ToggleCommentPresenter(View view) {
+    public ToggleCommentPresenter(final View view) {
         this.view = view;
     }
 
@@ -38,8 +39,13 @@ public class ToggleCommentPresenter {
         view.init(this);
     }
 
+    @Deprecated
     public Element getViewElement() {
-        return view.getElement();
+        return TemplateUtil.asErraiElement(view.getElement());
+    }
+
+    public View getView() {
+        return view;
     }
 
     public String getComment() {
@@ -47,10 +53,10 @@ public class ToggleCommentPresenter {
     }
 
     public void setHidden(final boolean hidden) {
-        view.getElement().setHidden(hidden);
+        view.getElement().hidden = hidden;
     }
 
-    public interface View extends UberElement<ToggleCommentPresenter> {
+    public interface View extends UberElemental<ToggleCommentPresenter> {
 
         String getComment();
     }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/commons/ToggleCommentView.html
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/commons/ToggleCommentView.html
@@ -13,7 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<div class="col-sm-12">
+<div data-field="view" class="col-sm-12">
     <form>
         <div class="form-group">
             <a href="#" data-field="addComment" data-i18n-key="AddAComment"></a>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/commons/ToggleCommentView.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/commons/ToggleCommentView.java
@@ -21,9 +21,10 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import com.google.gwt.event.dom.client.ClickEvent;
-import org.gwtbootstrap3.client.ui.Anchor;
+import elemental2.dom.HTMLAnchorElement;
+import elemental2.dom.HTMLDivElement;
+import elemental2.dom.HTMLElement;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
@@ -32,21 +33,31 @@ import org.uberfire.ext.editor.commons.client.resources.i18n.Constants;
 
 @Dependent
 @Templated
-public class ToggleCommentView implements ToggleCommentPresenter.View,
-                                          IsElement {
+public class ToggleCommentView implements ToggleCommentPresenter.View {
 
-    @Inject
+    @DataField("view")
+    private HTMLDivElement view;
+
     @DataField("addComment")
-    Anchor addComment;
+    private HTMLAnchorElement addComment;
 
-    @Inject
     @DataField("commentTextBox")
-    TextBox commentTextBox;
+    private TextBox commentTextBox;
 
-    @Inject
     private TranslationService translationService;
 
     private ToggleCommentPresenter presenter;
+
+    @Inject
+    public ToggleCommentView(final HTMLDivElement view,
+                             final HTMLAnchorElement addComment,
+                             final TextBox commentTextBox,
+                             final TranslationService translationService) {
+        this.view = view;
+        this.addComment = addComment;
+        this.commentTextBox = commentTextBox;
+        this.translationService = translationService;
+    }
 
     @Override
     public void init(final ToggleCommentPresenter presenter) {
@@ -73,5 +84,10 @@ public class ToggleCommentView implements ToggleCommentPresenter.View,
 
     private void toggleCommentTextBox() {
         commentTextBox.setVisible(!commentTextBox.isVisible());
+    }
+
+    @Override
+    public HTMLElement getElement() {
+        return view;
     }
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.menu.common;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.bus.client.api.messaging.Message;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
+import org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants;
+import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
+import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+
+@Dependent
+public class SaveAndRenameCommandBuilder<T, M> {
+
+    private final RenamePopUpPresenter renamePopUpPresenter;
+    private final BusyIndicatorView busyIndicatorView;
+    private final Event<NotificationEvent> notification;
+
+    private Supplier<Path> pathSupplier;
+    private Validator renameValidator;
+    private Caller<? extends SupportsSaveAndRename<T, M>> renameCaller;
+
+    private Supplier<M> metadataSupplier = () -> null;
+    private Supplier<T> contentSupplier = () -> null;
+    private Supplier<Boolean> isDirtySupplier = () -> Boolean.FALSE;
+    private Supplier<Boolean> saveValidator = () -> Boolean.TRUE;
+    private ParameterizedCommand<Path> onSuccess = (path) -> {
+    };
+    private Command onError = () -> {
+    };
+
+    @Inject
+    public SaveAndRenameCommandBuilder(final RenamePopUpPresenter renamePopUpPresenter,
+                                       final BusyIndicatorView busyIndicatorView,
+                                       final Event<NotificationEvent> notification) {
+
+        this.renamePopUpPresenter = renamePopUpPresenter;
+        this.busyIndicatorView = busyIndicatorView;
+        this.notification = notification;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addValidator(final Validator validator) {
+        this.renameValidator = validator;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addValidator(final Supplier<Boolean> validator) {
+        this.saveValidator = validator;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addRenameService(final Caller<? extends SupportsSaveAndRename<T, M>> renameCaller) {
+        this.renameCaller = renameCaller;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addPathSupplier(final Supplier<Path> pathSupplier) {
+        this.pathSupplier = pathSupplier;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addMetadataSupplier(final Supplier<M> metadataSupplier) {
+        this.metadataSupplier = metadataSupplier;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addContentSupplier(final Supplier<T> contentSupplier) {
+        this.contentSupplier = contentSupplier;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addIsDirtySupplier(final Supplier<Boolean> isDirtySupplier) {
+        this.isDirtySupplier = isDirtySupplier;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addSuccessCallback(final ParameterizedCommand<Path> onSuccess) {
+        this.onSuccess = onSuccess;
+        return this;
+    }
+
+    public SaveAndRenameCommandBuilder<T, M> addErrorCallback(final Command onError) {
+        this.onError = onError;
+        return this;
+    }
+
+    public Command build() {
+
+        checkNotNull("pathSupplier", pathSupplier);
+        checkNotNull("renameValidator", renameValidator);
+        checkNotNull("renameCaller", renameCaller);
+
+        return () -> {
+
+            final CommandWithFileNameAndCommitMessage renameCommand = makeRenameCommand();
+            final CommandWithFileNameAndCommitMessage saveAndRenameCommand = makeSaveAndRenameCommand();
+            final Boolean isValid = saveValidator.get();
+
+            if (!isValid) {
+                return;
+            }
+
+            renamePopUpPresenter.show(getPath(), renameValidator, isDirty(), renameCommand, saveAndRenameCommand);
+        };
+    }
+
+    CommandWithFileNameAndCommitMessage makeSaveAndRenameCommand() {
+        return (details) -> {
+
+            showBusyIndicator();
+            callSaveAndRename(details);
+        };
+    }
+
+    CommandWithFileNameAndCommitMessage makeRenameCommand() {
+        return (details) -> {
+
+            showBusyIndicator();
+            callRename(details);
+        };
+    }
+
+    void callSaveAndRename(final FileNameAndCommitMessage details) {
+
+        final String newFileName = details.getNewFileName();
+        final String commitMessage = details.getCommitMessage();
+
+        renameCaller.call(onSuccess(), onError()).saveAndRename(getPath(),
+                                                                newFileName,
+                                                                getMetadata(),
+                                                                getContent(),
+                                                                commitMessage);
+    }
+
+    void callRename(final FileNameAndCommitMessage details) {
+
+        final String newFileName = details.getNewFileName();
+        final String commitMessage = details.getCommitMessage();
+
+        renameCaller.call(onSuccess(), onError()).rename(getPath(),
+                                                         newFileName,
+                                                         commitMessage);
+    }
+
+    RemoteCallback<Path> onSuccess() {
+        return (Path path) -> {
+            onSuccess.execute(path);
+            hideRenamePopup();
+            hideBusyIndicator();
+            notifyItemRenamedSuccessfully();
+        };
+    }
+
+    SaveAndRenameErrorCallback onError() {
+        return new SaveAndRenameErrorCallback(busyIndicatorView);
+    }
+
+    void notifyItemRenamedSuccessfully() {
+        notification.fire(makeItemRenamedSuccessfullyEvent());
+    }
+
+    NotificationEvent makeItemRenamedSuccessfullyEvent() {
+        return new NotificationEvent(CommonConstants.INSTANCE.ItemRenamedSuccessfully());
+    }
+
+    void hideRenamePopup() {
+        renamePopUpView().hide();
+    }
+
+    void hideBusyIndicator() {
+        busyIndicatorView.hideBusyIndicator();
+    }
+
+    void showBusyIndicator() {
+        busyIndicatorView.showBusyIndicator(CommonConstants.INSTANCE.Renaming());
+    }
+
+    private RenamePopUpPresenter.View renamePopUpView() {
+        return renamePopUpPresenter.getView();
+    }
+
+    void handleDuplicatedFileName() {
+        renamePopUpView().handleDuplicatedFileName();
+    }
+
+    private boolean fileAlreadyExists(final Throwable throwable) {
+        return throwable != null && throwable.getMessage() != null && throwable.getMessage().contains("FileAlreadyExistsException");
+    }
+
+    private Path getPath() {
+        return pathSupplier.get();
+    }
+
+    private Boolean isDirty() {
+        return isDirtySupplier.get();
+    }
+
+    private M getMetadata() {
+        return metadataSupplier.get();
+    }
+
+    private T getContent() {
+        return contentSupplier.get();
+    }
+
+    class SaveAndRenameErrorCallback extends HasBusyIndicatorDefaultErrorCallback {
+
+        public SaveAndRenameErrorCallback(final HasBusyIndicator view) {
+            super(view);
+        }
+
+        @Override
+        public boolean error(final Message message,
+                             final Throwable throwable) {
+
+            if (fileAlreadyExists(throwable)) {
+                hideBusyIndicator();
+                handleDuplicatedFileName();
+
+                return false;
+            }
+
+            onError.execute();
+            hideRenamePopup();
+
+            return callSuper(message, throwable);
+        }
+
+        boolean callSuper(final Message message,
+                          final Throwable throwable) {
+            return super.error(message, throwable);
+        }
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/resources/i18n/Constants.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/resources/i18n/Constants.java
@@ -78,6 +78,9 @@ public class Constants {
     public static final String RenamePopUpView_Rename = "RenamePopUpView.Rename";
 
     @TranslationKey(defaultValue = "")
+    public static final String RenamePopUpView_SaveAndRename = "RenamePopUpView.SaveAndRename";
+
+    @TranslationKey(defaultValue = "")
     public static final String RenamePopUpView_Cancel = "RenamePopUpView.Cancel";
 
     @TranslationKey(defaultValue = "")

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/resources/org/uberfire/ext/editor/commons/client/resources/i18n/Constants.properties
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/resources/org/uberfire/ext/editor/commons/client/resources/i18n/Constants.properties
@@ -36,6 +36,7 @@ CopyPopUpView.CopyNotAllowed=You don't have permission to copy this file.
 RenamePopUpView.RenameAsset=Rename Asset
 RenamePopUpView.AssetName=Asset Name
 RenamePopUpView.Rename=Rename
+RenamePopUpView.SaveAndRename=Save and Rename
 RenamePopUpView.Cancel=Cancel
 RenamePopUpView.InvalidFileName=Resource name "{0}" is invalid.
 RenamePopUpView.FileAlreadyExists=File "{0}" already exists.

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorRenameTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorRenameTest.java
@@ -17,6 +17,7 @@
 package org.uberfire.ext.editor.commons.client;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +31,9 @@ import org.uberfire.ext.editor.commons.client.history.VersionMenuDropDownButton;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
 import org.uberfire.ext.editor.commons.client.menu.MenuItems;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
+import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.editor.commons.version.VersionService;
 import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
@@ -78,6 +82,21 @@ public class BaseEditorRenameTest {
                                     changeTitleNotification) {
             @Override
             protected void loadContent() {
+            }
+
+            @Override
+            protected SaveAndRenameCommandBuilder getSaveAndRenameCommandBuilder() {
+                return new SaveAndRenameCommandBuilder<>(null, null, null);
+            }
+
+            @Override
+            public Validator getRenameValidator() {
+                return mock(Validator.class);
+            }
+
+            @Override
+            protected Caller<? extends SupportsSaveAndRename> getSaveAndRenameServiceCaller() {
+                return mock(Caller.class);
             }
         };
         when(restoreUtil.createObservablePath(any(),

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.function.Supplier;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
+import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+import org.uberfire.workbench.model.menu.MenuItem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.uberfire.ext.editor.commons.client.menu.MenuItems.COPY;
+import static org.uberfire.ext.editor.commons.client.menu.MenuItems.DELETE;
+import static org.uberfire.ext.editor.commons.client.menu.MenuItems.HISTORY;
+import static org.uberfire.ext.editor.commons.client.menu.MenuItems.RENAME;
+import static org.uberfire.ext.editor.commons.client.menu.MenuItems.SAVE;
+import static org.uberfire.ext.editor.commons.client.menu.MenuItems.VALIDATE;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class BaseEditorTest {
+
+    private String fakeContent = "fakeContent";
+
+    @Mock
+    private VersionRecordManager versionRecordManager;
+
+    @Mock
+    private BaseEditorView baseView;
+
+    @Mock
+    private BasicFileMenuBuilder menuBuilder;
+
+    private SaveAndRenameCommandBuilder<String, DefaultMetadata> builder = spy(makeBuilder());
+
+    @InjectMocks
+    private BaseEditor<String, DefaultMetadata> editor = spy(makeBaseEditor());
+
+    @Test
+    public void testSaveAndRename() {
+
+        final Supplier pathSupplier = mock(Supplier.class);
+        final Validator renameValidator = mock(Validator.class);
+        final Supplier saveValidator = mock(Supplier.class);
+        final Caller supportsSaveAndRename = mock(Caller.class);
+        final Supplier metadataSupplier = mock(Supplier.class);
+        final Supplier contentSupplier = mock(Supplier.class);
+        final Supplier isDirtySupplier = mock(Supplier.class);
+        final ParameterizedCommand parameterizedCommand = mock(ParameterizedCommand.class);
+        final Command command = mock(Command.class);
+
+        doReturn(pathSupplier).when(editor).getPathSupplier();
+        doReturn(renameValidator).when(editor).getRenameValidator();
+        doReturn(saveValidator).when(editor).getSaveValidator();
+        doReturn(supportsSaveAndRename).when(editor).getSaveAndRenameServiceCaller();
+        doReturn(metadataSupplier).when(editor).getMetadataSupplier();
+        doReturn(contentSupplier).when(editor).getContentSupplier();
+        doReturn(isDirtySupplier).when(editor).isDirtySupplier();
+        doReturn(parameterizedCommand).when(editor).onSuccess();
+        doReturn(command).when(builder).build();
+
+        final Command saveAndRenameCommand = editor.getSaveAndRename();
+
+        assertEquals(command, saveAndRenameCommand);
+
+        verify(builder).addPathSupplier(pathSupplier);
+        verify(builder).addValidator(renameValidator);
+        verify(builder).addValidator(saveValidator);
+        verify(builder).addRenameService(supportsSaveAndRename);
+        verify(builder).addMetadataSupplier(metadataSupplier);
+        verify(builder).addContentSupplier(contentSupplier);
+        verify(builder).addIsDirtySupplier(isDirtySupplier);
+        verify(builder).addSuccessCallback(parameterizedCommand);
+    }
+
+    @Test
+    public void testGetPathSupplier() {
+
+        final ObservablePath observablePath = mock(ObservablePath.class);
+
+        doReturn(observablePath).when(versionRecordManager).getPathToLatest();
+
+        final Supplier<Path> pathSupplier = editor.getPathSupplier();
+
+        assertEquals(observablePath, pathSupplier.get());
+    }
+
+    @Test
+    public void testGetContentSupplier() {
+
+        final Supplier<String> contentSupplier = editor.getContentSupplier();
+        final String content = contentSupplier.get();
+
+        assertEquals(fakeContent, content);
+    }
+
+    @Test
+    public void testGetMetadataSupplier() {
+        assertNull(editor.getMetadataSupplier().get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() {
+        assertNull(editor.getSaveAndRenameServiceCaller());
+    }
+
+    @Test
+    public void testIsContentDirtyWhenEditorIsDirty() {
+
+        doReturn(true).when(editor).isDirty(fakeContent.hashCode());
+
+        assertTrue(editor.isContentDirty());
+    }
+
+    @Test
+    public void testIsContentDirtyWhenEditorIsNotDirty() {
+
+        doReturn(false).when(editor).isDirty(fakeContent.hashCode());
+
+        assertFalse(editor.isContentDirty());
+    }
+
+    @Test
+    public void testIsContentDirtyWhenGetContentRaisesAnException() {
+
+        doReturn(null).when(editor).getContentSupplier();
+
+        assertFalse(editor.isContentDirty());
+    }
+
+    @Test
+    public void testIsMetadataDirtyWhenMetadataIsDirty() {
+
+        final DefaultMetadata metadata = fakeMetadata(123);
+        final Supplier<DefaultMetadata> metadataSupplier = () -> metadata;
+
+        doReturn(metadataSupplier).when(editor).getMetadataSupplier();
+
+        editor.metadataOriginalHash = 456;
+
+        assertTrue(editor.isMetadataDirty());
+    }
+
+    @Test
+    public void testIsMetadataDirtyWhenMetadataIsNotDirty() {
+
+        final DefaultMetadata metadata = fakeMetadata(123);
+        final Supplier<DefaultMetadata> metadataSupplier = () -> metadata;
+
+        doReturn(metadataSupplier).when(editor).getMetadataSupplier();
+
+        editor.metadataOriginalHash = 123;
+
+        assertFalse(editor.isMetadataDirty());
+    }
+
+    @Test
+    public void testIsMetadataDirtyWhenMetadataIsNull() {
+        assertFalse(editor.isMetadataDirty());
+    }
+
+    @Test
+    public void testIsDirtySupplierWhenContentIsDirty() {
+
+        doReturn(true).when(editor).isContentDirty();
+        doReturn(false).when(editor).isMetadataDirty();
+
+        assertTrue(editor.isDirtySupplier().get());
+    }
+
+    @Test
+    public void testIsDirtySupplierWhenMetadataIsDirty() {
+
+        doReturn(false).when(editor).isContentDirty();
+        doReturn(true).when(editor).isMetadataDirty();
+
+        assertTrue(editor.isDirtySupplier().get());
+    }
+
+    @Test
+    public void testIsDirtySupplierWhenContentAndMetdataAreDirty() {
+
+        doReturn(true).when(editor).isContentDirty();
+        doReturn(true).when(editor).isMetadataDirty();
+
+        assertTrue(editor.isDirtySupplier().get());
+    }
+
+    @Test
+    public void testIsDirtySupplierWhenContentAndMetdataAreNotDirty() {
+
+        doReturn(false).when(editor).isContentDirty();
+        doReturn(false).when(editor).isMetadataDirty();
+
+        assertFalse(editor.isDirtySupplier().get());
+    }
+
+    @Test
+    public void testGetSaveValidatorWhenItIsReadOnlyAndItIsCurrentLatest() {
+
+        editor.isReadOnly = true;
+        doReturn(true).when(versionRecordManager).isCurrentLatest();
+
+        final boolean success = editor.getSaveValidator().get();
+
+        verify(baseView).alertReadOnly();
+        assertFalse(success);
+    }
+
+    @Test
+    public void testGetSaveValidatorWhenItIsReadOnlyAndItIsNotCurrentLatest() {
+
+        editor.isReadOnly = true;
+        doReturn(false).when(versionRecordManager).isCurrentLatest();
+
+        final boolean success = editor.getSaveValidator().get();
+
+        verify(versionRecordManager).restoreToCurrentVersion();
+        assertFalse(success);
+    }
+
+    @Test
+    public void testGetSaveValidatorWhenConcurrentUpdateSessionInfoIsNotNull() {
+
+        editor.isReadOnly = false;
+        editor.concurrentUpdateSessionInfo = mock(ObservablePath.OnConcurrentUpdateEvent.class);
+        doNothing().when(editor).showConcurrentUpdatePopup();
+
+        final boolean success = editor.getSaveValidator().get();
+
+        verify(editor).showConcurrentUpdatePopup();
+        assertFalse(success);
+    }
+
+    @Test
+    public void testGetSaveValidatorWhenConcurrentUpdateSessionInfoIsNull() {
+
+        editor.isReadOnly = false;
+        editor.concurrentUpdateSessionInfo = null;
+
+        final boolean success = editor.getSaveValidator().get();
+
+        assertTrue(success);
+    }
+
+    @Test
+    public void testOnSuccess() {
+
+        final Path path = mock(Path.class);
+        final String content = "content";
+        final int contentHash = content.hashCode();
+        final int metadataHash = 456;
+        final Supplier<String> contentSupplier = () -> content;
+        final Supplier<DefaultMetadata> metadataSupplier = () -> fakeMetadata(metadataHash);
+
+        doReturn(contentSupplier).when(editor).getContentSupplier();
+        doReturn(metadataSupplier).when(editor).getMetadataSupplier();
+
+        editor.onSuccess().execute(path);
+
+        verify(editor).setOriginalHash(contentHash);
+        verify(editor).setMetadataOriginalHash(metadataHash);
+    }
+
+    @Test
+    public void testMakeMenuBarWhenItContainsAllMenuItems() {
+
+        final ObservablePath path = mock(ObservablePath.class);
+        final MenuItem menuItem = mock(MenuItem.class);
+        final Command onValidate = mock(Command.class);
+        final Command onSave = mock(Command.class);
+        final Command saveAndRename = mock(Command.class);
+        final Validator validator = mock(Validator.class);
+        final Validator copyValidator = mock(Validator.class);
+        final Caller copyServiceCaller = mock(Caller.class);
+        final Caller deleteServiceCaller = mock(Caller.class);
+
+        editor.menuItems = new HashSet<>(Arrays.asList(SAVE, COPY, RENAME, DELETE, VALIDATE, HISTORY));
+
+        doReturn(path).when(versionRecordManager).getCurrentPath();
+        doReturn(menuItem).when(versionRecordManager).buildMenu();
+        doReturn(onValidate).when(editor).onValidate();
+        doReturn(onSave).when(editor).getOnSave();
+        doReturn(saveAndRename).when(editor).getSaveAndRename();
+        doReturn(validator).when(editor).getCopyValidator();
+        doReturn(copyValidator).when(editor).getCopyValidator();
+        doReturn(copyServiceCaller).when(editor).getCopyServiceCaller();
+        doReturn(deleteServiceCaller).when(editor).getDeleteServiceCaller();
+
+        editor.makeMenuBar();
+
+        verify(menuBuilder).addSave(onSave);
+        verify(menuBuilder).addCopy(path, copyValidator, copyServiceCaller);
+        verify(menuBuilder).addRename(saveAndRename);
+        verify(menuBuilder).addDelete(path, deleteServiceCaller);
+        verify(menuBuilder).addValidate(onValidate);
+        verify(menuBuilder).addNewTopLevelMenu(menuItem);
+    }
+
+    @Test
+    public void testMakeMenuBarWhenItDoesNotContainAllMenuItems() {
+
+        editor.menuItems = new HashSet<>();
+
+        editor.makeMenuBar();
+
+        verify(menuBuilder, never()).addSave(any(Command.class));
+        verify(menuBuilder, never()).addCopy(any(ObservablePath.class), any(Validator.class), any(Caller.class));
+        verify(menuBuilder, never()).addRename(any());
+        verify(menuBuilder, never()).addDelete(any(ObservablePath.class), any(Caller.class));
+        verify(menuBuilder, never()).addValidate(any());
+        verify(menuBuilder, never()).addNewTopLevelMenu(any());
+    }
+
+    private DefaultMetadata fakeMetadata(final int hashCode) {
+        return new DefaultMetadata() {
+            @Override
+            public int hashCode() {
+                return hashCode;
+            }
+        };
+    }
+
+    private SaveAndRenameCommandBuilder<String, DefaultMetadata> makeBuilder() {
+        return new SaveAndRenameCommandBuilder<>(null, null, null);
+    }
+
+    private BaseEditor<String, DefaultMetadata> makeBaseEditor() {
+        return new BaseEditor<String, DefaultMetadata>() {
+
+            @Override
+            protected SaveAndRenameCommandBuilder<String, DefaultMetadata> getSaveAndRenameCommandBuilder() {
+                return builder;
+            }
+
+            @Override
+            protected void loadContent() {
+            }
+
+            @Override
+            protected Supplier<String> getContentSupplier() {
+                return () -> fakeContent;
+            }
+        };
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/KieEditorTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/KieEditorTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.ext.editor.commons.client;
 
+import java.util.Set;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.junit.Before;
@@ -30,6 +32,7 @@ import org.uberfire.ext.editor.commons.client.event.ConcurrentDeleteAcceptedEven
 import org.uberfire.ext.editor.commons.client.event.ConcurrentDeleteIgnoredEvent;
 import org.uberfire.ext.editor.commons.client.event.ConcurrentRenameAcceptedEvent;
 import org.uberfire.ext.editor.commons.client.event.ConcurrentRenameIgnoredEvent;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.MenuItems;
 import org.uberfire.ext.editor.commons.version.events.RestoreEvent;
@@ -53,7 +56,7 @@ public class KieEditorTest {
     public void setUp() throws Exception {
         view = mock(BaseEditorView.class);
         restoreEvent = mock(RestoreEvent.class);
-        kieEditor = spy(new BaseEditor(view) {
+        kieEditor = spy(new BaseEditor<String, DefaultMetadata>(view) {
 
             @Override
             protected void loadContent() {
@@ -208,10 +211,12 @@ public class KieEditorTest {
             }
         };
 
+        final Set<MenuItems> menuItems = kieEditor.menuItems;
+
         kieEditor.init(new ObservablePathImpl(),
                        kieEditor.place,
                        kieEditor.type,
-                       kieEditor.menuItems.toArray(new MenuItems[0]));
+                       menuItems.toArray(new MenuItems[0]));
 
         kieEditor.onSave();
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/popups/CommonModalBuilderTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/popups/CommonModalBuilderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.popups;
+
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import elemental2.dom.HTMLElement;
+import org.gwtbootstrap3.client.ui.Modal;
+import org.gwtbootstrap3.client.ui.ModalBody;
+import org.gwtbootstrap3.client.ui.ModalFooter;
+import org.gwtbootstrap3.client.ui.gwt.FlowPanel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub({Modal.class, RootPanel.class})
+public class CommonModalBuilderTest {
+
+    @Mock
+    private BaseModal modalMock;
+
+    private CommonModalBuilder builder;
+
+    @Before
+    public void setup() {
+        builder = spy(new CommonModalBuilder());
+    }
+
+    @Test
+    public void testAddBody() {
+
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+        final FlowPanel flowPanel = mock(FlowPanel.class);
+        final ModalBody modalBody = mock(ModalBody.class);
+
+        doReturn(modalMock).when(builder).getModal();
+        doReturn(modalBody).when(builder).makeModalBody();
+        doReturn(flowPanel).when(builder).buildPanel(htmlElement, modalBody);
+
+        builder.addBody(htmlElement);
+
+        verify(modalMock).add(flowPanel);
+    }
+
+    @Test
+    public void testAddFooter() {
+
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+        final FlowPanel flowPanel = mock(FlowPanel.class);
+        final ModalFooter modalFooter = mock(ModalFooter.class);
+
+        doReturn(modalMock).when(builder).getModal();
+        doReturn(modalFooter).when(builder).makeModalFooter();
+        doReturn(flowPanel).when(builder).buildPanel(htmlElement, modalFooter);
+
+        builder.addFooter(htmlElement);
+
+        verify(modalMock).add(flowPanel);
+    }
+
+    @Test
+    public void testBuild() {
+
+        doReturn(modalMock).when(builder).getModal();
+
+        final BaseModal modal = builder.build();
+
+        assertEquals(modalMock, modal);
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/htmleditor/HtmlEditorTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/htmleditor/HtmlEditorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.htmleditor;
+
+import java.util.function.Supplier;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.backend.vfs.ObservablePath;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.BaseEditorView;
+import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
+import org.uberfire.ext.editor.commons.service.htmleditor.HtmlEditorService;
+import org.uberfire.mocks.CallerMock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class HtmlEditorTest {
+
+    @Mock
+    private HtmlResourceType htmlResourceType;
+
+    @Mock
+    private HtmlEditorPresenter presenter;
+
+    @Mock
+    private HtmlEditorService htmlEditorService;
+
+    @Mock
+    private VersionRecordManager versionRecordManagerMock;
+
+    @Mock
+    private BaseEditorView baseViewMock;
+
+    private Caller<HtmlEditorService> htmlEditorServiceCaller;
+
+    private HtmlEditor htmlEditor;
+
+    @Before
+    public void setup() {
+        htmlEditorServiceCaller = new CallerMock<>(htmlEditorService);
+        htmlEditor = spy(new HtmlEditor(htmlResourceType, presenter, htmlEditorServiceCaller) {{
+            baseView = baseViewMock;
+            versionRecordManager = versionRecordManagerMock;
+        }});
+    }
+
+    @Test
+    public void testGetContentSupplier() {
+
+        final String content = "content";
+
+        doReturn(content).when(presenter).getContent();
+
+        final Supplier<String> contentSupplier = htmlEditor.getContentSupplier();
+
+        assertEquals(content, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() {
+        assertEquals(htmlEditorServiceCaller, htmlEditor.getSaveAndRenameServiceCaller());
+    }
+
+    @Test
+    public void testLoadContent() {
+
+        final ObservablePath path = mock(ObservablePath.class);
+
+        doReturn(path).when(versionRecordManagerMock).getCurrentPath();
+
+        htmlEditor.loadContent();
+
+        verify(baseViewMock).hideBusyIndicator();
+        verify(htmlEditorService).load(path);
+        verify(presenter).setContent(anyString());
+    }
+
+    @Test
+    public void testSave() {
+
+        final ObservablePath path = mock(ObservablePath.class);
+        final RemoteCallback successCallback = mock(RemoteCallback.class);
+        final String content = "content";
+
+        doReturn(content).when(presenter).getContent();
+        doReturn(path).when(versionRecordManagerMock).getCurrentPath();
+        doReturn(successCallback).when(htmlEditor).getSaveSuccessCallback(anyInt());
+
+        htmlEditor.save();
+
+        verify(htmlEditorService).save(path, content, null, null);
+        verify(successCallback).callback(any(Path.class));
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilderTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilderTest.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.menu.common;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.event.Event;
+
+import org.jboss.errai.bus.client.api.messaging.Message;
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
+import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
+import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SaveAndRenameCommandBuilderTest {
+
+    @Mock
+    public SupportsSaveAndRename<String, DefaultMetadata> service;
+
+    @Mock
+    private RenamePopUpPresenter renamePopUpPresenter;
+
+    @Mock
+    private RenamePopUpPresenter.View renamePopUpPresenterView;
+
+    @Mock
+    private BusyIndicatorView busyIndicatorView;
+
+    @Mock
+    private Event<NotificationEvent> notification;
+
+    @Mock
+    private Path path;
+
+    @Mock
+    private DefaultMetadata metadata;
+
+    @Mock
+    private Validator validator;
+
+    @Mock
+    private ParameterizedCommand<Path> onSuccess;
+
+    @Mock
+    private Command onError;
+
+    @Mock
+    private NotificationEvent notificationEvent;
+
+    private SaveAndRenameCommandBuilder<String, DefaultMetadata> builder;
+
+    private Caller<SupportsSaveAndRename<String, DefaultMetadata>> renameCaller;
+
+    private boolean isDirty = true;
+
+    private String content = "content";
+
+    private Supplier<Path> pathSupplierFake = () -> path;
+
+    private Supplier<DefaultMetadata> metadataSupplierFake = () -> metadata;
+
+    private Supplier<String> contentSupplierFake = () -> content;
+
+    private Supplier<Boolean> isDirtySupplierFake = () -> isDirty;
+
+    @Before
+    public void setup() {
+        builder = spy(new SaveAndRenameCommandBuilder<>(renamePopUpPresenter, busyIndicatorView, notification));
+        renameCaller = new CallerMock<>(service);
+
+        doReturn(renamePopUpPresenterView).when(renamePopUpPresenter).getView();
+        doReturn(notificationEvent).when(builder).makeItemRenamedSuccessfullyEvent();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildWhenPathSupplierIsNull() throws Exception {
+
+        builder
+                .addValidator(validator)
+                .addRenameService(renameCaller)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildWhenValidatorIsNull() throws Exception {
+
+        builder
+                .addPathSupplier(pathSupplierFake)
+                .addRenameService(renameCaller)
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildWhenRenameCallerIsNull() throws Exception {
+
+        builder
+                .addPathSupplier(pathSupplierFake)
+                .addValidator(validator)
+                .build();
+    }
+
+    @Test
+    public void testBuildWhenRequiredParametersArePresent() throws Exception {
+
+        final CommandWithFileNameAndCommitMessage renameCommand = mock(CommandWithFileNameAndCommitMessage.class);
+        final CommandWithFileNameAndCommitMessage saveAndRenameCommand = mock(CommandWithFileNameAndCommitMessage.class);
+
+        doReturn(renameCommand).when(builder).makeRenameCommand();
+        doReturn(saveAndRenameCommand).when(builder).makeSaveAndRenameCommand();
+
+        final Command command = builder
+                .addPathSupplier(pathSupplierFake)
+                .addValidator(validator)
+                .addRenameService(renameCaller)
+                .addMetadataSupplier(metadataSupplierFake)
+                .addContentSupplier(contentSupplierFake)
+                .addIsDirtySupplier(isDirtySupplierFake)
+                .build();
+
+        command.execute();
+
+        verify(renamePopUpPresenter).show(path, validator, isDirty, renameCommand, saveAndRenameCommand);
+    }
+
+    @Test
+    public void testMakeSaveAndRenameCommand() throws Exception {
+
+        final String newFileName = "newFileName";
+        final String commitMessage = "commitMessage";
+        final FileNameAndCommitMessage message = new FileNameAndCommitMessage(newFileName, commitMessage);
+
+        doNothing().when(builder).showBusyIndicator();
+        doReturn(path).when(service).saveAndRename(path, newFileName, metadata, content, commitMessage);
+
+        builder
+                .addRenameService(renameCaller)
+                .addPathSupplier(pathSupplierFake)
+                .makeSaveAndRenameCommand()
+                .execute(message);
+
+        final InOrder inOrder = inOrder(builder);
+
+        inOrder.verify(builder).showBusyIndicator();
+        inOrder.verify(builder).callSaveAndRename(message);
+        inOrder.verify(builder).hideRenamePopup();
+        inOrder.verify(builder).hideBusyIndicator();
+        inOrder.verify(builder).notifyItemRenamedSuccessfully();
+    }
+
+    @Test
+    public void testMakeRenameCommand() throws Exception {
+
+        final String newFileName = "newFileName";
+        final String commitMessage = "commitMessage";
+        final FileNameAndCommitMessage message = new FileNameAndCommitMessage(newFileName, commitMessage);
+
+        doNothing().when(builder).showBusyIndicator();
+        doReturn(path).when(service).rename(path, newFileName, commitMessage);
+
+        builder
+                .addRenameService(renameCaller)
+                .addPathSupplier(pathSupplierFake)
+                .makeRenameCommand()
+                .execute(message);
+
+        final InOrder inOrder = inOrder(builder);
+
+        inOrder.verify(builder).showBusyIndicator();
+        inOrder.verify(builder).callRename(message);
+        inOrder.verify(builder).hideRenamePopup();
+        inOrder.verify(builder).hideBusyIndicator();
+        inOrder.verify(builder).notifyItemRenamedSuccessfully();
+    }
+
+    @Test
+    public void testOnSuccess() throws Exception {
+
+        builder
+                .addSuccessCallback(onSuccess)
+                .onSuccess()
+                .callback(path);
+
+        final InOrder inOrder = inOrder(onSuccess, builder);
+
+        inOrder.verify(onSuccess).execute(path);
+        inOrder.verify(builder).hideRenamePopup();
+        inOrder.verify(builder).hideBusyIndicator();
+        inOrder.verify(builder).notifyItemRenamedSuccessfully();
+    }
+
+    @Test
+    public void testOnErrorWhenFileAlreadyExists() throws Exception {
+
+        final Message message = mock(Message.class);
+        final Throwable throwable = mock(Throwable.class);
+
+        doReturn("FileAlreadyExistsException").when(throwable).getMessage();
+
+        final boolean error = builder
+                .addErrorCallback(onError)
+                .onError()
+                .error(message, throwable);
+
+        verify(busyIndicatorView).hideBusyIndicator();
+        verify(builder).handleDuplicatedFileName();
+        verify(onError, never()).execute();
+        verify(builder, never()).hideRenamePopup();
+
+        assertFalse(error);
+    }
+
+    @Test
+    public void testOnErrorWhenFileDoesNotExist() throws Exception {
+
+        final Message message = mock(Message.class);
+        final Throwable throwable = mock(Throwable.class);
+        final SaveAndRenameCommandBuilder.SaveAndRenameErrorCallback onSaveAndRenameError = builder.addErrorCallback(onError).onError();
+        final SaveAndRenameCommandBuilder.SaveAndRenameErrorCallback onErrorSpy = spy(onSaveAndRenameError);
+
+        doReturn("").when(throwable).getMessage();
+        doReturn(true).when(onErrorSpy).callSuper(message, throwable);
+
+        final boolean error = onErrorSpy.error(message, throwable);
+
+        verify(onError).execute();
+        verify(builder).hideRenamePopup();
+        verify(busyIndicatorView, never()).hideBusyIndicator();
+        verify(builder, never()).handleDuplicatedFileName();
+
+        assertTrue(error);
+    }
+}

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/src/main/java/org/uberfire/ext/layout/editor/api/PerspectiveServices.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/src/main/java/org/uberfire/ext/layout/editor/api/PerspectiveServices.java
@@ -20,17 +20,18 @@ import java.util.Collection;
 
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.plugin.model.Plugin;
 
 @Remote
-public interface PerspectiveServices
-        extends SupportsCopy,
-                SupportsRename,
-                SupportsDelete {
+public interface PerspectiveServices extends SupportsCopy,
+                                             SupportsDelete,
+                                             SupportsSaveAndRename<LayoutTemplate, DefaultMetadata> {
 
     Plugin createNewPerspective(String name, LayoutTemplate.Style style);
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/src/main/java/org/uberfire/ext/layout/editor/impl/PerspectiveServicesImpl.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/src/main/java/org/uberfire/ext/layout/editor/impl/PerspectiveServicesImpl.java
@@ -18,11 +18,15 @@ package org.uberfire.ext.layout.editor.impl;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.bus.server.annotations.Service;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.layout.editor.api.PerspectiveServices;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.plugin.backend.PluginServicesImpl;
@@ -36,11 +40,20 @@ public class PerspectiveServicesImpl implements PerspectiveServices {
 
     private PluginServicesImpl pluginServices;
     private LayoutServicesImpl layoutServices;
+    private SaveAndRenameServiceImpl<LayoutTemplate, DefaultMetadata> saveAndRenameService;
 
     @Inject
-    public PerspectiveServicesImpl(PluginServicesImpl pluginServices, LayoutServicesImpl layoutServices) {
+    public PerspectiveServicesImpl(final PluginServicesImpl pluginServices,
+                                   final LayoutServicesImpl layoutServices,
+                                   final SaveAndRenameServiceImpl<LayoutTemplate, DefaultMetadata> saveAndRenameService) {
         this.pluginServices = pluginServices;
         this.layoutServices = layoutServices;
+        this.saveAndRenameService = saveAndRenameService;
+    }
+
+    @PostConstruct
+    public void init() {
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -136,5 +149,22 @@ public class PerspectiveServicesImpl implements PerspectiveServices {
         String layoutModel = layoutServices.convertLayoutToString(layoutTemplate);
         LayoutEditorModel pluginCopy = new LayoutEditorModel(newName, PluginType.PERSPECTIVE_LAYOUT, path, layoutModel);
         pluginServices.saveLayout(pluginCopy, comment);
+    }
+
+    @Override
+    public Path save(final Path path,
+                     final LayoutTemplate content,
+                     final DefaultMetadata metadata,
+                     final String comment) {
+        return saveLayoutTemplate(path, content, comment);
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final DefaultMetadata metadata,
+                              final LayoutTemplate content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/pom.xml
@@ -51,5 +51,10 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-client</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/src/main/java/org/uberfire/ext/plugin/service/PluginServices.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/src/main/java/org/uberfire/ext/plugin/service/PluginServices.java
@@ -20,23 +20,23 @@ import java.util.Collection;
 
 import org.jboss.errai.bus.server.annotations.Remote;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.plugin.model.DynamicMenu;
 import org.uberfire.ext.plugin.model.LayoutEditorModel;
 import org.uberfire.ext.plugin.model.Media;
 import org.uberfire.ext.plugin.model.Plugin;
 import org.uberfire.ext.plugin.model.PluginContent;
-import org.uberfire.ext.plugin.model.PluginSimpleContent;
 import org.uberfire.ext.plugin.model.PluginType;
 import org.uberfire.ext.plugin.model.RuntimePlugin;
 
 @Remote
-public interface PluginServices
-        extends SupportsDelete,
-                SupportsCopy,
-                SupportsRename {
+public interface PluginServices extends SupportsDelete,
+                                        SupportsCopy,
+                                        SupportsSaveAndRename<Plugin, DefaultMetadata> {
 
     String getMediaServletURI();
 
@@ -55,7 +55,7 @@ public interface PluginServices
 
     DynamicMenu getDynamicMenuContent(final Path path);
 
-    Path save(final PluginSimpleContent plugin,
+    Path save(final Plugin plugin,
               final String commitMessage);
 
     LayoutEditorModel getLayoutEditor(Path path,

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/DynamicMenuEditorPresenter.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/DynamicMenuEditorPresenter.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Supplier;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -43,9 +45,10 @@ import org.uberfire.ext.editor.commons.client.BaseEditor;
 import org.uberfire.ext.editor.commons.client.BaseEditorView;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.plugin.client.resources.i18n.CommonConstants;
 import org.uberfire.ext.plugin.client.type.DynamicMenuResourceType;
 import org.uberfire.ext.plugin.client.validation.NameValidator;
@@ -73,22 +76,30 @@ import static org.uberfire.ext.editor.commons.client.menu.MenuItems.SAVE;
 @Dependent
 @WorkbenchEditor(identifier = "Dynamic Menu Editor", supportedTypes = {DynamicMenuResourceType.class}, priority = Integer.MAX_VALUE)
 public class DynamicMenuEditorPresenter
-        extends BaseEditor {
+        extends BaseEditor<Plugin, DefaultMetadata> {
 
     @Inject
     private DynamicMenuResourceType resourceType;
+
     @Inject
     private Caller<PluginServices> pluginServices;
+
     @Inject
     private Event<NotificationEvent> notification;
+
     @Inject
     private ActivityBeansCache activityBeansCache;
+
     @Inject
     private PluginNameValidator pluginNameValidator;
+
     @Inject
     private SavePopUpPresenter savePopUpPresenter;
-    private ListDataProvider<DynamicMenuItem> dataProvider = new ListDataProvider<DynamicMenuItem>();
+
+    private ListDataProvider<DynamicMenuItem> dataProvider = new ListDataProvider<>();
+
     private DynamicMenu menuItem;
+
     private Plugin plugin;
 
     @Inject
@@ -257,6 +268,11 @@ public class DynamicMenuEditorPresenter
         }).getDynamicMenuContent(getVersionRecordManager().getCurrentPath());
     }
 
+    @Override
+    protected Supplier<Plugin> getContentSupplier() {
+        return this::getContent;
+    }
+
     Caller<PluginServices> getPluginServices() {
         return pluginServices;
     }
@@ -322,7 +338,7 @@ public class DynamicMenuEditorPresenter
         return new DynamicMenu(menuItem.getName(),
                                PluginType.DYNAMIC_MENU,
                                versionRecordManager.getCurrentPath(),
-                               new ArrayList<DynamicMenuItem>(getDynamicMenuItems()));
+                               new ArrayList<>(getDynamicMenuItems()));
     }
 
     @Override
@@ -339,7 +355,7 @@ public class DynamicMenuEditorPresenter
         return getPluginServices();
     }
 
-    protected Caller<? extends SupportsRename> getRenameServiceCaller() {
+    protected Caller<? extends SupportsSaveAndRename<Plugin, DefaultMetadata>> getSaveAndRenameServiceCaller() {
         return getPluginServices();
     }
 

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditor.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditor.java
@@ -17,6 +17,8 @@
 package org.uberfire.ext.plugin.client.editor;
 
 import java.util.Collection;
+import java.util.function.Supplier;
+
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -32,9 +34,10 @@ import org.uberfire.ext.editor.commons.client.BaseEditor;
 import org.uberfire.ext.editor.commons.client.BaseEditorView;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.plugin.client.validation.PluginNameValidator;
 import org.uberfire.ext.plugin.event.NewPluginRegistered;
 import org.uberfire.ext.plugin.event.PluginAdded;
@@ -59,7 +62,7 @@ import static org.uberfire.ext.editor.commons.client.menu.MenuItems.DELETE;
 import static org.uberfire.ext.editor.commons.client.menu.MenuItems.RENAME;
 import static org.uberfire.ext.editor.commons.client.menu.MenuItems.SAVE;
 
-public abstract class RuntimePluginBaseEditor extends BaseEditor {
+public abstract class RuntimePluginBaseEditor extends BaseEditor<Plugin, DefaultMetadata> {
 
     protected Plugin plugin;
 
@@ -78,6 +81,10 @@ public abstract class RuntimePluginBaseEditor extends BaseEditor {
     @Inject
     private SavePopUpPresenter savePopUpPresenter;
 
+    public RuntimePluginBaseEditor() {
+        // Zero-parameter constructor for CDI proxies
+    }
+
     protected RuntimePluginBaseEditor(final BaseEditorView baseView) {
         super(baseView);
     }
@@ -85,6 +92,11 @@ public abstract class RuntimePluginBaseEditor extends BaseEditor {
     protected abstract PluginType getPluginType();
 
     protected abstract ClientResourceType getResourceType();
+
+    @Override
+    protected Supplier<Plugin> getContentSupplier() {
+        return this::getContent;
+    }
 
     @OnStartup
     public void onStartup(final ObservablePath path,
@@ -125,8 +137,8 @@ public abstract class RuntimePluginBaseEditor extends BaseEditor {
         return pluginServices;
     }
 
-    protected Caller<? extends SupportsRename> getRenameServiceCaller() {
-        return pluginServices;
+    protected Caller<? extends SupportsSaveAndRename<Plugin, DefaultMetadata>> getSaveAndRenameServiceCaller() {
+        return getPluginServices();
     }
 
     protected Caller<? extends SupportsCopy> getCopyServiceCaller() {
@@ -158,7 +170,7 @@ public abstract class RuntimePluginBaseEditor extends BaseEditor {
         return versionRecordManager.getCurrentPath();
     }
 
-    public PluginSimpleContent getContent() {
+    public Plugin getContent() {
         return new PluginSimpleContent(view().getContent(),
                                        view().getTemplate(),
                                        view().getCss(),
@@ -193,7 +205,6 @@ public abstract class RuntimePluginBaseEditor extends BaseEditor {
     abstract RuntimePluginBaseView view();
 
     Caller<PluginServices> getPluginServices() {
-
         return pluginServices;
     }
 

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/PerspectiveEditorPresenter.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/PerspectiveEditorPresenter.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -43,9 +45,10 @@ import org.uberfire.ext.editor.commons.client.BaseEditorView;
 import org.uberfire.ext.editor.commons.client.menu.MenuItems;
 import org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
-import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.layout.editor.api.PerspectiveServices;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.api.LayoutDragComponentPalette;
@@ -73,26 +76,34 @@ import static org.uberfire.ext.editor.commons.client.menu.MenuItems.SAVE;
 
 @Dependent
 @WorkbenchEditor(identifier = PerspectiveEditorPresenter.ID, supportedTypes = {PerspectiveLayoutPluginResourceType.class}, priority = Integer.MAX_VALUE)
-public class PerspectiveEditorPresenter extends BaseEditor {
+public class PerspectiveEditorPresenter extends BaseEditor<LayoutTemplate, DefaultMetadata> {
 
     public static final String ID = "Perspective Editor";
 
     @Inject
     private View perspectiveEditorView;
+
     @Inject
     private LayoutEditorPlugin layoutEditorPlugin;
+
     @Inject
     private Event<NotificationEvent> ufNotification;
+
     @Inject
     private PerspectiveLayoutPluginResourceType resourceType;
+
     @Inject
     private Caller<PerspectiveServices> perspectiveServices;
+
     @Inject
     private PluginNameValidator pluginNameValidator;
+
     @Inject
     private PluginController pluginController;
+
     @Inject
     private PerspectiveEditorSettings perspectiveEditorSettings;
+
     @Inject
     private SyncBeanManager beanManager;
     @Inject
@@ -196,12 +207,12 @@ public class PerspectiveEditorPresenter extends BaseEditor {
 
         if (perspectiveEditorSettings.isTagsEnabled()) {
             menuBuilder.addNewTopLevelMenu(MenuFactory.newTopLevelMenu(CommonConstants.INSTANCE.Tags())
-                    .respondsWith(() -> {
-                        AddTag addTag = new AddTag(PerspectiveEditorPresenter.this);
-                        addTag.show();
-                    })
-                    .endMenu()
-                    .build().getItems().get(0));
+                                                   .respondsWith(() -> {
+                                                       AddTag addTag = new AddTag(PerspectiveEditorPresenter.this);
+                                                       addTag.show();
+                                                   })
+                                                   .endMenu()
+                                                   .build().getItems().get(0));
         }
     }
 
@@ -238,11 +249,16 @@ public class PerspectiveEditorPresenter extends BaseEditor {
         layoutEditorPlugin.load(versionRecordManager.getCurrentPath(), this::afterLoad);
     }
 
+    @Override
+    protected Supplier<LayoutTemplate> getContentSupplier() {
+        return layoutEditorPlugin::getLayout;
+    }
+
     protected void afterLoad() {
         setOriginalHash(getCurrentModelHash());
         plugin = new Plugin(layoutEditorPlugin.getLayout().getName(),
-                PluginType.PERSPECTIVE_LAYOUT,
-                versionRecordManager.getCurrentPath());
+                            PluginType.PERSPECTIVE_LAYOUT,
+                            versionRecordManager.getCurrentPath());
     }
 
     @Override
@@ -265,8 +281,8 @@ public class PerspectiveEditorPresenter extends BaseEditor {
     protected void afterRename() {
         this.afterLoad();
         changeTitleNotification.fire(new ChangeTitleWidgetEvent(place,
-                getTitleText(),
-                getTitle()));
+                                                                getTitleText(),
+                                                                getTitle()));
     }
 
     @Override
@@ -285,7 +301,7 @@ public class PerspectiveEditorPresenter extends BaseEditor {
     }
 
     @Override
-    protected Caller<? extends SupportsRename> getRenameServiceCaller() {
+    protected Caller<? extends SupportsSaveAndRename<LayoutTemplate, DefaultMetadata>> getSaveAndRenameServiceCaller() {
         return perspectiveServices;
     }
 
@@ -308,9 +324,9 @@ public class PerspectiveEditorPresenter extends BaseEditor {
         return TargetDivList.list(layoutEditorPlugin.getLayout());
     }
 
-    public interface View extends BaseEditorView, UberView<PerspectiveEditorPresenter> {
+    public interface View extends BaseEditorView,
+                                  UberView<PerspectiveEditorPresenter> {
 
         void setupLayoutEditor(Widget widget);
     }
 }
-

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/DynamicMenuEditorPresenterTest.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/DynamicMenuEditorPresenterTest.java
@@ -18,18 +18,36 @@ package org.uberfire.ext.plugin.client.editor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.api.Caller;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.uberfire.ext.plugin.client.validation.RuleValidator;
+import org.uberfire.ext.plugin.model.DynamicMenu;
 import org.uberfire.ext.plugin.model.DynamicMenuItem;
+import org.uberfire.ext.plugin.model.Plugin;
+import org.uberfire.ext.plugin.service.PluginServices;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
+@RunWith(GwtMockitoTestRunner.class)
 public class DynamicMenuEditorPresenterTest {
 
+    @Mock
+    Caller<PluginServices> pluginServices;
+
     private DynamicMenuEditorPresenter presenter;
+
     private DynamicMenuEditorPresenter.View view;
 
     private DynamicMenuItem existingMenuItem;
@@ -37,7 +55,7 @@ public class DynamicMenuEditorPresenterTest {
     @Before
     public void setup() {
         view = mock(DynamicMenuEditorPresenter.View.class);
-        presenter = createDynamicMenuEditorPresenter();
+        presenter = spy(createDynamicMenuEditorPresenter());
 
         when(view.emptyActivityID()).thenReturn("e1");
         when(view.invalidActivityID()).thenReturn("e2");
@@ -91,6 +109,26 @@ public class DynamicMenuEditorPresenterTest {
                                                                            existingMenuItem);
         assertTrue(labelValidator.isValid("newMenuLabel"));
         assertTrue(labelValidator.isValid("existingMenuLabel"));
+    }
+
+    @Test
+    public void testGetContentSupplier() {
+
+        final Plugin dynamicMenu = mock(DynamicMenu.class);
+
+        doReturn(dynamicMenu).when(presenter).getContent();
+
+        final Supplier<Plugin> contentSupplier = presenter.getContentSupplier();
+
+        assertEquals(dynamicMenu, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() {
+
+        doReturn(pluginServices).when(presenter).getPluginServices();
+
+        assertEquals(pluginServices, presenter.getSaveAndRenameServiceCaller());
     }
 
     private DynamicMenuEditorPresenter createDynamicMenuEditorPresenter() {

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditorTest.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/editor/RuntimePluginBaseEditorTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.ext.plugin.client.editor;
 
+import java.util.function.Supplier;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
@@ -23,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
+import org.mockito.Mock;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.workbench.type.ClientResourceType;
@@ -33,30 +36,45 @@ import org.uberfire.ext.plugin.event.PluginSaved;
 import org.uberfire.ext.plugin.model.Media;
 import org.uberfire.ext.plugin.model.Plugin;
 import org.uberfire.ext.plugin.model.PluginContent;
-import org.uberfire.ext.plugin.model.PluginSimpleContent;
 import org.uberfire.ext.plugin.model.PluginType;
 import org.uberfire.ext.plugin.service.PluginServices;
 import org.uberfire.mocks.CallerMock;
 import org.uberfire.mvp.ParameterizedCommand;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class RuntimePluginBaseEditorTest {
 
-    RemoteCallback<PluginContent> successCallBack;
-    RuntimePluginBaseView baseEditorView = null;
+    @Mock
+    private RemoteCallback<PluginContent> successCallBack;
+
+    @Mock
+    private RuntimePluginBaseView baseEditorView;
+
+    @Mock
     private PluginServices pluginServices;
-    private CallerMock<PluginServices> callerMock;
+
+    @Mock
     private RuntimePluginBaseEditor editor;
+
+    @Mock
+    private Plugin pluginMock;
+
+    private CallerMock<PluginServices> callerMock;
 
     @Before
     public void setup() {
-        pluginServices = mock(PluginServices.class);
-        callerMock = new CallerMock<PluginServices>(pluginServices);
-        successCallBack = mock(RemoteCallback.class);
-        baseEditorView = mock(RuntimePluginBaseView.class);
+        callerMock = new CallerMock<>(pluginServices);
         editor = spy(createRuntimePluginBaseEditor());
     }
 
@@ -112,6 +130,19 @@ public class RuntimePluginBaseEditorTest {
         verify(baseEditorView).onSave();
     }
 
+    @Test
+    public void testGetContentSupplier() {
+
+        final Supplier<Plugin> contentSupplier = editor.getContentSupplier();
+
+        assertEquals(pluginMock, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() {
+        assertEquals(callerMock, editor.getSaveAndRenameServiceCaller());
+    }
+
     private RuntimePluginBaseEditor createRuntimePluginBaseEditor() {
 
         return new RuntimePluginBaseEditor(baseEditorView) {
@@ -141,8 +172,8 @@ public class RuntimePluginBaseEditorTest {
             }
 
             @Override
-            public PluginSimpleContent getContent() {
-                return mock(PluginSimpleContent.class);
+            public Plugin getContent() {
+                return pluginMock;
             }
 
             @Override
@@ -155,7 +186,7 @@ public class RuntimePluginBaseEditorTest {
             }
 
             @Override
-            protected RemoteCallback<Path> getSaveSuccessCallback(final int newHash) {
+            public RemoteCallback<Path> getSaveSuccessCallback(final int newHash) {
                 return path -> {
                 };
             }

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/PerspectiveEditorPresenterTest.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/PerspectiveEditorPresenterTest.java
@@ -16,6 +16,8 @@
 package org.uberfire.ext.plugin.client.perspective.editor;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.api.Caller;
@@ -30,7 +32,11 @@ import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
+import org.uberfire.ext.editor.commons.client.menu.common.SaveAndRenameCommandBuilder;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
+import org.uberfire.ext.editor.commons.file.DefaultMetadata;
+import org.uberfire.ext.layout.editor.api.PerspectiveServices;
+import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.LayoutEditorPresenter;
 import org.uberfire.ext.layout.editor.client.api.LayoutDragComponentGroup;
 import org.uberfire.ext.layout.editor.client.api.LayoutDragComponentPalette;
@@ -43,8 +49,14 @@ import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class PerspectiveEditorPresenterTest {
@@ -90,6 +102,12 @@ public class PerspectiveEditorPresenterTest {
 
     @Mock
     EventSourceMock<PerspectiveEditorFocusEvent> perspectiveEditorFocusEvent;
+
+    @Mock
+    Caller<PerspectiveServices> perspectiveServices;
+
+    @Mock
+    SaveAndRenameCommandBuilder<LayoutTemplate, DefaultMetadata> saveAndRenameCommandBuilder;
 
     @InjectMocks
     PerspectiveEditorPresenter presenter;
@@ -140,6 +158,8 @@ public class PerspectiveEditorPresenterTest {
 
         when(beanManager.lookupBeans(PerspectiveEditorComponentGroupProvider.class))
                 .thenReturn(Arrays.asList(perspectiveEditorGroupBeanB, perspectiveEditorGroupBeanA));
+
+        mockSaveAndRenameCommandBuilder();
     }
 
     @Test
@@ -157,7 +177,7 @@ public class PerspectiveEditorPresenterTest {
 
         verify(menuBuilder).addSave(any(Command.class));
         verify(menuBuilder).addCopy(any(Path.class), any(Validator.class), any(Caller.class));
-        verify(menuBuilder).addRename(any(Path.class), any(Validator.class), any(Caller.class));
+        verify(menuBuilder).addRename(any(Command.class));
         verify(menuBuilder).addDelete(any(Path.class), any(Caller.class));
         verify(menuBuilder).addDelete(any(Path.class), any(Caller.class));
         verify(menuBuilder, never()).addNewTopLevelMenu(any());
@@ -170,9 +190,39 @@ public class PerspectiveEditorPresenterTest {
 
         verify(menuBuilder).addSave(any(Command.class));
         verify(menuBuilder).addCopy(any(Path.class), any(Validator.class), any(Caller.class));
-        verify(menuBuilder).addRename(any(Path.class), any(Validator.class), any(Caller.class));
+        verify(menuBuilder).addRename(any(Command.class));
         verify(menuBuilder).addDelete(any(Path.class), any(Caller.class));
         verify(menuBuilder).addDelete(any(Path.class), any(Caller.class));
         verify(menuBuilder).addNewTopLevelMenu(any());
+    }
+
+    @Test
+    public void testGetContentSupplier() {
+
+        final LayoutTemplate layoutTemplate = mock(LayoutTemplate.class);
+
+        doReturn(layoutTemplate).when(layoutEditorPlugin).getLayout();
+
+        final Supplier<LayoutTemplate> contentSupplier = presenter.getContentSupplier();
+
+        assertEquals(layoutTemplate, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() {
+        assertEquals(perspectiveServices, presenter.getSaveAndRenameServiceCaller());
+    }
+
+    private void mockSaveAndRenameCommandBuilder() {
+        when(saveAndRenameCommandBuilder.addPathSupplier(any())).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addValidator(any(Validator.class))).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addValidator(any(Supplier.class))).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addRenameService(any())).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addMetadataSupplier(any())).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addContentSupplier(any())).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addIsDirtySupplier(any())).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addSuccessCallback(any())).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.build()).thenReturn(() -> {
+        });
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-api/src/main/java/org/uberfire/ext/wires/bpmn/api/service/BpmnService.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-api/src/main/java/org/uberfire/ext/wires/bpmn/api/service/BpmnService.java
@@ -24,6 +24,7 @@ import org.uberfire.ext.editor.commons.service.support.SupportsCreate;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRead;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.editor.commons.service.support.SupportsUpdate;
 import org.uberfire.ext.wires.bpmn.api.model.impl.BpmnEditorContent;
 import org.uberfire.ext.wires.bpmn.api.model.impl.nodes.ProcessNode;
@@ -33,6 +34,7 @@ import org.uberfire.ext.wires.bpmn.api.service.todo.Metadata;
 public interface BpmnService extends SupportsCreate<ProcessNode>,
                                      SupportsRead<ProcessNode>,
                                      SupportsUpdate<ProcessNode, Metadata>,
+                                     SupportsSaveAndRename<ProcessNode, Metadata>,
                                      SupportsDelete,
                                      SupportsCopy,
                                      SupportsRename {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/src/main/java/org/uberfire/ext/wires/bpmn/backend/BpmnServiceImpl.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/src/main/java/org/uberfire/ext/wires/bpmn/backend/BpmnServiceImpl.java
@@ -29,6 +29,7 @@ import org.jboss.errai.bus.server.annotations.Service;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
 import org.uberfire.ext.editor.commons.service.CopyService;
 import org.uberfire.ext.editor.commons.service.DeleteService;
 import org.uberfire.ext.editor.commons.service.RenameService;
@@ -70,6 +71,9 @@ public class BpmnServiceImpl implements BpmnService {
 
     @Inject
     private BpmnResourceTypeDefinition typeDefinition;
+
+    @Inject
+    private SaveAndRenameServiceImpl<ProcessNode, Metadata> saveAndRenameService;
     /**
      * TEMPORARY METHODS UNTIL INTEGRATED INTO KIE-WB
      */
@@ -205,6 +209,8 @@ public class BpmnServiceImpl implements BpmnService {
 
         ioService.write(root.resolve("file1.bpmn"),
                         BpmnPersistence.getInstance().marshal(new ProcessNode()));
+
+        saveAndRenameService.init(this);
     }
 
     @Override
@@ -222,5 +228,14 @@ public class BpmnServiceImpl implements BpmnService {
             files.add(Paths.convert(itr.next()));
         }
         return files;
+    }
+
+    @Override
+    public Path saveAndRename(final Path path,
+                              final String newFileName,
+                              final Metadata metadata,
+                              final ProcessNode content,
+                              final String comment) {
+        return saveAndRenameService.saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/src/test/java/org/uberfire/ext/wires/bpmn/backend/BpmnServiceImplTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/src/test/java/org/uberfire/ext/wires/bpmn/backend/BpmnServiceImplTest.java
@@ -17,14 +17,28 @@
 package org.uberfire.ext.wires.bpmn.backend;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.backend.service.SaveAndRenameServiceImpl;
+import org.uberfire.ext.wires.bpmn.api.model.impl.nodes.ProcessNode;
+import org.uberfire.ext.wires.bpmn.api.service.todo.Metadata;
+import org.uberfire.java.nio.file.FileSystem;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+@RunWith(MockitoJUnitRunner.class)
 public class BpmnServiceImplTest {
 
+    @Mock
+    private SaveAndRenameServiceImpl<ProcessNode, Metadata> saveAndRenameService;
+
     @Spy
+    @InjectMocks
     private BpmnServiceImpl bpmnService = new BpmnServiceImpl();
 
     @Test(expected = UnsupportedOperationException.class)
@@ -38,5 +52,19 @@ public class BpmnServiceImplTest {
                          newName,
                          targetDirectory,
                          comment);
+    }
+
+    @Test
+    public void testSaveAndRename() {
+
+        final String newFileName = "newFileName";
+        final String comment = "comment";
+        final Path path = mock(Path.class);
+        final Metadata metadata = mock(Metadata.class);
+        final ProcessNode content = mock(ProcessNode.class);
+
+        bpmnService.saveAndRename(path, newFileName, metadata, content, comment);
+
+        verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/src/main/java/org/uberfire/ext/wires/bpmn/client/editor/BpmnEditorPresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/src/main/java/org/uberfire/ext/wires/bpmn/client/editor/BpmnEditorPresenter.java
@@ -15,6 +15,8 @@
  */
 package org.uberfire.ext.wires.bpmn.client.editor;
 
+import java.util.function.Supplier;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -29,9 +31,11 @@ import org.uberfire.client.annotations.WorkbenchPartTitleDecoration;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.mvp.UberView;
 import org.uberfire.ext.editor.commons.client.BaseEditor;
+import org.uberfire.ext.editor.commons.service.support.SupportsSaveAndRename;
 import org.uberfire.ext.wires.bpmn.api.model.impl.BpmnEditorContent;
 import org.uberfire.ext.wires.bpmn.api.model.impl.nodes.ProcessNode;
 import org.uberfire.ext.wires.bpmn.api.service.BpmnService;
+import org.uberfire.ext.wires.bpmn.api.service.todo.Metadata;
 import org.uberfire.ext.wires.bpmn.client.resources.i18n.BpmnEditorConstants;
 import org.uberfire.ext.wires.bpmn.client.type.BpmnResourceType;
 import org.uberfire.lifecycle.OnMayClose;
@@ -46,8 +50,7 @@ import static org.uberfire.ext.editor.commons.client.menu.MenuItems.SAVE;
 
 @Dependent
 @WorkbenchEditor(identifier = "BPMN Editor", supportedTypes = {BpmnResourceType.class}, priority = Integer.MAX_VALUE)
-public class BpmnEditorPresenter
-        extends BaseEditor {
+public class BpmnEditorPresenter extends BaseEditor<ProcessNode, Metadata> {
 
     @Inject
     private BpmnResourceType resourceType;
@@ -108,6 +111,20 @@ public class BpmnEditorPresenter
     protected void loadContent() {
         //TODO {manstis} When we move to KIE-WB this class can extend KieBaseEditor and be refactored
         service.call(getModelSuccessCallback()).loadContent(versionRecordManager.getCurrentPath());
+    }
+
+    @Override
+    protected Supplier<ProcessNode> getContentSupplier() {
+        return this::getContent;
+    }
+
+    ProcessNode getContent() {
+        return process;
+    }
+
+    @Override
+    protected Caller<? extends SupportsSaveAndRename<ProcessNode, Metadata>> getSaveAndRenameServiceCaller() {
+        return service;
     }
 
     private RemoteCallback<BpmnEditorContent> getModelSuccessCallback() {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/src/test/java/org/uberfire/ext/wires/bpmn/client/editor/BpmnEditorPresenterTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/src/test/java/org/uberfire/ext/wires/bpmn/client/editor/BpmnEditorPresenterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.bpmn.client.editor;
+
+import java.util.function.Supplier;
+
+import org.jboss.errai.common.client.api.Caller;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.bpmn.api.model.impl.nodes.ProcessNode;
+import org.uberfire.ext.wires.bpmn.api.service.BpmnService;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BpmnEditorPresenterTest {
+
+    @Mock
+    private BpmnEditorView view;
+
+    @Mock
+    private ProcessNode processNode;
+
+    @Mock
+    private Caller<BpmnService> service;
+
+    @InjectMocks
+    private BpmnEditorPresenter presenter = spy(new BpmnEditorPresenter(view));
+
+    @Test
+    public void testGetContentSupplier() {
+
+        doReturn(processNode).when(presenter).getContent();
+
+        final Supplier<ProcessNode> contentSupplier = presenter.getContentSupplier();
+
+        assertEquals(processNode, contentSupplier.get());
+    }
+
+    @Test
+    public void testGetSaveAndRenameServiceCaller() {
+        assertEquals(service, presenter.getSaveAndRenameServiceCaller());
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorViewImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorViewImpl.java
@@ -107,6 +107,10 @@ public class MultiPageEditorViewImpl extends ResizeTabPanel implements MultiPage
     @Override
     public void disablePage(int index) {
 
+        if (!isValid(index)) {
+            return;
+        }
+
         final Widget tab = getTabBar().getWidget(index);
 
         tab.addStyleName("disabled");
@@ -116,10 +120,18 @@ public class MultiPageEditorViewImpl extends ResizeTabPanel implements MultiPage
     @Override
     public void enablePage(int index) {
 
+        if (!isValid(index)) {
+            return;
+        }
+
         final Widget tab = getTabBar().getWidget(index);
 
         tab.removeStyleName("disabled");
         enableWidget(tab);
+    }
+
+    boolean isValid(final int index) {
+        return getTabBar().getWidgetCount() > index;
     }
 
     private void enableWidget(final Widget tab) {

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorViewImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorViewImplTest.java
@@ -136,6 +136,7 @@ public class MultiPageEditorViewImplTest {
         doReturn(widget).when(navTabs).getWidget(index);
         doReturn(element).when(widget).getElement();
         doReturn(style).when(element).getStyle();
+        doReturn(true).when(view).isValid(anyInt());
 
         view.disablePage(index);
 
@@ -156,6 +157,7 @@ public class MultiPageEditorViewImplTest {
         doReturn(widget).when(navTabs).getWidget(index);
         doReturn(element).when(widget).getElement();
         doReturn(style).when(element).getStyle();
+        doReturn(true).when(view).isValid(anyInt());
 
         view.enablePage(index);
 


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/RHBA-148
- https://issues.jboss.org/browse/AF-819

---
Demo:
![demo](https://user-images.githubusercontent.com/1079279/35909185-e79488d6-0bd9-11e8-8223-97e9718f444f.gif)

---

Important topics:

I) I'm keeping the editors, that have their own implementation of the save-and-rename operation, intact;

II) I couldn't apply the generic approach on `jbpm-designer`, due to the save operation that is coupled to native JS code. Thus, I needed to implement a custom solution there;

III) The "save commit" and the "rename commit" are not being squashed. I don't think that it's a problem since we're showing explicitly to the user that two operations are being executed (but, maybe I'm missing something, wdyt @manstis?).

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/170
- https://github.com/kiegroup/kie-wb-common/pull/1414
- https://github.com/kiegroup/drools-wb/pull/804
- https://github.com/kiegroup/optaplanner-wb/pull/251
- https://github.com/kiegroup/jbpm-designer/pull/743