### PR TITLE
DROOLS-2332: [DMN Editor] Performance poor for lots of nested tables

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/context/GridBodyRenderContext.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/context/GridBodyRenderContext.java
@@ -35,7 +35,6 @@ public class GridBodyRenderContext {
     private final double absoluteColumnOffsetX;
     private final int minVisibleRowIndex;
     private final int maxVisibleRowIndex;
-    private final boolean isSelectionLayer;
     private final Transform transform;
     private final GridRenderer renderer;
     private final SelectionsTransformer transformer;
@@ -48,7 +47,6 @@ public class GridBodyRenderContext {
                                  final int minVisibleRowIndex,
                                  final int maxVisibleRowIndex,
                                  final List<GridColumn<?>> blockColumns,
-                                 final boolean isSelectionLayer,
                                  final Transform transform,
                                  final GridRenderer renderer,
                                  final SelectionsTransformer transformer) {
@@ -60,7 +58,6 @@ public class GridBodyRenderContext {
         this.minVisibleRowIndex = minVisibleRowIndex;
         this.maxVisibleRowIndex = maxVisibleRowIndex;
         this.blockColumns = blockColumns;
-        this.isSelectionLayer = isSelectionLayer;
         this.transform = transform;
         this.renderer = renderer;
         this.transformer = transformer;
@@ -130,14 +127,6 @@ public class GridBodyRenderContext {
      */
     public List<GridColumn<?>> getBlockColumns() {
         return blockColumns;
-    }
-
-    /**
-     * Returns a flag indicating whether the SelectionLayer is being rendered.
-     * @return true if the SelectionLayer is being rendered.
-     */
-    public boolean isSelectionLayer() {
-        return isSelectionLayer;
     }
 
     /**

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/context/GridHeaderRenderContext.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/context/GridHeaderRenderContext.java
@@ -26,14 +26,11 @@ public class GridHeaderRenderContext {
 
     private final List<GridColumn<?>> allColumns;
     private final List<GridColumn<?>> blockColumns;
-    private final boolean isSelectionLayer;
 
     public GridHeaderRenderContext(final List<GridColumn<?>> allColumns,
-                                   final List<GridColumn<?>> blockColumns,
-                                   final boolean isSelectionLayer) {
+                                   final List<GridColumn<?>> blockColumns) {
         this.allColumns = allColumns;
         this.blockColumns = blockColumns;
-        this.isSelectionLayer = isSelectionLayer;
     }
 
     /**
@@ -50,13 +47,5 @@ public class GridHeaderRenderContext {
      */
     public List<GridColumn<?>> getBlockColumns() {
         return blockColumns;
-    }
-
-    /**
-     * Returns a flag indicating whether the SelectionLayer is being rendered.
-     * @return true of the SelectionLayer is being rendered.
-     */
-    public boolean isSelectionLayer() {
-        return isSelectionLayer;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
@@ -65,9 +65,9 @@ public class BaseGridWidget extends Group implements GridWidget {
     protected final Queue<Pair<Group, List<GridRenderer.RendererCommand>>> renderQueue = new ArrayDeque<>();
 
     //These are final as a reference is held by the ISelectionsTransformers
-    protected final List<GridColumn<?>> allColumns = new ArrayList<GridColumn<?>>();
-    protected final List<GridColumn<?>> bodyColumns = new ArrayList<GridColumn<?>>();
-    protected final List<GridColumn<?>> floatingColumns = new ArrayList<GridColumn<?>>();
+    protected final List<GridColumn<?>> allColumns = new ArrayList<>();
+    protected final List<GridColumn<?>> bodyColumns = new ArrayList<>();
+    protected final List<GridColumn<?>> floatingColumns = new ArrayList<>();
 
     protected GridData model;
     protected GridRenderer renderer;
@@ -77,6 +77,7 @@ public class BaseGridWidget extends Group implements GridWidget {
     protected Group bodySelections = null;
     protected Group floatingBody = null;
     protected Group floatingBodySelections = null;
+    protected Group boundary = null;
     protected BaseGridRendererHelper.RenderingInformation renderingInformation;
 
     private Group selection = null;
@@ -303,6 +304,7 @@ public class BaseGridWidget extends Group implements GridWidget {
         this.floatingHeader = null;
         this.bodySelections = null;
         this.floatingBodySelections = null;
+        this.boundary = null;
         this.allColumns.clear();
         this.bodyColumns.clear();
         this.floatingColumns.clear();
@@ -348,7 +350,10 @@ public class BaseGridWidget extends Group implements GridWidget {
         }
 
         //Draw if required
-        if (this.bodyColumns.size() > 0) {
+        if (bodyColumns.size() > 0) {
+
+            boundary = new Group();
+
             drawHeader(renderingInformation);
 
             if (model.getRowCount() > 0) {
@@ -379,10 +384,10 @@ public class BaseGridWidget extends Group implements GridWidget {
                                                          floatingColumnsTransformer,
                                                          renderingInformation));
         }
-
-        addCommandToRenderQueue(this,
-                                renderGridBoundary(renderingInformation));
-
+        if (boundary != null) {
+            addCommandToRenderQueue(boundary,
+                                    renderGridBoundary(renderingInformation));
+        }
         if (isSelected) {
             assertSelectionWidget();
         }
@@ -410,6 +415,10 @@ public class BaseGridWidget extends Group implements GridWidget {
             add(floatingHeader);
         }
 
+        if (boundary != null) {
+            add(boundary);
+        }
+
         //Include selection indicator if required
         if (isSelected) {
             add(selection);
@@ -432,8 +441,6 @@ public class BaseGridWidget extends Group implements GridWidget {
         final List<GridColumn<?>> allColumns = renderingInformation.getAllColumns();
         final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
-        final List<GridColumn<?>> bodyColumns = bodyBlockInformation.getColumns();
-        final List<GridColumn<?>> floatingColumns = floatingBlockInformation.getColumns();
 
         final double headerX = bodyBlockInformation.getX();
         final double headerY = bodyBlockInformation.getHeaderY();
@@ -474,8 +481,6 @@ public class BaseGridWidget extends Group implements GridWidget {
     protected void drawBody(final BaseGridRendererHelper.RenderingInformation renderingInformation) {
         final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
-        final List<GridColumn<?>> bodyColumns = bodyBlockInformation.getColumns();
-        final List<GridColumn<?>> floatingColumns = floatingBlockInformation.getColumns();
 
         final double bodyX = bodyBlockInformation.getX();
         final double bodyY = bodyBlockInformation.getBodyY();
@@ -607,8 +612,7 @@ public class BaseGridWidget extends Group implements GridWidget {
         final List<GridColumn<?>> allColumns = new ArrayList<>();
         final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
-        final List<GridColumn<?>> bodyColumns = bodyBlockInformation.getColumns();
-        final List<GridColumn<?>> floatingColumns = floatingBlockInformation.getColumns();
+
         if (body != null || header != null) {
             allColumns.addAll(bodyColumns);
             x = bodyBlockInformation.getX();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
@@ -60,26 +60,27 @@ public class BaseGridWidget extends Group implements GridWidget {
 
     protected final SelectionsTransformer bodyTransformer;
     protected final SelectionsTransformer floatingColumnsTransformer;
-
     protected final BaseGridRendererHelper rendererHelper;
-
     protected final Queue<Pair<Group, List<GridRenderer.RendererCommand>>> renderQueue = new ArrayDeque<>();
 
     //These are final as a reference is held by the ISelectionsTransformers
     protected final List<GridColumn<?>> allColumns = new ArrayList<GridColumn<?>>();
     protected final List<GridColumn<?>> bodyColumns = new ArrayList<GridColumn<?>>();
     protected final List<GridColumn<?>> floatingColumns = new ArrayList<GridColumn<?>>();
-    private final CellSelectionManager cellSelectionManager;
+
     protected GridData model;
     protected GridRenderer renderer;
     protected Group header = null;
     protected Group floatingHeader = null;
     protected Group body = null;
-    protected Group floatingBody = null;
     protected Group bodySelections = null;
-    protected Group floatingSelections = null;
+    protected Group floatingBody = null;
+    protected Group floatingBodySelections = null;
+    protected BaseGridRendererHelper.RenderingInformation renderingInformation;
+
     private Group selection = null;
     private boolean isSelected = false;
+    private final CellSelectionManager cellSelectionManager;
 
     public BaseGridWidget(final GridData model,
                           final GridSelectionManager selectionManager,
@@ -207,11 +208,10 @@ public class BaseGridWidget extends Group implements GridWidget {
     @Override
     public void select() {
         isSelected = true;
-        final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
         if (renderingInformation == null) {
             return;
         }
-        assertSelectionWidget(renderingInformation);
+        assertSelectionWidget();
         add(selection);
     }
 
@@ -228,7 +228,7 @@ public class BaseGridWidget extends Group implements GridWidget {
         return isSelected;
     }
 
-    private void assertSelectionWidget(final BaseGridRendererHelper.RenderingInformation renderingInformation) {
+    private void assertSelectionWidget() {
         this.selection = new Group();
         addCommandToRenderQueue(selection,
                                 renderer.renderSelector(getWidth(),
@@ -250,13 +250,8 @@ public class BaseGridWidget extends Group implements GridWidget {
     protected void drawWithoutTransforms(Context2D context,
                                          double alpha,
                                          BoundingBox bb) {
-        body = null;
-        header = null;
-        floatingBody = null;
-        floatingHeader = null;
-        bodySelections = null;
-        floatingSelections = null;
-        if ((context.isSelection()) && (false == isListening())) {
+        final boolean isSelectionLayer = context.isSelection();
+        if (isSelectionLayer && (false == isListening())) {
             return;
         }
         alpha = alpha * getAttributes().getAlpha();
@@ -264,118 +259,26 @@ public class BaseGridWidget extends Group implements GridWidget {
         if (alpha <= 0) {
             return;
         }
-
         if (model.getColumns().isEmpty()) {
             return;
         }
 
         //Clear existing content
         this.removeAll();
-        this.allColumns.clear();
-        this.bodyColumns.clear();
-        this.floatingColumns.clear();
-        this.renderQueue.clear();
 
-        //If there's no RenderingInformation the GridWidget is not visible
-        final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
-        if (renderingInformation == null) {
-            destroyDOMElementResources();
-            return;
-        }
-
-        final int minVisibleRowIndex = renderingInformation.getMinVisibleRowIndex();
-        final int maxVisibleRowIndex = renderingInformation.getMaxVisibleRowIndex();
-        final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
-        final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
-        final List<GridColumn<?>> allColumns = renderingInformation.getAllColumns();
-        final List<GridColumn<?>> bodyColumns = bodyBlockInformation.getColumns();
-        final List<GridColumn<?>> floatingColumns = floatingBlockInformation.getColumns();
-        final boolean isSelectionLayer = context.isSelection();
-
-        this.allColumns.addAll(allColumns);
-        this.bodyColumns.addAll(bodyColumns);
-        this.floatingColumns.addAll(floatingColumns);
-
-        //Signal columns to attach or detach rendering support
         if (!isSelectionLayer) {
-            for (GridColumn<?> column : model.getColumns()) {
-                if (bodyColumns.contains(column) || floatingColumns.contains(column)) {
-                    if (column instanceof HasMultipleDOMElementResources) {
-                        ((HasMultipleDOMElementResources) column).initialiseResources();
-                    }
-                } else if (column instanceof HasDOMElementResources) {
-                    ((HasDOMElementResources) column).destroyResources();
-                }
+            //If there's no RenderingInformation the GridWidget is not visible
+            this.renderingInformation = prepare();
+            if (renderingInformation == null) {
+                destroyDOMElementResources();
+                return;
             }
+            makeRenderingCommands();
         }
 
-        //Draw if required
-        if (this.bodyColumns.size() > 0) {
-            drawHeader(renderingInformation,
-                       isSelectionLayer);
+        layerRenderGroups();
 
-            if (model.getRowCount() > 0) {
-                drawBody(renderingInformation,
-                         isSelectionLayer);
-            }
-
-            //The order these are added ensures the parts overlap correctly
-            if (body != null) {
-                add(body);
-
-                    if (!isSelectionLayer) {
-                        bodySelections = new Group();
-                        bodySelections.setX(body.getX()).setY(body.getY());
-                        add(bodySelections);
-                }
-            }
-            if (header != null) {
-                add(header);
-            }
-
-            if (floatingBody != null) {
-                add(floatingBody);
-
-                    if (!isSelectionLayer) {
-                        floatingSelections = new Group();
-                        floatingSelections.setX(floatingBody.getX()).setY(floatingBody.getY());
-                        add(floatingSelections);
-                }
-            }
-            if (floatingHeader != null) {
-                add(floatingHeader);
-            }
-
-            if (bodySelections != null) {
-                addCommandToRenderQueue(bodySelections,
-                                        renderSelectedRanges(bodyColumns,
-                                                             bodyBlockInformation.getX(),
-                                                             minVisibleRowIndex,
-                                                             maxVisibleRowIndex,
-                                                             bodyTransformer,
-                                                             renderingInformation));
-            }
-            if (floatingSelections != null) {
-                addCommandToRenderQueue(floatingSelections,
-                                        renderSelectedRanges(floatingColumns,
-                                                             floatingBlockInformation.getX(),
-                                                             minVisibleRowIndex,
-                                                             maxVisibleRowIndex,
-                                                             floatingColumnsTransformer,
-                                                             renderingInformation));
-            }
-
-            addCommandToRenderQueue(this,
-                                    renderGridBoundary(renderingInformation));
-
-            //Include selection indicator if required
-            if (isSelected) {
-                assertSelectionWidget(renderingInformation);
-                add(selection);
-            }
-
-            executeRenderQueueCommands();
-        }
+        executeRenderQueueCommands(isSelectionLayer);
 
         //Signal columns to free any unused resources
         if (!isSelectionLayer) {
@@ -397,11 +300,119 @@ public class BaseGridWidget extends Group implements GridWidget {
                                     bb);
     }
 
+    BaseGridRendererHelper.RenderingInformation prepare() {
+        this.body = null;
+        this.header = null;
+        this.floatingBody = null;
+        this.floatingHeader = null;
+        this.bodySelections = null;
+        this.floatingBodySelections = null;
+        this.allColumns.clear();
+        this.bodyColumns.clear();
+        this.floatingColumns.clear();
+        this.renderQueue.clear();
+
+        //If there's no RenderingInformation the GridWidget is not visible
+        final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
+        if (renderingInformation == null) {
+            return null;
+        }
+
+        final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
+        final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
+        final List<GridColumn<?>> allColumns = renderingInformation.getAllColumns();
+        final List<GridColumn<?>> bodyColumns = bodyBlockInformation.getColumns();
+        final List<GridColumn<?>> floatingColumns = floatingBlockInformation.getColumns();
+
+        this.allColumns.addAll(allColumns);
+        this.bodyColumns.addAll(bodyColumns);
+        this.floatingColumns.addAll(floatingColumns);
+
+        return renderingInformation;
+    }
+
     void destroyDOMElementResources() {
         for (GridColumn<?> column : model.getColumns()) {
             if (column.getColumnRenderer() instanceof HasDOMElementResources) {
                 ((HasDOMElementResources) column.getColumnRenderer()).destroyResources();
             }
+        }
+    }
+
+    void makeRenderingCommands() {
+        //Signal columns to attach or detach rendering support
+        for (GridColumn<?> column : model.getColumns()) {
+            if (bodyColumns.contains(column) || floatingColumns.contains(column)) {
+                if (column instanceof HasMultipleDOMElementResources) {
+                    ((HasMultipleDOMElementResources) column).initialiseResources();
+                }
+            } else if (column instanceof HasDOMElementResources) {
+                ((HasDOMElementResources) column).destroyResources();
+            }
+        }
+
+        //Draw if required
+        if (this.bodyColumns.size() > 0) {
+            drawHeader(renderingInformation);
+
+            if (model.getRowCount() > 0) {
+                drawBody(renderingInformation);
+            }
+        }
+
+        final int minVisibleRowIndex = renderingInformation.getMinVisibleRowIndex();
+        final int maxVisibleRowIndex = renderingInformation.getMaxVisibleRowIndex();
+        final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
+        final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
+
+        if (bodySelections != null) {
+            addCommandToRenderQueue(bodySelections,
+                                    renderSelectedRanges(bodyColumns,
+                                                         bodyBlockInformation.getX(),
+                                                         minVisibleRowIndex,
+                                                         maxVisibleRowIndex,
+                                                         bodyTransformer,
+                                                         renderingInformation));
+        }
+        if (floatingBodySelections != null) {
+            addCommandToRenderQueue(floatingBodySelections,
+                                    renderSelectedRanges(floatingColumns,
+                                                         floatingBlockInformation.getX(),
+                                                         minVisibleRowIndex,
+                                                         maxVisibleRowIndex,
+                                                         floatingColumnsTransformer,
+                                                         renderingInformation));
+        }
+
+        addCommandToRenderQueue(this,
+                                renderGridBoundary(renderingInformation));
+
+        if (isSelected) {
+            assertSelectionWidget();
+        }
+    }
+
+    void layerRenderGroups() {
+        //The order these are added ensures the parts overlap correctly
+        if (body != null) {
+            add(body);
+            add(bodySelections);
+        }
+        if (header != null) {
+            add(header);
+        }
+
+        if (floatingBody != null) {
+            add(floatingBody);
+            add(floatingBodySelections);
+        }
+        if (floatingHeader != null) {
+            add(floatingHeader);
+        }
+
+        //Include selection indicator if required
+        if (isSelected) {
+            add(selection);
         }
     }
 
@@ -417,8 +428,7 @@ public class BaseGridWidget extends Group implements GridWidget {
         return super.setVisible(visible);
     }
 
-    protected void drawHeader(final BaseGridRendererHelper.RenderingInformation renderingInformation,
-                              final boolean isSelectionLayer) {
+    protected void drawHeader(final BaseGridRendererHelper.RenderingInformation renderingInformation) {
         final List<GridColumn<?>> allColumns = renderingInformation.getAllColumns();
         final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
@@ -440,7 +450,6 @@ public class BaseGridWidget extends Group implements GridWidget {
             addCommandsToRenderQueue(header,
                                      renderGridHeaderWidget(allColumns,
                                                             bodyColumns,
-                                                            isSelectionLayer,
                                                             renderingInformation));
 
             if (addFloatingHeader) {
@@ -454,14 +463,12 @@ public class BaseGridWidget extends Group implements GridWidget {
                 addCommandsToRenderQueue(floatingHeader,
                                          renderGridHeaderWidget(floatingColumns,
                                                                 floatingColumns,
-                                                                isSelectionLayer,
                                                                 renderingInformation));
             }
         }
     }
 
-    protected void drawBody(final BaseGridRendererHelper.RenderingInformation renderingInformation,
-                            final boolean isSelectionLayer) {
+    protected void drawBody(final BaseGridRendererHelper.RenderingInformation renderingInformation) {
         final BaseGridRendererHelper.RenderingBlockInformation bodyBlockInformation = renderingInformation.getBodyBlockInformation();
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
         final List<GridColumn<?>> bodyColumns = bodyBlockInformation.getColumns();
@@ -477,26 +484,29 @@ public class BaseGridWidget extends Group implements GridWidget {
 
         body = new Group();
         body.setX(bodyX).setY(bodyY);
+        bodySelections = new Group();
+        bodySelections.setX(bodyX).setY(bodyY);
+
         addCommandsToRenderQueue(body,
                                  renderGridBodyWidget(bodyColumns,
                                                       bodyBlockInformation.getX(),
                                                       minVisibleRowIndex,
                                                       maxVisibleRowIndex,
-                                                      isSelectionLayer,
                                                       bodyTransformer,
                                                       renderingInformation));
 
         //Render floating columns
         if (floatingColumns.size() > 0) {
             floatingBody = new Group();
-            floatingBody.setX(floatingBodyX);
-            floatingBody.setY(floatingBodyY);
+            floatingBody.setX(floatingBodyX).setY(floatingBodyY);
+            floatingBodySelections = new Group();
+            floatingBodySelections.setX(floatingBodyX).setY(floatingBodyY);
+
             addCommandsToRenderQueue(floatingBody,
                                      renderGridBodyWidget(floatingColumns,
                                                           floatingBlockInformation.getX(),
                                                           minVisibleRowIndex,
                                                           maxVisibleRowIndex,
-                                                          isSelectionLayer,
                                                           floatingColumnsTransformer,
                                                           renderingInformation));
         }
@@ -512,23 +522,32 @@ public class BaseGridWidget extends Group implements GridWidget {
         renderQueue.add(new Pair<>(parent, commands));
     }
 
-    protected void executeRenderQueueCommands() {
-        renderQueue.stream().forEach(p -> p.getK2().forEach(c -> c.execute(p.getK1())));
+    protected void executeRenderQueueCommands(final boolean isSelectionLayer) {
+        renderQueue.stream()
+                .forEach(p -> p.getK2()
+                        .forEach(c -> c.execute(new GridRenderer.GridRendererContext() {
+                            @Override
+                            public Group getGroup() {
+                                return p.getK1();
+                            }
+
+                            @Override
+                            public boolean isSelectionLayer() {
+                                return isSelectionLayer;
+                            }
+                        })));
     }
 
     /**
      * Render the Widget's Header and append to this Group.
      * @param allColumns All columns in the model.
      * @param blockColumns The columns to render for a block.
-     * @param isSelectionLayer Is the SelectionLayer being rendered.
      */
     protected List<GridRenderer.RendererCommand> renderGridHeaderWidget(final List<GridColumn<?>> allColumns,
                                                                         final List<GridColumn<?>> blockColumns,
-                                                                        final boolean isSelectionLayer,
                                                                         final BaseGridRendererHelper.RenderingInformation renderingInformation) {
         final GridHeaderRenderContext context = new GridHeaderRenderContext(allColumns,
-                                                                            blockColumns,
-                                                                            isSelectionLayer);
+                                                                            blockColumns);
         return renderer.renderHeader(model,
                                      context,
                                      rendererHelper,
@@ -541,14 +560,12 @@ public class BaseGridWidget extends Group implements GridWidget {
      * @param absoluteColumnOffsetX Absolute offset from Grid's X co-ordinate to render first column in block.
      * @param minVisibleRowIndex The index of the first visible row.
      * @param maxVisibleRowIndex The index of the last visible row.
-     * @param isSelectionLayer Is the SelectionLayer being rendered.
      * @param transformer SelectionTransformer in operation.
      */
     protected List<GridRenderer.RendererCommand> renderGridBodyWidget(final List<GridColumn<?>> blockColumns,
                                                                       final double absoluteColumnOffsetX,
                                                                       final int minVisibleRowIndex,
                                                                       final int maxVisibleRowIndex,
-                                                                      final boolean isSelectionLayer,
                                                                       final SelectionsTransformer transformer,
                                                                       final BaseGridRendererHelper.RenderingInformation renderingInformation) {
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
@@ -565,7 +582,6 @@ public class BaseGridWidget extends Group implements GridWidget {
                                                                         minVisibleRowIndex,
                                                                         maxVisibleRowIndex,
                                                                         blockColumns,
-                                                                        isSelectionLayer,
                                                                         getViewport().getTransform(),
                                                                         renderer,
                                                                         transformer);
@@ -642,7 +658,6 @@ public class BaseGridWidget extends Group implements GridWidget {
                                                                         minVisibleRowIndex,
                                                                         maxVisibleRowIndex,
                                                                         blockColumns,
-                                                                        false,
                                                                         getViewport().getTransform(),
                                                                         renderer,
                                                                         transformer);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/GridColumnRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/GridColumnRenderer.java
@@ -16,6 +16,7 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 import com.ait.lienzo.client.core.shape.Group;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
@@ -33,11 +34,13 @@ public interface GridColumnRenderer<T> {
      * @param headerMetaData MetaData for the header
      * @param context Contextual information to support rendering
      * @param renderingInformation Calculated rendering information supporting rendering.
+     * @param columnRenderingConstraint Function to determine whether column should be rendered to the SelectionLayer
      * @return
      */
     List<GridRenderer.RendererCommand> renderHeader(final List<GridColumn.HeaderMetaData> headerMetaData,
                                                     final GridHeaderColumnRenderContext context,
-                                                    final BaseGridRendererHelper.RenderingInformation renderingInformation);
+                                                    final BaseGridRendererHelper.RenderingInformation renderingInformation,
+                                                    final BiFunction<Boolean, GridColumn<?>, Boolean> columnRenderingConstraint);
 
     /**
      * Renders the column.textual information to support rendering
@@ -45,12 +48,14 @@ public interface GridColumnRenderer<T> {
      * @param context Contextual information to support rendering
      * @param rendererHelper Helper for rendering.
      * @param renderingInformation Calculated rendering information supporting rendering.
+     * @param columnRenderingConstraint Function to determine whether column should be rendered to the SelectionLayer
      * @return
      */
     List<GridRenderer.RendererCommand> renderColumn(final GridColumn<?> column,
                                                     final GridBodyColumnRenderContext context,
                                                     final BaseGridRendererHelper rendererHelper,
-                                                    final BaseGridRendererHelper.RenderingInformation renderingInformation);
+                                                    final BaseGridRendererHelper.RenderingInformation renderingInformation,
+                                                    final BiFunction<Boolean, GridColumn<?>, Boolean> columnRenderingConstraint);
 
     /**
      * Renders a cell for the column for a row. Normally a column would use its logical index

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
@@ -19,6 +19,7 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.i
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
 import com.ait.lienzo.client.core.shape.BoundingBoxPathClipper;
@@ -47,7 +48,8 @@ public class ColumnRenderingStrategyMerged {
     public static List<GridRenderer.RendererCommand> render(final GridColumn<?> column,
                                                             final GridBodyColumnRenderContext context,
                                                             final BaseGridRendererHelper rendererHelper,
-                                                            final BaseGridRendererHelper.RenderingInformation renderingInformation) {
+                                                            final BaseGridRendererHelper.RenderingInformation renderingInformation,
+                                                            final BiFunction<Boolean, GridColumn<?>, Boolean> columnRenderingConstraint) {
         final double x = context.getX();
         final double absoluteGridY = context.getAbsoluteGridY();
         final double absoluteColumnX = context.getAbsoluteColumnX();
@@ -68,176 +70,180 @@ public class ColumnRenderingStrategyMerged {
         final List<GridRenderer.RendererCommand> commands = new ArrayList<>();
 
         //Grid lines
-        commands.add((GridRenderer.RenderBodyGridLinesCommand) (parent) -> {
-            //- horizontal
-            final MultiPath bodyGrid = theme.getBodyGridLine();
-            for (int rowIndex = minVisibleRowIndex; rowIndex <= maxVisibleRowIndex; rowIndex++) {
-                final double y = visibleRowOffsets.get(rowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0);
-                final GridRow row = model.getRow(rowIndex);
+        commands.add((GridRenderer.RenderBodyGridLinesCommand) (rc) -> {
+            if (!rc.isSelectionLayer()) {
+                //- horizontal
+                final MultiPath bodyGrid = theme.getBodyGridLine();
+                for (int rowIndex = minVisibleRowIndex; rowIndex <= maxVisibleRowIndex; rowIndex++) {
+                    final double y = visibleRowOffsets.get(rowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0);
+                    final GridRow row = model.getRow(rowIndex);
 
-                if (!row.isMerged()) {
-                    //If row doesn't contain merged cells just draw a line across the visible body
-                    bodyGrid.M(x, y + 0.5)
-                            .L(x + columnWidth, y + 0.5);
-                } else if (!row.isCollapsed()) {
-                    //If row isn't collapsed just draw a line across the visible body at the top of the merged block
-                    final GridCell<?> cell = model.getCell(rowIndex,
-                                                           columnIndex);
-
-                    if (cell == null || cell.getMergedCellCount() > 0) {
-                        //Draw a line-segment for empty cells and cells that are to have content rendered
+                    if (!row.isMerged()) {
+                        //If row doesn't contain merged cells just draw a line across the visible body
                         bodyGrid.M(x, y + 0.5)
                                 .L(x + columnWidth, y + 0.5);
-                    } else if (isCollapsedRowMultiValue(model,
-                                                        column,
-                                                        cell,
-                                                        rowIndex)) {
-                        //Special case for when a cell follows collapsed row(s) with multiple values
-                        bodyGrid.M(x, y + 0.5)
-                                .L(x + columnWidth, y + 0.5);
+                    } else if (!row.isCollapsed()) {
+                        //If row isn't collapsed just draw a line across the visible body at the top of the merged block
+                        final GridCell<?> cell = model.getCell(rowIndex,
+                                                               columnIndex);
+
+                        if (cell == null || cell.getMergedCellCount() > 0) {
+                            //Draw a line-segment for empty cells and cells that are to have content rendered
+                            bodyGrid.M(x, y + 0.5)
+                                    .L(x + columnWidth, y + 0.5);
+                        } else if (isCollapsedRowMultiValue(model,
+                                                            column,
+                                                            cell,
+                                                            rowIndex)) {
+                            //Special case for when a cell follows collapsed row(s) with multiple values
+                            bodyGrid.M(x, y + 0.5)
+                                    .L(x + columnWidth, y + 0.5);
+                        }
                     }
                 }
-            }
 
-            //- vertical
-            if (columnIndex < model.getColumnCount() - 1) {
-                bodyGrid.M(x + columnWidth + 0.5, 0)
-                        .L(x + columnWidth + 0.5, columnHeight);
-            }
+                //- vertical
+                if (columnIndex < model.getColumnCount() - 1) {
+                    bodyGrid.M(x + columnWidth + 0.5, 0)
+                            .L(x + columnWidth + 0.5, columnHeight);
+                }
 
-            parent.add(bodyGrid);
+                rc.getGroup().add(bodyGrid);
+            }
         });
 
         //Column content
-        commands.add((GridRenderer.RenderBodyGridContentCommand) (parent) -> {
-            final Group columnGroup = new Group().setX(x);
-            int iterations = 0;
-            for (int rowIndex = minVisibleRowIndex; rowIndex <= maxVisibleRowIndex; rowIndex++) {
+        commands.add((GridRenderer.RenderBodyGridContentCommand) (rc) -> {
+            if (columnRenderingConstraint.apply(rc.isSelectionLayer(), column)) {
+                final Group columnGroup = new Group().setX(x);
+                int iterations = 0;
+                for (int rowIndex = minVisibleRowIndex; rowIndex <= maxVisibleRowIndex; rowIndex++) {
 
-                // This is a defensive programming to prevent this loop from never ending.
-                // The check should never be satisfied however, especially in early development, this loop sometimes became
-                // infinite. All known issue are resolved however the check remains as a safety precaution. Without the check
-                // the Workbench could appear to "lock up" - if the infinite loop scenario reoccurred. With the check,
-                // at worst, the grid will be incorrectly rendered.
-                iterations++;
-                if (iterations > LOOP_THRESHOLD) {
-                    break;
-                }
+                    // This is a defensive programming to prevent this loop from never ending.
+                    // The check should never be satisfied however, especially in early development, this loop sometimes became
+                    // infinite. All known issue are resolved however the check remains as a safety precaution. Without the check
+                    // the Workbench could appear to "lock up" - if the infinite loop scenario reoccurred. With the check,
+                    // at worst, the grid will be incorrectly rendered.
+                    iterations++;
+                    if (iterations > LOOP_THRESHOLD) {
+                        break;
+                    }
 
-                final double y = visibleRowOffsets.get(rowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0);
-                final GridRow row = model.getRow(rowIndex);
-                final GridCell<?> cell = model.getCell(rowIndex,
-                                                       columnIndex);
+                    final double y = visibleRowOffsets.get(rowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0);
+                    final GridRow row = model.getRow(rowIndex);
+                    final GridCell<?> cell = model.getCell(rowIndex,
+                                                           columnIndex);
 
-                //Only show content for rows that are not collapsed
-                if (row.isCollapsed()) {
-                    continue;
-                }
+                    //Only show content for rows that are not collapsed
+                    if (row.isCollapsed()) {
+                        continue;
+                    }
 
-                //Add highlight for merged cells with different values
-                final boolean isCollapsedCellMixedValue = isCollapsedCellMixedValue(model,
-                                                                                    rowIndex,
-                                                                                    columnIndex);
+                    //Add highlight for merged cells with different values
+                    final boolean isCollapsedCellMixedValue = isCollapsedCellMixedValue(model,
+                                                                                        rowIndex,
+                                                                                        columnIndex);
 
-                if (isCollapsedCellMixedValue) {
-                    final Group mixedValueGroup = renderMergedCellMixedValueHighlight(columnWidth,
-                                                                                      row.getHeight());
-                    mixedValueGroup.setX(0).setY(y).setListening(true);
-                    columnGroup.add(mixedValueGroup);
-                }
+                    if (isCollapsedCellMixedValue) {
+                        final Group mixedValueGroup = renderMergedCellMixedValueHighlight(columnWidth,
+                                                                                          row.getHeight());
+                        mixedValueGroup.setX(0).setY(y).setListening(true);
+                        columnGroup.add(mixedValueGroup);
+                    }
 
-                //Only show content if there's a Cell behind it!
-                if (cell == null) {
-                    continue;
-                }
+                    //Only show content if there's a Cell behind it!
+                    if (cell == null) {
+                        continue;
+                    }
 
-                //Add Group Toggle for first row in a Merged block
-                if (cell.getMergedCellCount() > 1) {
-                    final GridCell<?> nextRowCell = model.getCell(rowIndex + 1,
-                                                                  columnIndex);
-                    if (nextRowCell != null) {
-                        final Group gt = renderGroupedCellToggle(columnWidth,
-                                                                 row.getHeight(),
-                                                                 nextRowCell.isCollapsed());
-                        gt.setX(0).setY(y);
-                        columnGroup.add(gt);
+                    //Add Group Toggle for first row in a Merged block
+                    if (cell.getMergedCellCount() > 1) {
+                        final GridCell<?> nextRowCell = model.getCell(rowIndex + 1,
+                                                                      columnIndex);
+                        if (nextRowCell != null) {
+                            final Group gt = renderGroupedCellToggle(columnWidth,
+                                                                     row.getHeight(),
+                                                                     nextRowCell.isCollapsed());
+                            gt.setX(0).setY(y);
+                            columnGroup.add(gt);
+                        }
+                    }
+
+                    if (cell.getMergedCellCount() > 0) {
+                        //If cell is "lead" i.e. top of a merged block centralize content in cell
+                        final double cellHeight = getCellHeight(rowIndex,
+                                                                model,
+                                                                cell);
+                        final GridBodyCellRenderContext cellContext = new GridBodyCellRenderContext(absoluteColumnX,
+                                                                                                    absoluteGridY + renderer.getHeaderHeight() + visibleRowOffsets.get(rowIndex - minVisibleRowIndex),
+                                                                                                    columnWidth,
+                                                                                                    cellHeight,
+                                                                                                    clipMinY,
+                                                                                                    clipMinX,
+                                                                                                    rowIndex,
+                                                                                                    columnIndex,
+                                                                                                    isFloating,
+                                                                                                    transform,
+                                                                                                    renderer);
+
+                        //Render cell's content
+                        final Group cc = column.getColumnRenderer().renderCell((GridCell) cell,
+                                                                               cellContext);
+                        cc.setX(0).setY(y).setListening(true);
+                        columnGroup.add(cc);
+
+                        //Skip remainder of merged block
+                        rowIndex = rowIndex + cell.getMergedCellCount() - 1;
+                    } else {
+                        //Otherwise the cell has been clipped and we need to back-track to the "lead" cell to centralize content
+                        double _y = y;
+                        int _rowIndex = rowIndex;
+                        GridCell<?> _cell = cell;
+                        while (_cell.getMergedCellCount() == 0) {
+                            _rowIndex--;
+                            _y = _y - model.getRow(_rowIndex).getHeight();
+                            _cell = model.getCell(_rowIndex,
+                                                  columnIndex);
+                        }
+
+                        final double cellHeight = getCellHeight(_rowIndex,
+                                                                model,
+                                                                _cell);
+                        final GridBodyCellRenderContext cellContext = new GridBodyCellRenderContext(absoluteColumnX,
+                                                                                                    absoluteGridY + renderer.getHeaderHeight() + rendererHelper.getRowOffset(_rowIndex),
+                                                                                                    columnWidth,
+                                                                                                    cellHeight,
+                                                                                                    clipMinY,
+                                                                                                    clipMinX,
+                                                                                                    rowIndex,
+                                                                                                    columnIndex,
+                                                                                                    isFloating,
+                                                                                                    transform,
+                                                                                                    renderer);
+
+                        //Render cell's content
+                        final Group cc = column.getColumnRenderer().renderCell((GridCell) _cell,
+                                                                               cellContext);
+                        cc.setX(0).setY(_y).setListening(true);
+                        columnGroup.add(cc);
+
+                        //Skip remainder of merged block
+                        rowIndex = _rowIndex + _cell.getMergedCellCount() - 1;
                     }
                 }
 
-                if (cell.getMergedCellCount() > 0) {
-                    //If cell is "lead" i.e. top of a merged block centralize content in cell
-                    final double cellHeight = getCellHeight(rowIndex,
-                                                            model,
-                                                            cell);
-                    final GridBodyCellRenderContext cellContext = new GridBodyCellRenderContext(absoluteColumnX,
-                                                                                                absoluteGridY + renderer.getHeaderHeight() + visibleRowOffsets.get(rowIndex - minVisibleRowIndex),
-                                                                                                columnWidth,
-                                                                                                cellHeight,
-                                                                                                clipMinY,
-                                                                                                clipMinX,
-                                                                                                rowIndex,
-                                                                                                columnIndex,
-                                                                                                isFloating,
-                                                                                                transform,
-                                                                                                renderer);
+                //Clip Column Group
+                final double gridLinesStrokeWidth = theme.getBodyGridLine().getStrokeWidth();
+                final BoundingBox bb = new BoundingBox(gridLinesStrokeWidth,
+                                                       0,
+                                                       columnWidth - gridLinesStrokeWidth,
+                                                       columnHeight);
+                final IPathClipper clipper = new BoundingBoxPathClipper(bb);
+                columnGroup.setPathClipper(clipper);
+                clipper.setActive(true);
 
-                    //Render cell's content
-                    final Group cc = column.getColumnRenderer().renderCell((GridCell) cell,
-                                                                           cellContext);
-                    cc.setX(0).setY(y).setListening(true);
-                    columnGroup.add(cc);
-
-                    //Skip remainder of merged block
-                    rowIndex = rowIndex + cell.getMergedCellCount() - 1;
-                } else {
-                    //Otherwise the cell has been clipped and we need to back-track to the "lead" cell to centralize content
-                    double _y = y;
-                    int _rowIndex = rowIndex;
-                    GridCell<?> _cell = cell;
-                    while (_cell.getMergedCellCount() == 0) {
-                        _rowIndex--;
-                        _y = _y - model.getRow(_rowIndex).getHeight();
-                        _cell = model.getCell(_rowIndex,
-                                              columnIndex);
-                    }
-
-                    final double cellHeight = getCellHeight(_rowIndex,
-                                                            model,
-                                                            _cell);
-                    final GridBodyCellRenderContext cellContext = new GridBodyCellRenderContext(absoluteColumnX,
-                                                                                                absoluteGridY + renderer.getHeaderHeight() + rendererHelper.getRowOffset(_rowIndex),
-                                                                                                columnWidth,
-                                                                                                cellHeight,
-                                                                                                clipMinY,
-                                                                                                clipMinX,
-                                                                                                rowIndex,
-                                                                                                columnIndex,
-                                                                                                isFloating,
-                                                                                                transform,
-                                                                                                renderer);
-
-                    //Render cell's content
-                    final Group cc = column.getColumnRenderer().renderCell((GridCell) _cell,
-                                                                           cellContext);
-                    cc.setX(0).setY(_y).setListening(true);
-                    columnGroup.add(cc);
-
-                    //Skip remainder of merged block
-                    rowIndex = _rowIndex + _cell.getMergedCellCount() - 1;
-                }
+                rc.getGroup().add(columnGroup);
             }
-
-            //Clip Column Group
-            final double gridLinesStrokeWidth = theme.getBodyGridLine().getStrokeWidth();
-            final BoundingBox bb = new BoundingBox(gridLinesStrokeWidth,
-                                                   0,
-                                                   columnWidth - gridLinesStrokeWidth,
-                                                   columnHeight);
-            final IPathClipper clipper = new BoundingBoxPathClipper(bb);
-            columnGroup.setPathClipper(clipper);
-            clipper.setActive(true);
-
-            parent.add(columnGroup);
         });
 
         return commands;

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/GridRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/GridRenderer.java
@@ -33,10 +33,17 @@ import org.uberfire.mvp.ParameterizedCommand;
  */
 public interface GridRenderer {
 
+    interface GridRendererContext {
+
+        Group getGroup();
+
+        boolean isSelectionLayer();
+    }
+
     /**
      * Generic command to render a component of the grid
      */
-    interface RendererCommand extends ParameterizedCommand<Group> {
+    interface RendererCommand extends ParameterizedCommand<GridRendererContext> {
 
     }
 
@@ -69,13 +76,6 @@ public interface GridRenderer {
     }
 
     /**
-     * Generic command for all body related rendering.
-     */
-    interface RendererBodyCommand extends RendererCommand {
-
-    }
-
-    /**
      * Command to render the "Grid lines" components of the grid header
      */
     interface RenderHeaderGridLinesCommand extends RendererHeaderCommand {
@@ -93,6 +93,13 @@ public interface GridRenderer {
      * Command to render the "content" components of the grid header
      */
     interface RenderHeaderContentCommand extends RendererHeaderCommand {
+
+    }
+
+    /**
+     * Generic command for all body related rendering.
+     */
+    interface RendererBodyCommand extends RendererCommand {
 
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/GridWidgetRegistry.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/GridWidgetRegistry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.layer;
+
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+
+public interface GridWidgetRegistry {
+
+    /**
+     * Registers a {@link GridWidget}
+     * @param gridWidget The {@link GridWidget} to register
+     */
+    void register(final GridWidget gridWidget);
+
+    /**
+     * Deregisters a {@link GridWidget}
+     * @param gridWidget The {@link GridWidget} to deregister
+     */
+    void deregister(final GridWidget gridWidget);
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseBoundsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseBoundsTest.java
@@ -18,7 +18,7 @@ package org.uberfire.ext.wires.core.grids.client.model.impl;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class BaseBoundsTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTransformationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTransformationTest.java
@@ -26,7 +26,9 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.FloatingSelectionsTransformer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.SelectedRange;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class GridCellSelectionsTransformationTest extends BaseGridTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridColumnIndexingTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridColumnIndexingTest.java
@@ -23,7 +23,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class GridColumnIndexingTest extends BaseGridTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridColumnsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridColumnsTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridTest.Expected.build;
 
 public class GridColumnsTest extends BaseGridTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridMergingTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridMergingTest.java
@@ -20,7 +20,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class GridMergingTest extends BaseGridTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilitiesTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridTest;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class ColumnIndexUtilitiesTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
@@ -38,8 +38,15 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridWidgetDnDMouseDownHandlerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseUpHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseUpHandlerTest.java
@@ -28,7 +28,11 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState.GridWidgetHandlersOperation;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridWidgetDnDMouseUpHandlerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimationTest.java
@@ -30,7 +30,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GridWidgetEnterPinnedModeAnimationTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimationTest.java
@@ -31,7 +31,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GridWidgetExitPinnedModeAnimationTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/BooleanDOMElementColumnTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/BooleanDOMElementColumnTest.java
@@ -32,8 +32,10 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.impl.CheckBoxDOMElementFactory;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BooleanDOMElementColumnTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandlerTest.java
@@ -42,8 +42,15 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.Selection
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.BaseCellSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BaseGridWidgetKeyboardHandlerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseClickHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseClickHandlerTest.java
@@ -31,7 +31,13 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BaseGridWidgetMouseClickHandlerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandlerTest.java
@@ -36,7 +36,13 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManage
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BaseGridWidgetMouseDoubleClickHandlerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetRenderingTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetRenderingTest.java
@@ -137,7 +137,7 @@ public class BaseGridWidgetRenderingTest {
         when(renderer.renderHeader(any(GridData.class),
                                    any(GridHeaderRenderContext.class),
                                    eq(rendererHelper),
-                                   any(BaseGridRendererHelper.RenderingInformation.class))).thenReturn(Collections.singletonList((parent) -> parent.add(header)));
+                                   any(BaseGridRendererHelper.RenderingInformation.class))).thenReturn(Collections.singletonList((rc) -> rc.getGroup().add(header)));
     }
 
     @SuppressWarnings("unchecked")
@@ -146,7 +146,7 @@ public class BaseGridWidgetRenderingTest {
         when(renderer.renderBody(any(GridData.class),
                                  any(GridBodyRenderContext.class),
                                  eq(rendererHelper),
-                                 any(BaseGridRendererHelper.RenderingInformation.class))).thenReturn(Collections.singletonList((parent) -> parent.add(body)));
+                                 any(BaseGridRendererHelper.RenderingInformation.class))).thenReturn(Collections.singletonList((rc) -> rc.getGroup().add(body)));
     }
 
     @SuppressWarnings("unchecked")
@@ -154,13 +154,13 @@ public class BaseGridWidgetRenderingTest {
         when(selections.asNode()).thenReturn(mock(Node.class));
         when(renderer.renderSelectedCells(any(GridData.class),
                                           any(GridBodyRenderContext.class),
-                                          eq(rendererHelper))).thenReturn((parent) -> parent.add(selections));
+                                          eq(rendererHelper))).thenReturn((rc) -> rc.getGroup().add(selections));
     }
 
     @SuppressWarnings("unchecked")
     private void mockBoundary() {
         when(boundary.asNode()).thenReturn(mock(Node.class));
-        when(renderer.renderGridBoundary(any(GridBoundaryRenderContext.class))).thenReturn((parent) -> parent.add(boundary));
+        when(renderer.renderGridBoundary(any(GridBoundaryRenderContext.class))).thenReturn((rc) -> rc.getGroup().add(boundary));
     }
 
     @Test
@@ -189,11 +189,9 @@ public class BaseGridWidgetRenderingTest {
         verify(column,
                times(1)).freeUnusedResources();
         verify(gridWidget,
-               times(1)).drawHeader(eq(ri),
-                                    eq(false));
+               times(1)).drawHeader(eq(ri));
         verify(gridWidget,
-               times(1)).drawBody(eq(ri),
-                                  eq(false));
+               times(1)).drawBody(eq(ri));
     }
 
     @Test
@@ -221,10 +219,8 @@ public class BaseGridWidgetRenderingTest {
         verify(column,
                times(1)).freeUnusedResources();
         verify(gridWidget,
-               times(1)).drawHeader(eq(ri),
-                                    eq(false));
+               times(1)).drawHeader(eq(ri));
         verify(gridWidget,
-               never()).drawBody(any(BaseGridRendererHelper.RenderingInformation.class),
-                                 any(Boolean.class));
+               never()).drawBody(any(BaseGridRendererHelper.RenderingInformation.class));
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetTest.java
@@ -32,8 +32,11 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.Selection
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BaseGridWidgetTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/GridCellSelectorMouseClickHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/GridCellSelectorMouseClickHandlerTest.java
@@ -39,7 +39,14 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelec
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridCellSelectorMouseClickHandlerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererNonSelectionLayerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererNonSelectionLayerTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import com.ait.lienzo.client.core.shape.Line;
+import com.ait.lienzo.client.core.shape.MultiPath;
+import com.ait.lienzo.client.core.shape.Rectangle;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyColumnRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBoundaryRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderColumnRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderBodyGridBackgroundCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderGridBoundaryCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderHeaderBackgroundCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderHeaderGridLinesCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderSelectorCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RendererCommand;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils.ROW_HEIGHT;
+import static org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils.makeRenderingInformation;
+
+@WithClassesToStub({Text.class})
+@RunWith(LienzoMockitoTestRunner.class)
+public class BaseGridRendererNonSelectionLayerTest extends BaseGridRendererTest {
+
+    @Override
+    protected boolean isSelectionLayer() {
+        return false;
+    }
+
+    @Test
+    public void checkRenderSelector() {
+        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
+                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
+
+        final RendererCommand command = renderer.renderSelector(WIDTH,
+                                                                HEIGHT,
+                                                                ri);
+
+        assertNotNull(command);
+        assertRenderingCommands(Collections.singletonList(command),
+                                RenderSelectorCommand.class);
+
+        command.execute(rc);
+
+        final ArgumentCaptor<MultiPath> selectorCaptor = ArgumentCaptor.forClass(MultiPath.class);
+        verify(parent).add(selectorCaptor.capture());
+
+        final MultiPath selector = selectorCaptor.getValue();
+        assertEquals(WIDTH,
+                     selector.getBoundingBox().getWidth(),
+                     0.5);
+        assertEquals(HEIGHT,
+                     selector.getBoundingBox().getHeight(),
+                     0.5);
+    }
+
+    @Test
+    public void checkSelectedCellsClippedByHeader() {
+        checkRenderedSelectedCells(0,
+                                   0,
+                                   1,
+                                   3,
+                                   1,
+                                   2);
+    }
+
+    @Test
+    public void checkSelectedCellsNotClippedByHeader() {
+        checkRenderedSelectedCells(0,
+                                   0,
+                                   1,
+                                   3,
+                                   0,
+                                   2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRenderHeader() {
+        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
+                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
+        final GridHeaderRenderContext context = mock(GridHeaderRenderContext.class);
+        doReturn(model.getColumns()).when(context).getAllColumns();
+        doReturn(model.getColumns()).when(context).getBlockColumns();
+
+        final List<RendererCommand> commands = renderer.renderHeader(model,
+                                                                     context,
+                                                                     rendererHelper,
+                                                                     ri);
+        assertThat(commands).isNotNull();
+        assertThat(commands).asList().hasSize(2);
+        assertRenderingCommands(commands,
+                                RenderHeaderBackgroundCommand.class, RenderHeaderGridLinesCommand.class);
+
+        //Check the ColumnRenderer was asked to contribute towards the rendering
+        //It is mocked in this test and hence we cannot verify it actually did anything.
+        verify(columnRenderer).renderHeader(anyList(),
+                                            any(GridHeaderColumnRenderContext.class),
+                                            eq(ri),
+                                            any(BiFunction.class));
+
+        //Notional check for background rendering
+        final ArgumentCaptor<Rectangle> rectangleCaptor = ArgumentCaptor.forClass(Rectangle.class);
+
+        commands.stream().filter(c -> c instanceof RenderHeaderBackgroundCommand).findFirst().ifPresent(c -> c.execute(rc));
+
+        verify(parent).add(rectangleCaptor.capture());
+
+        assertRenderedRectangle(rectangleCaptor.getValue(),
+                                column.getWidth(),
+                                BaseGridWidgetRenderingTestUtils.HEADER_HEIGHT);
+
+        //Notional check for header/body divider
+        reset(parent);
+        final ArgumentCaptor<Line> lineCaptor = ArgumentCaptor.forClass(Line.class);
+
+        commands.stream().filter(c -> c instanceof RenderHeaderGridLinesCommand).findFirst().ifPresent(c -> c.execute(rc));
+
+        verify(parent).add(lineCaptor.capture());
+
+        final Line line = lineCaptor.getValue();
+        assertEquals(column.getWidth(),
+                     line.getBoundingBox().getWidth(),
+                     0.5);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRenderBody() {
+        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
+                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
+        final GridBodyRenderContext context = mock(GridBodyRenderContext.class);
+        doReturn(0).when(context).getMinVisibleRowIndex();
+        doReturn(model.getRowCount() - 1).when(context).getMaxVisibleRowIndex();
+        doReturn(model.getColumns()).when(context).getBlockColumns();
+
+        final List<RendererCommand> commands = renderer.renderBody(model,
+                                                                   context,
+                                                                   rendererHelper,
+                                                                   ri);
+        assertThat(commands).isNotNull();
+        assertThat(commands).asList().hasSize(1);
+        assertThat(commands).asList().hasOnlyOneElementSatisfying(o -> assertTrue(o instanceof RenderBodyGridBackgroundCommand));
+
+        //Check the ColumnRenderer was asked to contribute towards the rendering
+        //It is mocked in this test and hence we cannot verify it actually did anything.
+        verify(columnRenderer).renderColumn(eq(column),
+                                            any(GridBodyColumnRenderContext.class),
+                                            eq(rendererHelper),
+                                            eq(ri),
+                                            any(BiFunction.class));
+
+        //Notional check for background rendering
+        final ArgumentCaptor<Rectangle> rectangleCaptor = ArgumentCaptor.forClass(Rectangle.class);
+
+        commands.get(0).execute(rc);
+
+        verify(parent).add(rectangleCaptor.capture());
+
+        assertRenderedRectangle(rectangleCaptor.getValue(),
+                                column.getWidth(),
+                                ri.getVisibleRowOffsets().get(2) + ROW_HEIGHT);
+    }
+
+    @Test
+    public void checkRenderBoundary() {
+        final double WIDTH = 100.0;
+        final double HEIGHT = 200.0;
+        final GridBoundaryRenderContext context = new GridBoundaryRenderContext(0, 0, WIDTH, HEIGHT);
+
+        final RendererCommand command = renderer.renderGridBoundary(context);
+
+        assertNotNull(command);
+        assertRenderingCommands(Collections.singletonList(command),
+                                RenderGridBoundaryCommand.class);
+
+        command.execute(rc);
+
+        final ArgumentCaptor<Rectangle> boundaryCaptor = ArgumentCaptor.forClass(Rectangle.class);
+        verify(parent).add(boundaryCaptor.capture());
+
+        assertRenderedRectangle(boundaryCaptor.getValue(),
+                                WIDTH,
+                                HEIGHT);
+    }
+
+    private void checkRenderedSelectedCells(final int selectionRowIndex,
+                                            final int selectionColumnIndex,
+                                            final int selectionColumnCount,
+                                            final int selectionRowCount,
+                                            final int minVisibleRowIndex,
+                                            final int maxVisibleRowIndex) {
+        this.model.selectCells(selectionRowIndex,
+                               selectionColumnIndex,
+                               selectionColumnCount,
+                               selectionRowCount);
+        when(context.getMinVisibleRowIndex()).thenReturn(minVisibleRowIndex);
+        when(context.getMaxVisibleRowIndex()).thenReturn(maxVisibleRowIndex);
+
+        renderer.renderSelectedCells(model,
+                                     context,
+                                     rendererHelper).execute(rc);
+
+        verify(renderer,
+               times(1)).renderSelectedRange(eq(model),
+                                             columnsCaptor.capture(),
+                                             eq(selectionColumnIndex),
+                                             selectedRangeCaptor.capture());
+
+        final List<GridColumn<?>> columns = columnsCaptor.getValue();
+        assertNotNull(columns);
+        assertEquals(1,
+                     columns.size());
+        assertEquals(column,
+                     columns.get(0));
+
+        final SelectedRange selectedRange = selectedRangeCaptor.getValue();
+        assertNotNull(selectedRange);
+        assertEquals(selectionColumnIndex,
+                     selectedRange.getUiColumnIndex());
+        assertEquals(minVisibleRowIndex,
+                     selectedRange.getUiRowIndex());
+        assertEquals(selectionColumnCount,
+                     selectedRange.getWidth());
+        assertEquals(maxVisibleRowIndex - minVisibleRowIndex + 1,
+                     selectedRange.getHeight());
+    }
+
+    @SafeVarargs
+    private final void assertRenderingCommands(final List<RendererCommand> actualCommands,
+                                               final Class<? extends RendererCommand>... expectedTypes) {
+        assertThat(actualCommands).asList().hasOnlyElementsOfTypes(expectedTypes);
+        Arrays.asList(expectedTypes).forEach(type -> assertThat(actualCommands).asList().filteredOn(type::isInstance).hasSize(1));
+    }
+
+    private void assertRenderedRectangle(final Rectangle rectangle,
+                                         final double expectedWidth,
+                                         final double expectedHeight) {
+        assertEquals(expectedWidth,
+                     rectangle.getWidth(),
+                     0.5);
+        assertEquals(expectedHeight,
+                     rectangle.getHeight(),
+                     0.5);
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererSelectionLayerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererSelectionLayerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyColumnRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBoundaryRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderColumnRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderBodyGridBackgroundCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderGridBoundaryCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderHeaderBackgroundCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderHeaderGridLinesCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderSelectorCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RendererCommand;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils.ROW_HEIGHT;
+import static org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils.makeRenderingInformation;
+
+@WithClassesToStub({Text.class})
+@RunWith(LienzoMockitoTestRunner.class)
+public class BaseGridRendererSelectionLayerTest extends BaseGridRendererTest {
+
+    @Override
+    protected boolean isSelectionLayer() {
+        return true;
+    }
+
+    @Test
+    public void checkRenderSelector() {
+        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
+                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
+
+        final RendererCommand command = renderer.renderSelector(WIDTH,
+                                                                HEIGHT,
+                                                                ri);
+
+        assertNotNull(command);
+        assertRenderingCommands(Collections.singletonList(command),
+                                RenderSelectorCommand.class);
+
+        command.execute(rc);
+
+        verify(parent, never()).add(anyObject());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkSelectedCells() {
+        this.model.selectCells(0, 0, 1, 1);
+        when(context.getMinVisibleRowIndex()).thenReturn(0);
+        when(context.getMaxVisibleRowIndex()).thenReturn(1);
+
+        renderer.renderSelectedCells(model,
+                                     context,
+                                     rendererHelper).execute(rc);
+
+        verify(renderer, never()).renderSelectedRange(any(GridData.class),
+                                                      anyList(),
+                                                      anyInt(),
+                                                      any(SelectedRange.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRenderHeader() {
+        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
+                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
+        final GridHeaderRenderContext context = mock(GridHeaderRenderContext.class);
+        doReturn(model.getColumns()).when(context).getAllColumns();
+        doReturn(model.getColumns()).when(context).getBlockColumns();
+
+        final List<RendererCommand> commands = renderer.renderHeader(model,
+                                                                     context,
+                                                                     rendererHelper,
+                                                                     ri);
+        assertThat(commands).isNotNull();
+        assertThat(commands).asList().hasSize(2);
+        assertRenderingCommands(commands,
+                                RenderHeaderBackgroundCommand.class, RenderHeaderGridLinesCommand.class);
+
+        //Check the ColumnRenderer was asked to contribute towards the rendering
+        //It is mocked in this test and hence we cannot verify it actually did anything.
+        verify(columnRenderer).renderHeader(anyList(),
+                                            any(GridHeaderColumnRenderContext.class),
+                                            eq(ri),
+                                            any(BiFunction.class));
+
+        //Notional check for background rendering
+        commands.stream().filter(c -> c instanceof RenderHeaderBackgroundCommand).findFirst().ifPresent(c -> c.execute(rc));
+        verify(parent, never()).add(anyObject());
+
+        //Notional check for header/body divider
+        reset(parent);
+        commands.stream().filter(c -> c instanceof RenderHeaderGridLinesCommand).findFirst().ifPresent(c -> c.execute(rc));
+        verify(parent, never()).add(anyObject());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRenderBody() {
+        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
+                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
+        final GridBodyRenderContext context = mock(GridBodyRenderContext.class);
+        doReturn(0).when(context).getMinVisibleRowIndex();
+        doReturn(model.getRowCount() - 1).when(context).getMaxVisibleRowIndex();
+        doReturn(model.getColumns()).when(context).getBlockColumns();
+
+        final List<RendererCommand> commands = renderer.renderBody(model,
+                                                                   context,
+                                                                   rendererHelper,
+                                                                   ri);
+        assertThat(commands).isNotNull();
+        assertThat(commands).asList().hasSize(1);
+        assertThat(commands).asList().hasOnlyOneElementSatisfying(o -> assertTrue(o instanceof RenderBodyGridBackgroundCommand));
+
+        //Check the ColumnRenderer was asked to contribute towards the rendering
+        //It is mocked in this test and hence we cannot verify it actually did anything.
+        verify(columnRenderer).renderColumn(eq(column),
+                                            any(GridBodyColumnRenderContext.class),
+                                            eq(rendererHelper),
+                                            eq(ri),
+                                            any(BiFunction.class));
+
+        commands.get(0).execute(rc);
+
+        verify(parent, never()).add(anyObject());
+    }
+
+    @Test
+    public void checkRenderBoundary() {
+        final double WIDTH = 100.0;
+        final double HEIGHT = 200.0;
+        final GridBoundaryRenderContext context = new GridBoundaryRenderContext(0, 0, WIDTH, HEIGHT);
+
+        final RendererCommand command = renderer.renderGridBoundary(context);
+
+        assertNotNull(command);
+        assertRenderingCommands(Collections.singletonList(command),
+                                RenderGridBoundaryCommand.class);
+
+        command.execute(rc);
+
+        verify(parent, never()).add(anyObject());
+    }
+
+    @SafeVarargs
+    private final void assertRenderingCommands(final List<RendererCommand> actualCommands,
+                                               final Class<? extends RendererCommand>... expectedTypes) {
+        assertThat(actualCommands).asList().hasOnlyElementsOfTypes(expectedTypes);
+        Arrays.asList(expectedTypes).forEach(type -> assertThat(actualCommands).asList().filteredOn(type::isInstance).hasSize(1));
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,22 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import com.ait.lienzo.client.core.shape.Group;
-import com.ait.lienzo.client.core.shape.Line;
-import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.shape.Rectangle;
-import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import com.google.gwtmockito.WithClassesToStub;
-import org.gwtbootstrap3.client.ui.html.Text;
 import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -37,70 +29,55 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
-import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyColumnRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyRenderContext;
-import org.uberfire.ext.wires.core.grids.client.widget.context.GridBoundaryRenderContext;
-import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderColumnRenderContext;
-import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.StringPopupColumn;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderBodyGridBackgroundCommand;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderGridBoundaryCommand;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderHeaderBackgroundCommand;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderHeaderGridLinesCommand;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RenderSelectorCommand;
-import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.RendererCommand;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer.GridRendererContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.SelectionsTransformer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.GridRendererTheme;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.impl.BlueTheme;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils.ROW_HEIGHT;
-import static org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils.makeRenderingInformation;
 
-@WithClassesToStub({Text.class})
-@RunWith(LienzoMockitoTestRunner.class)
-public class BaseGridRendererTest {
+public abstract class BaseGridRendererTest {
 
-    @Mock
-    private GridColumnRenderer<String> columnRenderer;
+    protected static final double WIDTH = 100.0;
+
+    protected static final double HEIGHT = 200.0;
 
     @Mock
-    private GridBodyRenderContext context;
+    protected GridColumnRenderer<String> columnRenderer;
 
     @Mock
-    private BaseGridRendererHelper rendererHelper;
+    protected GridBodyRenderContext context;
+
+    @Mock
+    protected BaseGridRendererHelper rendererHelper;
+
+    @Mock
+    protected Group parent;
+
+    @Mock
+    protected GridRendererContext rc;
 
     @Captor
-    private ArgumentCaptor<List<GridColumn<?>>> columnsCaptor;
+    protected ArgumentCaptor<List<GridColumn<?>>> columnsCaptor;
 
     @Captor
-    private ArgumentCaptor<SelectedRange> selectedRangeCaptor;
+    protected ArgumentCaptor<SelectedRange> selectedRangeCaptor;
 
-    private GridData model;
+    protected GridData model;
 
-    private GridColumn<String> column;
+    protected GridColumn<String> column;
 
-    private SelectionsTransformer selectionsTransformer;
+    protected SelectionsTransformer selectionsTransformer;
 
-    private GridRendererTheme theme = new BlueTheme();
+    protected GridRendererTheme theme = new BlueTheme();
 
-    private BaseGridRenderer renderer;
+    protected BaseGridRenderer renderer;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -124,225 +101,10 @@ public class BaseGridRendererTest {
         when(context.getBlockColumns()).thenReturn(Collections.singletonList(column));
         when(context.getTransformer()).thenReturn(selectionsTransformer);
         doCallRealMethod().when(rendererHelper).getWidth(anyList());
+
+        when(rc.getGroup()).thenReturn(parent);
+        when(rc.isSelectionLayer()).thenReturn(isSelectionLayer());
     }
 
-    @Test
-    public void checkRenderSelector() {
-        final double WIDTH = 100.0;
-        final double HEIGHT = 200.0;
-        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
-                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
-
-        final RendererCommand command = renderer.renderSelector(WIDTH,
-                                                                HEIGHT,
-                                                                ri);
-
-        assertNotNull(command);
-        assertRenderingCommands(Collections.singletonList(command),
-                                RenderSelectorCommand.class);
-
-        final Group parent = mock(Group.class);
-        command.execute(parent);
-
-        final ArgumentCaptor<MultiPath> selectorCaptor = ArgumentCaptor.forClass(MultiPath.class);
-        verify(parent).add(selectorCaptor.capture());
-
-        final MultiPath selector = selectorCaptor.getValue();
-        assertEquals(WIDTH,
-                     selector.getBoundingBox().getWidth(),
-                     0.5);
-        assertEquals(HEIGHT,
-                     selector.getBoundingBox().getHeight(),
-                     0.5);
-    }
-
-    @Test
-    public void checkSelectedCellsClippedByHeader() {
-        checkRenderedSelectedCells(0,
-                                   0,
-                                   1,
-                                   3,
-                                   1,
-                                   2);
-    }
-
-    @Test
-    public void checkSelectedCellsNotClippedByHeader() {
-        checkRenderedSelectedCells(0,
-                                   0,
-                                   1,
-                                   3,
-                                   0,
-                                   2);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void checkRenderHeader() {
-        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
-                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
-        final GridHeaderRenderContext context = mock(GridHeaderRenderContext.class);
-        doReturn(model.getColumns()).when(context).getAllColumns();
-        doReturn(model.getColumns()).when(context).getBlockColumns();
-
-        final List<RendererCommand> commands = renderer.renderHeader(model,
-                                                                     context,
-                                                                     rendererHelper,
-                                                                     ri);
-        assertThat(commands).isNotNull();
-        assertThat(commands).asList().hasSize(2);
-        assertRenderingCommands(commands,
-                                RenderHeaderBackgroundCommand.class, RenderHeaderGridLinesCommand.class);
-
-        //Check the ColumnRenderer was asked to contribute towards the rendering
-        //It is mocked in this test and hence we cannot verify it actually did anything.
-        verify(columnRenderer).renderHeader(anyList(),
-                                            any(GridHeaderColumnRenderContext.class),
-                                            eq(ri));
-
-        //Notional check for background rendering
-        final ArgumentCaptor<Rectangle> rectangleCaptor = ArgumentCaptor.forClass(Rectangle.class);
-        final Group parent = mock(Group.class);
-
-        commands.stream().filter(c -> c instanceof RenderHeaderBackgroundCommand).findFirst().ifPresent(c -> c.execute(parent));
-
-        verify(parent).add(rectangleCaptor.capture());
-
-        assertRenderedRectangle(rectangleCaptor.getValue(),
-                                column.getWidth(),
-                                BaseGridWidgetRenderingTestUtils.HEADER_HEIGHT);
-
-        //Notional check for header/body divider
-        reset(parent);
-        final ArgumentCaptor<Line> lineCaptor = ArgumentCaptor.forClass(Line.class);
-
-        commands.stream().filter(c -> c instanceof RenderHeaderGridLinesCommand).findFirst().ifPresent(c -> c.execute(parent));
-
-        verify(parent).add(lineCaptor.capture());
-
-        final Line line = lineCaptor.getValue();
-        assertEquals(column.getWidth(),
-                     line.getBoundingBox().getWidth(),
-                     0.5);
-    }
-
-    @Test
-    public void checkRenderBody() {
-        final BaseGridRendererHelper.RenderingInformation ri = makeRenderingInformation(model,
-                                                                                        Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2));
-        final GridBodyRenderContext context = mock(GridBodyRenderContext.class);
-        doReturn(0).when(context).getMinVisibleRowIndex();
-        doReturn(model.getRowCount() - 1).when(context).getMaxVisibleRowIndex();
-        doReturn(model.getColumns()).when(context).getBlockColumns();
-
-        final List<RendererCommand> commands = renderer.renderBody(model,
-                                                                   context,
-                                                                   rendererHelper,
-                                                                   ri);
-        assertThat(commands).isNotNull();
-        assertThat(commands).asList().hasSize(1);
-        assertThat(commands).asList().hasOnlyOneElementSatisfying(o -> assertTrue(o instanceof RenderBodyGridBackgroundCommand));
-
-        //Check the ColumnRenderer was asked to contribute towards the rendering
-        //It is mocked in this test and hence we cannot verify it actually did anything.
-        verify(columnRenderer).renderColumn(eq(column),
-                                            any(GridBodyColumnRenderContext.class),
-                                            eq(rendererHelper),
-                                            eq(ri));
-
-        //Notional check for background rendering
-        final ArgumentCaptor<Rectangle> rectangleCaptor = ArgumentCaptor.forClass(Rectangle.class);
-        final Group parent = mock(Group.class);
-
-        commands.get(0).execute(parent);
-
-        verify(parent).add(rectangleCaptor.capture());
-
-        assertRenderedRectangle(rectangleCaptor.getValue(),
-                                column.getWidth(),
-                                ri.getVisibleRowOffsets().get(2) + ROW_HEIGHT);
-    }
-
-    @Test
-    public void checkRenderBoundary() {
-        final double WIDTH = 100.0;
-        final double HEIGHT = 200.0;
-        final GridBoundaryRenderContext context = new GridBoundaryRenderContext(0, 0, WIDTH, HEIGHT);
-
-        final RendererCommand command = renderer.renderGridBoundary(context);
-
-        assertNotNull(command);
-        assertRenderingCommands(Collections.singletonList(command),
-                                RenderGridBoundaryCommand.class);
-
-        final Group parent = mock(Group.class);
-        command.execute(parent);
-
-        final ArgumentCaptor<Rectangle> boundaryCaptor = ArgumentCaptor.forClass(Rectangle.class);
-        verify(parent).add(boundaryCaptor.capture());
-
-        assertRenderedRectangle(boundaryCaptor.getValue(),
-                                WIDTH,
-                                HEIGHT);
-    }
-
-    private void checkRenderedSelectedCells(final int selectionRowIndex,
-                                            final int selectionColumnIndex,
-                                            final int selectionColumnCount,
-                                            final int selectionRowCount,
-                                            final int minVisibleRowIndex,
-                                            final int maxVisibleRowIndex) {
-        this.model.selectCells(selectionRowIndex,
-                               selectionColumnIndex,
-                               selectionColumnCount,
-                               selectionRowCount);
-        when(context.getMinVisibleRowIndex()).thenReturn(minVisibleRowIndex);
-        when(context.getMaxVisibleRowIndex()).thenReturn(maxVisibleRowIndex);
-
-        renderer.renderSelectedCells(model,
-                                     context,
-                                     rendererHelper).execute(mock(Group.class));
-
-        verify(renderer,
-               times(1)).renderSelectedRange(eq(model),
-                                             columnsCaptor.capture(),
-                                             eq(selectionColumnIndex),
-                                             selectedRangeCaptor.capture());
-
-        final List<GridColumn<?>> columns = columnsCaptor.getValue();
-        assertNotNull(columns);
-        assertEquals(1,
-                     columns.size());
-        assertEquals(column,
-                     columns.get(0));
-
-        final SelectedRange selectedRange = selectedRangeCaptor.getValue();
-        assertNotNull(selectedRange);
-        assertEquals(selectionColumnIndex,
-                     selectedRange.getUiColumnIndex());
-        assertEquals(minVisibleRowIndex,
-                     selectedRange.getUiRowIndex());
-        assertEquals(selectionColumnCount,
-                     selectedRange.getWidth());
-        assertEquals(maxVisibleRowIndex - minVisibleRowIndex + 1,
-                     selectedRange.getHeight());
-    }
-
-    @SafeVarargs
-    private final void assertRenderingCommands(final List<RendererCommand> actualCommands,
-                                               final Class<? extends RendererCommand>... expectedTypes) {
-        assertThat(actualCommands).asList().hasOnlyElementsOfTypes(expectedTypes);
-        Arrays.asList(expectedTypes).forEach(type -> assertThat(actualCommands).asList().filteredOn(type::isInstance).hasSize(1));
-    }
-
-    private void assertRenderedRectangle(final Rectangle rectangle,
-                                         final double expectedWidth,
-                                         final double expectedHeight) {
-        assertEquals(expectedWidth,
-                     rectangle.getWidth(),
-                     0.5);
-        assertEquals(expectedHeight,
-                     rectangle.getHeight(),
-                     0.5);
-    }
+    protected abstract boolean isSelectionLayer();
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/SelectionExtensionTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/SelectionExtensionTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class SelectionExtensionTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManagerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManagerTest.java
@@ -45,8 +45,14 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelec
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.SelectionExtension;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BaseCellSelectionManagerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RangeSelectionStrategyMergedDataTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RangeSelectionStrategyMergedDataTest.java
@@ -22,7 +22,8 @@ import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridData.SelectedCell;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RangeSelectionStrategyMergedDataTest extends BaseCellSelectionStrategyTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RangeSelectionStrategyUnmergedDataTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RangeSelectionStrategyUnmergedDataTest.java
@@ -23,7 +23,8 @@ import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridData.SelectedCell;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RangeSelectionStrategyUnmergedDataTest extends BaseCellSelectionStrategyTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RowSelectionStrategyMergedDataTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RowSelectionStrategyMergedDataTest.java
@@ -22,7 +22,8 @@ import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridData.SelectedCell;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RowSelectionStrategyMergedDataTest extends BaseCellSelectionStrategyTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RowSelectionStrategyUnmergedDataTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/RowSelectionStrategyUnmergedDataTest.java
@@ -23,7 +23,8 @@ import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridData.SelectedCell;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.CellSelectionStrategy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RowSelectionStrategyUnmergedDataTest extends BaseCellSelectionStrategyTest {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayerTest.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import com.ait.lienzo.client.core.mediator.Mediators;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.Layer;
+import com.ait.lienzo.client.core.shape.Node;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Transform;
 import com.ait.lienzo.client.widget.LienzoPanel;
@@ -35,11 +36,19 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
-import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.DefaultPinnedModeManager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class DefaultGridLayerTest {
@@ -53,7 +62,7 @@ public class DefaultGridLayerTest {
     @Mock
     private Mediators mediators;
 
-    private GridLayer gridLayer;
+    private DefaultGridLayer gridLayer;
 
     private Transform transform;
 
@@ -260,5 +269,61 @@ public class DefaultGridLayerTest {
                      connectors.size());
         assertEquals(isVisible,
                      connectors.iterator().next().isVisible());
+    }
+
+    @Test
+    public void testRegister() {
+        final GridWidget gridWidget1 = mock(GridWidget.class);
+        final GridWidget gridWidget2 = mock(GridWidget.class);
+
+        gridLayer.register(gridWidget1);
+
+        assertThat(gridLayer.getGridWidgets().size()).isEqualTo(1);
+        assertThat(gridLayer.getGridWidgets()).contains(gridWidget1);
+
+        gridLayer.register(gridWidget2);
+
+        assertThat(gridLayer.getGridWidgets().size()).isEqualTo(2);
+        assertThat(gridLayer.getGridWidgets()).contains(gridWidget1, gridWidget2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRegisterAndAddAsPrimitive() {
+        final GridWidget gridWidget1 = mock(GridWidget.class);
+        final GridWidget gridWidget2 = mock(GridWidget.class);
+        when(gridWidget1.asNode()).thenReturn(mock(Node.class));
+        when(gridWidget1.getModel()).thenReturn(new BaseGridData());
+
+        gridLayer.add(gridWidget1);
+
+        assertThat(gridLayer.getGridWidgets().size()).isEqualTo(1);
+        assertThat(gridLayer.getGridWidgets()).contains(gridWidget1);
+
+        gridLayer.register(gridWidget2);
+
+        assertThat(gridLayer.getGridWidgets().size()).isEqualTo(2);
+        assertThat(gridLayer.getGridWidgets()).contains(gridWidget1, gridWidget2);
+    }
+
+    @Test
+    public void testDeregister() {
+        final GridWidget gridWidget1 = mock(GridWidget.class);
+        final GridWidget gridWidget2 = mock(GridWidget.class);
+
+        gridLayer.register(gridWidget1);
+        gridLayer.register(gridWidget2);
+
+        assertThat(gridLayer.getGridWidgets().size()).isEqualTo(2);
+        assertThat(gridLayer.getGridWidgets()).contains(gridWidget1, gridWidget2);
+
+        gridLayer.deregister(gridWidget1);
+
+        assertThat(gridLayer.getGridWidgets().size()).isEqualTo(1);
+        assertThat(gridLayer.getGridWidgets()).contains(gridWidget2);
+
+        gridLayer.deregister(gridWidget2);
+
+        assertThat(gridLayer.getGridWidgets()).isEmpty();
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManagerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManagerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager.PrioritizedCommand;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridLayerRedrawManagerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanelTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanelTest.java
@@ -32,7 +32,14 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.scrollbars.GridLienzoScrollHandler;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridLienzoPanelTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/BoundaryMousePanMediatorTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/BoundaryMousePanMediatorTest.java
@@ -39,8 +39,14 @@ import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BoundaryMousePanMediatorTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/BoundaryTransformMediatorTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/BoundaryTransformMediatorTest.java
@@ -24,7 +24,8 @@ import org.junit.runner.RunWith;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class BoundaryTransformMediatorTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/DefaultPinnedModeManagerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/DefaultPinnedModeManagerTest.java
@@ -35,8 +35,13 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMediator;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class DefaultPinnedModeManagerTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/GridTransformMediatorTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/GridTransformMediatorTest.java
@@ -26,8 +26,9 @@ import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridTransformMediatorTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/RestrictedMousePanMediatorTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/RestrictedMousePanMediatorTest.java
@@ -33,8 +33,16 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class RestrictedMousePanMediatorTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBarsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBarsTest.java
@@ -25,8 +25,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GridLienzoScrollBarsTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBoundsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBoundsTest.java
@@ -31,8 +31,13 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridLienzoScrollBoundsTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
@@ -41,8 +41,18 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLay
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyDouble;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.uberfire.ext.wires.core.grids.client.widget.scrollbars.GridLienzoScrollHandler.DEFAULT_INTERNAL_SCROLL_HEIGHT;
 import static org.uberfire.ext.wires.core.grids.client.widget.scrollbars.GridLienzoScrollHandler.DEFAULT_INTERNAL_SCROLL_WIDTH;
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollPositionTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollPositionTest.java
@@ -26,8 +26,12 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GridLienzoScrollPositionTest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollUITest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollUITest.java
@@ -26,9 +26,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class GridLienzoScrollUITest {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/demo/grids/WiresGridsDemoPresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/demo/grids/WiresGridsDemoPresenter.java
@@ -405,33 +405,35 @@ public class WiresGridsDemoPresenter implements WiresGridsDemoView.Presenter {
                                                               public RendererCommand renderSelector(final double width,
                                                                                                     final double height,
                                                                                                     final BaseGridRendererHelper.RenderingInformation renderingInformation) {
-                                                                  return (RenderSelectorCommand) (parent) -> {
-                                                                      final Group g = new Group();
-                                                                      final Bounds bounds = getSelectorBounds(width,
-                                                                                                              height,
-                                                                                                              renderingInformation);
+                                                                  return (RenderSelectorCommand) (rc) -> {
+                                                                      if (!rc.isSelectionLayer()) {
+                                                                          final Group g = new Group();
+                                                                          final Bounds bounds = getSelectorBounds(width,
+                                                                                                                  height,
+                                                                                                                  renderingInformation);
 
-                                                                      final MultiPath selector = theme.getSelector()
-                                                                              .M(bounds.getX() + 0.5,
-                                                                                 bounds.getY() + 0.5)
-                                                                              .L(bounds.getX() + 0.5,
-                                                                                 height)
-                                                                              .L(width,
-                                                                                 height)
-                                                                              .L(width,
-                                                                                 bounds.getY() + 0.5)
-                                                                              .L(bounds.getX() + 0.5,
-                                                                                 bounds.getY() + 0.5)
-                                                                              .setListening(false);
-                                                                      g.add(selector);
+                                                                          final MultiPath selector = theme.getSelector()
+                                                                                  .M(bounds.getX() + 0.5,
+                                                                                     bounds.getY() + 0.5)
+                                                                                  .L(bounds.getX() + 0.5,
+                                                                                     height)
+                                                                                  .L(width,
+                                                                                     height)
+                                                                                  .L(width,
+                                                                                     bounds.getY() + 0.5)
+                                                                                  .L(bounds.getX() + 0.5,
+                                                                                     bounds.getY() + 0.5)
+                                                                                  .setListening(false);
+                                                                          g.add(selector);
 
-                                                                      final Text t = theme.getHeaderText();
-                                                                      t.setText(translationService.getTranslation(WiresGridsDemoConstants.GridWidget4_Selector_Caption));
-                                                                      t.setX(bounds.getWidth() / 2);
-                                                                      t.setY(bounds.getY() - renderingInformation.getHeaderRowsYOffset() / 2);
-                                                                      g.add(t);
+                                                                          final Text t = theme.getHeaderText();
+                                                                          t.setText(translationService.getTranslation(WiresGridsDemoConstants.GridWidget4_Selector_Caption));
+                                                                          t.setX(bounds.getWidth() / 2);
+                                                                          t.setY(bounds.getY() - renderingInformation.getHeaderRowsYOffset() / 2);
+                                                                          g.add(t);
 
-                                                                      parent.add(g);
+                                                                          rc.getGroup().add(g);
+                                                                      }
                                                                   };
                                                               }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-2332

This PR changes rendering to re-use the existing commands when rendering to Lienzo's "selection layer". It also adds support for editors (most notably the DMN Editor) to register additional ```GridWidget```s (rather than traverse the data-model looking for nested grids - see change in related ```kie-wb-common``` PR). These two changes improve performance.