### PR TITLE
AF-599: When adding fields next to each other, each field leaves empty row behind.

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import javax.annotation.PostConstruct;
@@ -288,8 +289,15 @@ public class Container {
     }
 
     private void removeOldComponent(Column column) {
-        for (Row row : rows) {
-            row.removeChildColumn(column);
+
+        // Search the row that contains the column
+        Optional<Row> rowOptional = rows.stream()
+                .filter(row -> row.cointainsColumn(column))
+                .findAny();
+
+        // If the row is present remove it!
+        if (rowOptional.isPresent()) {
+            rowOptional.get().removeChildColumn(column);
         }
     }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/rows/RowTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/rows/RowTest.java
@@ -33,7 +33,10 @@ import org.uberfire.ext.layout.editor.client.infra.ColumnResizeEvent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jgroups.util.Util.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -299,6 +302,56 @@ public class RowTest extends AbstractLayoutEditorTest {
         verify(componentDropEventMock).fire(dropEventCaptor.capture());
         assertTrue(dropEventCaptor.getValue().getFromMove());
         assertTrue(dnDManager.isOnComponentMove());
+
+    }
+
+    @Test
+    public void moveLastElementInRow() throws Exception {
+        loadLayout(FULL_LAYOUT_PAGE);
+
+        Row firstRow = getRowByIndex(FIRST_ROW);
+
+        Row secondRow = getRowByIndex(SECOND_ROW);
+
+        assertThat(container.getRows())
+                .hasSize(2)
+                .containsOnly(firstRow, secondRow);
+
+        assertThat(secondRow.getColumns())
+                .hasSize(1);
+
+        Column droppedColumn = secondRow.getColumns().get(0);
+        assertThat(droppedColumn)
+                .isNotNull();
+
+        dnDManager.dragComponent(droppedColumn.getLayoutComponent(),
+                                 droppedColumn.getId(),
+                                 droppedColumn);
+
+        // Dropping secondRow BEFORE firstRow
+        firstRow.drop("", RowDrop.Orientation.BEFORE);
+
+        assertThat(container.getRows())
+                .hasSize(2);
+
+        // after the drop firstRowAfterMove must be a new row containing droppedColumn
+        Row firstRowAfterMove = getRowByIndex(FIRST_ROW);
+
+        // after the drop secondRowAfterMove must be firstRow
+        Row secondRowAfterMove = getRowByIndex(SECOND_ROW);
+
+        assertNotEquals(firstRow, firstRowAfterMove);
+
+        assertNotEquals(secondRow, secondRowAfterMove);
+
+        assertThat(firstRowAfterMove.getColumns())
+                .hasSize(1);
+
+        assertThat(firstRowAfterMove.getColumns().get(0).getLayoutComponent())
+                .isNotNull()
+                .isEqualTo(droppedColumn.getLayoutComponent());
+
+        assertEquals(firstRow, secondRowAfterMove);
 
     }
 }


### PR DESCRIPTION
When moving the last element of a row, the empty row wasn't removed. This change triggers the row removal every time the last column is removed from a row, doesn't matter if it's because a removal or because a move.

@jsoltes @dgutierr could you please review?