### PR TITLE
Close busy popup when view closed to prevent issues from ERRAI-1095

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/BusyIndicatorView.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/BusyIndicatorView.java
@@ -15,6 +15,7 @@
  */
 package org.uberfire.ext.widgets.common.client.common;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.Dependent;
 
 @Dependent
@@ -25,7 +26,13 @@ public class BusyIndicatorView implements HasBusyIndicator {
         BusyPopup.showMessage(message);
     }
 
+    /**
+     * This method is invoked by the container when this bean is destroyed,
+     * so that loading popups are guaranteed to close when an enclosing
+     * bean is destroyed.
+     */
     @Override
+    @PreDestroy
     public void hideBusyIndicator() {
         BusyPopup.close();
     }


### PR DESCRIPTION
[ERRAI-1095](https://issues.jboss.org/projects/ERRAI/issues/ERRAI-1095) prevents callbacks from invoking on Errai callers after the enclosing bean is destroyed. A possible side-effect is that some beans can be closed before they hide popups, causing the popups to remain indefinitely. This prevents that issue for loading popups created with the `BusyIndicatorView`.