### PR TITLE
AF-1036: implement sanitized number input

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/SanitizedNumberInput.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/SanitizedNumberInput.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.widgets;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.IsElement;
+import org.jboss.errai.common.client.dom.EventListener;
+import org.jboss.errai.common.client.dom.KeyboardEvent;
+import org.jboss.errai.common.client.dom.NumberInput;
+
+@Dependent
+public class SanitizedNumberInput implements IsElement {
+
+    @Inject
+    NumberInput input;
+
+    private boolean allowNegative = false;
+    private boolean allowDecimal = false;
+
+    public void init() {
+        init("0", null, false, false);
+    }
+
+    public void init(final String min, final String step) {
+        init(min, step, false, false);
+    }
+
+    public void init(final String min, final String step, final boolean allowNegative, final boolean allowDecimal) {
+        if (min != null) {
+            input.setAttribute("min", min);
+        }
+        if (step != null) {
+            input.setAttribute("step", step);
+        }
+        this.allowDecimal = allowDecimal || (step != null && step.contains("."));
+        this.allowNegative = allowNegative || (min != null && min.startsWith("-"));
+
+        input.addEventListener("keypress", getEventListener(this.allowNegative, this.allowDecimal), false);
+    }
+
+    protected EventListener<KeyboardEvent> getEventListener(boolean allowNegative, boolean allowDecimal) {
+        return e -> {
+            String key = e.getKey();
+            if (key.length() == 1) {
+                char k = key.charAt(0);
+                if ((k != '-' || !allowNegative)
+                        && (k != '.' || !allowDecimal)
+                        && (k < '0' || k > '9')) {
+                    e.preventDefault();
+                }
+            }
+        };
+    }
+
+    @Override
+    public NumberInput getElement() {
+        return input;
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/SanitizedNumberInputTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/SanitizedNumberInputTest.java
@@ -1,0 +1,83 @@
+package org.uberfire.client.views.pfly.widgets;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.jboss.errai.common.client.dom.KeyboardEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SanitizedNumberInputTest {
+
+    @InjectMocks
+    SanitizedNumberInput input;
+
+    @Before
+    public void setup() {
+    }
+
+    private boolean allowNegative = false;
+    private boolean allowDecimal = false;
+
+    @Test
+    public void testNumericInput() {
+        testValidKeyCode("9");
+        testValidKeyCode("8");
+        testValidKeyCode("0");
+        testValidKeyCode("Backspace");
+
+        testInvalidKeyCode("-");
+        testInvalidKeyCode("+");
+        testInvalidKeyCode(" ");
+        testInvalidKeyCode(".");
+    }
+
+    @Test
+    public void testNumericInputNegative() {
+        allowNegative = true;
+        allowDecimal = false;
+        testValidKeyCode("-");
+        testInvalidKeyCode(".");
+    }
+
+    @Test
+    public void testNumericInputDecimal() {
+        allowNegative = false;
+        allowDecimal = true;
+        testInvalidKeyCode("-");
+        testValidKeyCode(".");
+    }
+
+    @Test
+    public void testNumericInputNegativeDecimal() {
+        allowNegative = true;
+        allowDecimal = true;
+        testValidKeyCode("-");
+        testValidKeyCode(".");
+    }
+
+    protected void testValidKeyCode(String key) {
+        testKeyCode(key,
+                    0);
+    }
+
+    protected void testInvalidKeyCode(String key) {
+        testKeyCode(key,
+                    1);
+    }
+
+    protected void testKeyCode(String key,
+                               int wantedNumberOfInvocations) {
+        final KeyboardEvent event = mock(KeyboardEvent.class);
+        when(event.getKey()).thenReturn(key);
+        input.getEventListener(allowNegative, allowDecimal).call(event);
+        verify(event,
+               times(wantedNumberOfInvocations)).preventDefault();
+    }
+}


### PR DESCRIPTION
New component - input that allows only numbers (and optionally minus sign and/or decimal point) to be typed. 

Issue: [AF-1036](https://issues.jboss.org/browse/AF-1036)

Two things to note:
 - `<input type="number">` is already sanitized by default in Google Chrome (but Chrome also allows you to type in "e" and a plus sign)
 - in Firefox it is possible to enter an invalid character using a compose key (e.g. Compose + o + a => å), even cancelling all keyboard events does not prevent this.