### PR TITLE
Replace Fest with assertJ in dashbuilder tests

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
@@ -149,8 +149,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert-core</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/src/test/java/org/dashbuilder/config/ConfigAnnotationTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/src/test/java/org/dashbuilder/config/ConfigAnnotationTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.dashbuilder.pojo.Bean;
 import org.dashbuilder.pojo.BeanExt;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Arquillian.class)
 public class ConfigAnnotationTest extends BaseCDITest {


### PR DESCRIPTION
Yesterday I replaced fest-assert-core with assertj-core in kie-soup (https://github.com/kiegroup/kie-soup/pull/36). Now appformer build is [failing,](https://kie-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/appformer-pullrequests/397/testReport/junit/org.dashbuilder.dataset/DataSetSubsystemCDITest/testGroup/) because one dashbuilder module in appformer repo still uses fest-assert-core. This PR fixes that by also replacing fest by assertJ in this repo