### PR TITLE
Remove useless alerts for Upload editor.

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBase.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadBase.java
@@ -74,10 +74,8 @@ public abstract class DefaultEditorFileUploadBase
 
         form.addSubmitCompleteHandler(event -> {
             if (isUploadSuccessful(event)) {
-                Window.alert(CoreConstants.INSTANCE.UploadSuccess());
                 executeCallback(successCallback);
             } else {
-                Window.alert(CoreConstants.INSTANCE.UploadFail());
                 executeCallback(errorCallback);
             }
         });


### PR DESCRIPTION
Notifications should be handled in success/error callbacks in a way
it is "native" to target system.