### PR TITLE
Remove duplicated junit/mockito/fest dependency declarations

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-sql-tests/pom.xml
@@ -59,12 +59,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
@@ -89,12 +89,5 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 </project>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -83,12 +83,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
@@ -111,11 +111,6 @@
 
     <!-- test -->
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
@@ -87,12 +87,6 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
-    </dependency>    
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
@@ -77,16 +77,5 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
@@ -113,13 +113,6 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.jboss.byteman</groupId>
       <artifactId>byteman</artifactId>

--- a/uberfire-extensions/uberfire-preferences-ui-client/pom.xml
+++ b/uberfire-extensions/uberfire-preferences-ui-client/pom.xml
@@ -34,12 +34,6 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
@@ -115,12 +115,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.1_spec</artifactId>
       <scope>provided</scope>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
@@ -33,12 +33,6 @@
 
   <dependencies>
     <!-- dependencies added because of new illegal transitive dependency check -->
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/pom.xml
@@ -73,12 +73,6 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
     
   </dependencies>
   

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
@@ -67,12 +67,6 @@
       <artifactId>errai-bus</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
@@ -155,13 +155,7 @@
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
+    
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
@@ -91,12 +91,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
@@ -127,13 +127,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-
   </dependencies>
 
 </project>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
@@ -124,12 +124,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
   
 </project>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
@@ -124,12 +124,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
@@ -169,12 +169,6 @@
     </dependency>
     
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
@@ -80,12 +80,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
@@ -31,12 +31,7 @@
   <description>Uberfire Simple Docks Client</description>
 
   <dependencies>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
+    
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
@@ -111,12 +111,6 @@
 
     <!-- Test -->
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/pom.xml
@@ -119,11 +119,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-client/pom.xml
@@ -67,11 +67,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>      

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/pom.xml
@@ -59,11 +59,6 @@
     </dependency>
 
     <!-- Test -->
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
@@ -70,12 +70,6 @@
       <artifactId>xstream</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
@@ -126,12 +126,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-preferences/uberfire-preferences-api/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-api/pom.xml
@@ -45,10 +45,5 @@
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/uberfire-preferences/uberfire-preferences-client/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-client/pom.xml
@@ -34,12 +34,6 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/uberfire-preferences/uberfire-preferences-processors/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-processors/pom.xml
@@ -72,18 +72,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>

--- a/uberfire-rest/uberfire-rest-client/pom.xml
+++ b/uberfire-rest/uberfire-rest-client/pom.xml
@@ -16,12 +16,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>

--- a/uberfire-services/uberfire-services-api/pom.xml
+++ b/uberfire-services/uberfire-services-api/pom.xml
@@ -79,20 +79,6 @@
       <artifactId>uberfire-preferences-api</artifactId>
     </dependency>
 
-    <!-- Unit testing -->
-
-    <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/uberfire-testing-utils/pom.xml
+++ b/uberfire-testing-utils/pom.xml
@@ -95,12 +95,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
@ederign can you please review and merge? This removes all the duplicate declarations of test dependencies junit / mockito-core / fest-assert-core.
All descendants of uberfire-parent automatically inherit these thanks to [this declaration](https://github.com/kiegroup/appformer/blob/master/pom.xml#L1335-L1351) in uberfire-parent, so no need to declare those in descendant poms.

After this PR is merged I'm planning to globally replace all usages of fest-assert-core (which is predecessor of assertj, and is no longer maintained since 2013) by assertj-core.