### PR TITLE
fix GuvnorM2RepositoryTest

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
@@ -69,7 +69,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Aether.class)
-@PowerMockIgnore({"javax.crypto.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.net.ssl.*"})
 public class GuvnorM2RepositoryTest {
 
     public static final String KIE_SETTINGS_CUSTOM_KEY = "kie.maven.settings.custom";


### PR DESCRIPTION
Hi @paulovmr,
this test has been failing for a long time on our Jenkins against productized binaries with 
`java.security.NoSuchAlgorithmException: class configured for SSLContext: sun.security.ssl.SSLContextImpl$DefaultSSLContext`
I think that this should fix the issue and should not break anything. Could you, please, take a look at this?
