### PR TITLE
Replace fest-assert-core with assertj-core

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
@@ -149,12 +149,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-spi</artifactId>
       <scope>test</scope>

--- a/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/pom.xml
@@ -153,12 +153,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
@@ -71,12 +71,6 @@
       <artifactId>kie-soup-json</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1309,7 +1309,7 @@
 	<artifactId>log4j-to-slf4j</artifactId>
 	<version>${version.org.apache.logging.log4j.log4j-to-slf4j}</version>
       </dependency>
-      
+
       <!-- Test deps -->
       <dependency>
         <groupId>mysql</groupId>
@@ -1346,8 +1346,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easytesting</groupId>
-      <artifactId>fest-assert-core</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/uberfire-api/src/test/java/org/uberfire/workbench/model/menu/impl/TestBehavior.java
+++ b/uberfire-api/src/test/java/org/uberfire/workbench/model/menu/impl/TestBehavior.java
@@ -24,12 +24,9 @@ import org.uberfire.workbench.model.menu.MenuItemCommand;
 import org.uberfire.workbench.model.menu.MenuPosition;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
 
-/**
- *
- */
 public class TestBehavior {
 
     private static Command DUMMY = new Command() {

--- a/uberfire-backend/uberfire-backend-api/src/test/java/org/uberfire/backend/vfs/PathTest.java
+++ b/uberfire-backend/uberfire-backend-api/src/test/java/org/uberfire/backend/vfs/PathTest.java
@@ -17,9 +17,7 @@
 package org.uberfire.backend.vfs;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -28,27 +26,14 @@ import static org.uberfire.backend.vfs.PathFactory.newPath;
 
 public class PathTest {
 
-    final FileSystem fs = new FileSystem() {
-
-        @Override
-        public List<Path> getRootDirectories() {
-            return null;
-        }
-
-        @Override
-        public Set<String> supportedFileAttributeViews() {
-            return null;
-        }
-    };
-
     @Test
     public void generalState() {
         {
             final Path path = newPath("resource",
                                       "scheme://path/to/some/resource");
-            assertThat(path.equals(path)).isTrue();
-            assertThat(path.equals(newPath("resource",
-                                           "scheme://path/to/some/resource"))).isTrue();
+            assertThat(path).isEqualTo(path);
+            assertThat(path).isEqualTo(newPath("resource",
+                                               "scheme://path/to/some/resource"));
             assertThat(path.hashCode()).isEqualTo(newPath("resource",
                                                           "scheme://path/to/some/resource").hashCode());
             assertThat(path.hashCode()).isEqualTo(path.hashCode());
@@ -73,7 +58,7 @@ public class PathTest {
 
     @Test
     public void checkNPE() {
-        final Map<Path, String> hashMap = new HashMap<Path, String>();
+        final Map<Path, String> hashMap = new HashMap<>();
         final Path path = newPath("defaultPackage",
                                   "default://guvnor-jcr2vfs-migration/defaultPackage/");
         hashMap.put(path,

--- a/uberfire-backend/uberfire-backend-api/src/test/java/org/uberfire/backend/vfs/PathTest.java
+++ b/uberfire-backend/uberfire-backend-api/src/test/java/org/uberfire/backend/vfs/PathTest.java
@@ -23,12 +23,9 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.uberfire.backend.vfs.PathFactory.newPath;
 
-/**
- *
- */
 public class PathTest {
 
     final FileSystem fs = new FileSystem() {

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManagerTest.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManagerTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.cdi.workspace.Workspace;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -46,9 +47,11 @@ public class WorkspaceManagerTest {
         this.workspaceManager.initialize();
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testWorkspaceNotFound() {
-        this.workspaceManager.getWorkspace("none");
+        assertThatThrownBy(() -> workspaceManager.getWorkspace("none"))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("Workspace <<none>> not found");
     }
 
     @Test

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/LockCleanupSessionListenerTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/LockCleanupSessionListenerTest.java
@@ -30,6 +30,7 @@ import org.uberfire.backend.vfs.impl.LockInfo;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -44,10 +45,13 @@ public class LockCleanupSessionListenerTest {
     @Mock
     private IOService ioService;
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void throwExceptionWhenIOProducerNotInitialized() {
         final LockCleanupSessionListener listener = new LockCleanupSessionListener();
-        listener.sessionDestroyed(evt);
+
+        assertThatThrownBy(() -> listener.sessionDestroyed(evt))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("org.uberfire.backend.server.io.ConfigIOServiceProducer not initialized on startup");
     }
 
     @Test

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthzPolicyDeployerTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthzPolicyDeployerTest.java
@@ -43,6 +43,7 @@ import org.uberfire.security.authz.PermissionTypeRegistry;
 import org.uberfire.security.impl.authz.DefaultPermissionManager;
 import org.uberfire.security.impl.authz.DefaultPermissionTypeRegistry;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -69,7 +70,7 @@ public class AuthzPolicyDeployerTest {
     }
 
     @Test
-    public void testPolicyDir() throws Exception {
+    public void testPolicyDir() {
         WebAppSettings.get().setRootDir("/test");
         Path path = deployer.getPolicyDir();
         Path expected = Paths.get(URI.create("file:///test/WEB-INF/classes"));
@@ -77,9 +78,11 @@ public class AuthzPolicyDeployerTest {
                      expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testInvalidPolicy() throws Exception {
-        testPolicyLoad("WEB-INF/classes/invalid/security-policy.properties");
+    @Test
+    public void testInvalidPolicy() {
+        assertThatThrownBy(() -> testPolicyLoad("WEB-INF/classes/invalid/security-policy.properties"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Key must start with [default|role|group]");
     }
 
     @Test
@@ -181,7 +184,7 @@ public class AuthzPolicyDeployerTest {
     }
 
     @Test
-    public void testNothingToDeploy() throws Exception {
+    public void testNothingToDeploy() {
         deployer.deployPolicy(null);
         verify(storage,
                never()).loadPolicy();
@@ -190,7 +193,7 @@ public class AuthzPolicyDeployerTest {
     }
 
     @Test
-    public void testAlreadyDeployed() throws Exception {
+    public void testAlreadyDeployed() {
         when(storage.loadPolicy()).thenReturn(mock(AuthorizationPolicy.class));
         deployer.deployPolicy(Paths.get(""));
 

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthzPolicyMarshallerTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthzPolicyMarshallerTest.java
@@ -41,6 +41,7 @@ import org.uberfire.security.impl.authz.AuthorizationPolicyBuilder;
 import org.uberfire.security.impl.authz.DefaultPermissionManager;
 import org.uberfire.security.impl.authz.DefaultPermissionTypeRegistry;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -85,7 +86,7 @@ public class AuthzPolicyMarshallerTest {
 
     @Test
     public void testOverwriteDefault() {
-        Map input = new HashMap<>();
+        Map<String, String> input = new HashMap<>();
         input.put("default.permission.perspective.read",
                   "false");
         input.put("default.permission.perspective.read.HomePerspective",
@@ -173,23 +174,29 @@ public class AuthzPolicyMarshallerTest {
                      "repository.update.git://repo1");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRoleMissing() {
-        marshaller.parse("role..priority");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testTypeMissing() {
-        marshaller.parse(".admin.priority");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testIncompleteEntry() {
-        marshaller.parse("role");
+        assertThatThrownBy(() -> marshaller.parse("role..priority"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Role value is empty");
     }
 
     @Test
-    public void testReadDefaultEntries() throws Exception {
+    public void testTypeMissing() {
+        assertThatThrownBy(() -> marshaller.parse(".admin.priority"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Key must start with [default|role|group]");
+    }
+
+    @Test
+    public void testIncompleteEntry() {
+        assertThatThrownBy(() -> marshaller.parse("role"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Role value is empty");
+    }
+
+    @Test
+    public void testReadDefaultEntries() {
         AuthorizationPolicy policy = builder.bydefault().home("B")
                 .permission("p1",
                             false)
@@ -311,7 +318,7 @@ public class AuthzPolicyMarshallerTest {
     }
 
     @Test
-    public void testPolicyWrite() throws Exception {
+    public void testPolicyWrite() {
         builder.role("admin").priority(5).home("A")
                 .permission("p1",
                             true)

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
@@ -125,11 +125,6 @@
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -74,12 +74,6 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemProvidersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemProvidersTest.java
@@ -22,17 +22,17 @@ import org.junit.Test;
 import org.uberfire.java.nio.file.api.FileSystemProviders;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FileSystemProvidersTest {
 
     @Test
     public void generalTests() {
-        assertThat(FileSystemProviders.installedProviders()).isNotNull().isNotEmpty().hasSize(1);
-        assertThat(FileSystemProviders.getDefaultProvider()).isNotNull().isInstanceOf(SimpleFileSystemProvider.class);
+        assertThat(FileSystemProviders.installedProviders()).isNotEmpty().hasSize(1);
+        assertThat(FileSystemProviders.getDefaultProvider()).isInstanceOf(SimpleFileSystemProvider.class);
 
-        assertThat(FileSystemProviders.resolveProvider(URI.create("default:///"))).isNotNull().isInstanceOf(SimpleFileSystemProvider.class);
-        assertThat(FileSystemProviders.resolveProvider(URI.create("file:///"))).isNotNull().isInstanceOf(SimpleFileSystemProvider.class);
+        assertThat(FileSystemProviders.resolveProvider(URI.create("default:///"))).isInstanceOf(SimpleFileSystemProvider.class);
+        assertThat(FileSystemProviders.resolveProvider(URI.create("file:///"))).isInstanceOf(SimpleFileSystemProvider.class);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemProvidersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemProvidersTest.java
@@ -23,20 +23,23 @@ import org.uberfire.java.nio.file.api.FileSystemProviders;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FileSystemProvidersTest {
 
     @Test
     public void generalTests() {
-        assertThat(FileSystemProviders.installedProviders()).isNotEmpty().hasSize(1);
+        assertThat(FileSystemProviders.installedProviders()).hasSize(1);
         assertThat(FileSystemProviders.getDefaultProvider()).isInstanceOf(SimpleFileSystemProvider.class);
 
         assertThat(FileSystemProviders.resolveProvider(URI.create("default:///"))).isInstanceOf(SimpleFileSystemProvider.class);
         assertThat(FileSystemProviders.resolveProvider(URI.create("file:///"))).isInstanceOf(SimpleFileSystemProvider.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void resolveProviderNull() {
-        FileSystemProviders.resolveProvider(null);
+        assertThatThrownBy(() -> FileSystemProviders.resolveProvider(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Parameter named 'uri' should be not null!");
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemsTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.uberfire.java.nio.fs.file.BaseSimpleFileSystem;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FileSystemsTest {
 
@@ -34,8 +34,8 @@ public class FileSystemsTest {
 
     @Test
     public void testGetFileSystemByURI() {
-        assertThat(FileSystems.getFileSystem(URI.create("default:///"))).isNotNull().isInstanceOf(BaseSimpleFileSystem.class);
-        assertThat(FileSystems.getFileSystem(URI.create("file:///"))).isNotNull().isInstanceOf(BaseSimpleFileSystem.class);
+        assertThat(FileSystems.getFileSystem(URI.create("default:///"))).isInstanceOf(BaseSimpleFileSystem.class);
+        assertThat(FileSystems.getFileSystem(URI.create("file:///"))).isInstanceOf(BaseSimpleFileSystem.class);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemsTest.java
@@ -18,18 +18,19 @@ package org.uberfire.java.nio.file;
 
 import java.net.URI;
 import java.util.Collections;
-import java.util.Map;
 
 import org.junit.Test;
 import org.uberfire.java.nio.fs.file.BaseSimpleFileSystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FileSystemsTest {
 
     @Test
     public void testGetDefault() {
-        assertThat(FileSystems.getDefault()).isNotNull().isInstanceOf(BaseSimpleFileSystem.class);
+        assertThat(FileSystems.getDefault())
+                .isInstanceOf(BaseSimpleFileSystem.class);
     }
 
     @Test
@@ -38,54 +39,52 @@ public class FileSystemsTest {
         assertThat(FileSystems.getFileSystem(URI.create("file:///"))).isInstanceOf(BaseSimpleFileSystem.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileSystemNull() {
-        FileSystems.getFileSystem(null);
+        assertThatThrownBy(() -> FileSystems.getFileSystem(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'uri' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFileSystemNull1() {
-        final Map<String, ?> emptyMap = Collections.emptyMap();
-        FileSystems.newFileSystem(null,
-                                  emptyMap);
+        assertThatThrownBy(() -> FileSystems.newFileSystem(null, Collections.emptyMap()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'uri' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFileSystemNull2() {
-        FileSystems.newFileSystem(URI.create("jgit:///test"),
-                                  null);
+        assertThatThrownBy(() -> FileSystems.newFileSystem(URI.create("jgit:///test"), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'env' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFileSystemNull3() {
-        FileSystems.newFileSystem((URI) null,
-                                  null);
+        assertThatThrownBy(() -> FileSystems.newFileSystem((URI) null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'uri' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFileSystemNull4() {
-        FileSystems.newFileSystem((Path) null,
-                                  null);
+        assertThatThrownBy(() -> FileSystems.newFileSystem((Path) null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFileSystemNull5() {
-        FileSystems.newFileSystem(URI.create("jgit:///test"),
-                                  null,
-                                  null);
+        assertThatThrownBy(() -> FileSystems.newFileSystem(URI.create("jgit:///test"), null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'env' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFileSystemNull6() {
-        FileSystems.newFileSystem(URI.create("jgit:///test"),
-                                  null,
-                                  null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void newFileSystemNull7() {
-        FileSystems.newFileSystem(null,
-                                  null,
-                                  null);
+        assertThatThrownBy(() -> FileSystems.newFileSystem(null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'uri' should be not null!");
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileTreeWalkerTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileTreeWalkerTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.uberfire.java.nio.IOException;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Ignore
 public class FileTreeWalkerTest extends AbstractBaseTest {

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileUtilityMethodsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileUtilityMethodsTest.java
@@ -26,12 +26,12 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.fest.assertions.data.Index;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.data.Index.atIndex;
 import static org.uberfire.java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static org.uberfire.java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
@@ -61,32 +61,32 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void newBufferedReaderNoSuchFileException() throws IOException {
+    public void newBufferedReaderNoSuchFileException() {
         Files.newBufferedReader(Paths.get("/some/file/here"),
                                 Charset.defaultCharset());
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void newBufferedReaderNoSuchFileException2() throws IOException {
+    public void newBufferedReaderNoSuchFileException2() {
         Files.newBufferedReader(newTempDir(),
                                 Charset.defaultCharset());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newBufferedReaderNull1() throws IOException {
+    public void newBufferedReaderNull1() {
         Files.newBufferedReader(null,
                                 Charset.defaultCharset());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newBufferedReaderNull2() throws IOException {
+    public void newBufferedReaderNull2() {
         Files.newBufferedReader(Files.createTempFile("foo",
                                                      "bar"),
                                 null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newBufferedReaderNull3() throws IOException {
+    public void newBufferedReaderNull3() {
         Files.newBufferedReader(null,
                                 null);
     }
@@ -113,19 +113,19 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newBufferedWriterNull1() throws IOException {
+    public void newBufferedWriterNull1() {
         Files.newBufferedWriter(null,
                                 Charset.defaultCharset());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newBufferedWriterNull2() throws IOException {
+    public void newBufferedWriterNull2() {
         Files.newBufferedWriter(newTempDir().resolve("some"),
                                 null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newBufferedWriterNull3() throws IOException {
+    public void newBufferedWriterNull3() {
         Files.newBufferedWriter(null,
                                 null);
     }
@@ -205,14 +205,14 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyIn2PathNull1() throws IOException {
+    public void copyIn2PathNull1() {
         Files.copy((InputStream) null,
                    newTempDir().resolve("my_new_file.txt"),
                    REPLACE_EXISTING);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyIn2PathNull2() throws IOException {
+    public void copyIn2PathNull2() {
         Files.copy(Files.newInputStream(Files.createTempFile("foo",
                                                              "bar")),
                    null,
@@ -220,7 +220,7 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyIn2PathNull3() throws IOException {
+    public void copyIn2PathNull3() {
         Files.copy(Files.newInputStream(Files.createTempFile("foo",
                                                              "bar")),
                    newTempDir().resolve("my_new_file.txt"),
@@ -228,7 +228,7 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyIn2PathNull4() throws IOException {
+    public void copyIn2PathNull4() {
         Files.copy(Files.newInputStream(Files.createTempFile("foo",
                                                              "bar")),
                    newTempDir().resolve("my_new_file.txt"),
@@ -236,7 +236,7 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void copyIn2PathInvalidOption() throws IOException {
+    public void copyIn2PathInvalidOption() {
         Files.copy(Files.newInputStream(Files.createTempFile("foo",
                                                              "bar")),
                    newTempDir().resolve("my_new_file.txt"),
@@ -282,14 +282,14 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyPath2OutNull2() throws IOException {
+    public void copyPath2OutNull2() {
         Files.copy(Files.createTempFile("foo",
                                         "bar"),
                    null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyPath2OutInvalidOption() throws IOException {
+    public void copyPath2OutInvalidOption() {
         Files.copy(null,
                    null);
     }
@@ -322,17 +322,17 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void readAllBytesFileNotExists() throws IOException {
+    public void readAllBytesFileNotExists() {
         Files.readAllBytes(newTempDir().resolve("file.big"));
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void readAllBytesDir() throws IOException {
+    public void readAllBytesDir() {
         Files.readAllBytes(newTempDir());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAllBytesNull() throws IOException {
+    public void readAllBytesNull() {
         Files.readAllBytes(null);
     }
 
@@ -347,8 +347,8 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
 
         final List<String> result = Files.readAllLines(dir.resolve("myfile.txt"),
                                                        Charset.defaultCharset());
-        assertThat(result).isNotEmpty().hasSize(1).contains("content",
-                                                            Index.atIndex(0));
+        assertThat(result).hasSize(1)
+                .contains("content", atIndex(0));
 
         final BufferedWriter writer2 = Files.newBufferedWriter(dir.resolve("myfile2.txt"),
                                                                Charset.defaultCharset());
@@ -358,42 +358,39 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
 
         final List<String> result2 = Files.readAllLines(dir.resolve("myfile2.txt"),
                                                         Charset.defaultCharset());
-        assertThat(result2).isNotEmpty().hasSize(3)
-                .contains("content",
-                          Index.atIndex(0))
-                .contains("newFile",
-                          Index.atIndex(1))
-                .contains("line",
-                          Index.atIndex(2));
+        assertThat(result2).hasSize(3)
+                .contains("content", atIndex(0))
+                .contains("newFile", atIndex(1))
+                .contains("line", atIndex(2));
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void readAllLinesFileNotExists() throws IOException {
+    public void readAllLinesFileNotExists() {
         Files.readAllLines(newTempDir().resolve("file.big"),
                            Charset.defaultCharset());
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void readAllLinesDir() throws IOException {
+    public void readAllLinesDir() {
         Files.readAllLines(newTempDir(),
                            Charset.defaultCharset());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAllLinesNull1() throws IOException {
+    public void readAllLinesNull1() {
         Files.readAllLines(null,
                            Charset.defaultCharset());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAllLinesNull2() throws IOException {
+    public void readAllLinesNull2() {
         Files.readAllLines(Files.createTempFile(null,
                                                 null),
                            null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAllLinesNull3() throws IOException {
+    public void readAllLinesNull3() {
         Files.readAllLines(null,
                            null);
     }
@@ -445,11 +442,9 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
 
         final List<String> result = Files.readAllLines(dir.resolve("file.txt"),
                                                        Charset.defaultCharset());
-        assertThat(result).isNotEmpty().hasSize(2)
-                .contains("some",
-                          Index.atIndex(0))
-                .contains("value",
-                          Index.atIndex(1));
+        assertThat(result).hasSize(2)
+                .contains("some", atIndex(0))
+                .contains("value", atIndex(1));
     }
 
     @Test(expected = org.uberfire.java.nio.IOException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileUtilityMethodsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileUtilityMethodsTest.java
@@ -24,12 +24,14 @@ import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.data.Index.atIndex;
 import static org.uberfire.java.nio.file.LinkOption.NOFOLLOW_LINKS;
@@ -41,11 +43,10 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
     public void newBufferedReader() throws IOException {
         final Path dir = newTempDir();
 
-        final OutputStream out = Files.newOutputStream(dir.resolve("file.txt"));
-        assertThat(out).isNotNull();
-
-        out.write("content".getBytes());
-        out.close();
+        try (final OutputStream out = Files.newOutputStream(dir.resolve("file.txt"))) {
+            assertThat(out).isNotNull();
+            out.write("content".getBytes());
+        }
 
         final BufferedReader reader = Files.newBufferedReader(dir.resolve("file.txt"),
                                                               Charset.defaultCharset());
@@ -56,256 +57,288 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
         try {
             reader.read();
             fail("can't read closed stream");
-        } catch (Exception ex) {
+        } catch (Exception ignored) {
         }
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void newBufferedReaderNoSuchFileException() {
-        Files.newBufferedReader(Paths.get("/some/file/here"),
-                                Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.newBufferedReader(Paths.get("/some/file/here"),
+                                                         Charset.defaultCharset()))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void newBufferedReaderNoSuchFileException2() {
-        Files.newBufferedReader(newTempDir(),
-                                Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.newBufferedReader(newTempDir(),
+                                                         Charset.defaultCharset()))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newBufferedReaderNull1() {
-        Files.newBufferedReader(null,
-                                Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.newBufferedReader(null,
+                                                         Charset.defaultCharset()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newBufferedReaderNull2() {
-        Files.newBufferedReader(Files.createTempFile("foo",
-                                                     "bar"),
-                                null);
+        assertThatThrownBy(() -> Files.newBufferedReader(Files.createTempFile("foo",
+                                                                              "bar"),
+                                                         null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'cs' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newBufferedReaderNull3() {
-        Files.newBufferedReader(null,
-                                null);
+        assertThatThrownBy(() -> Files.newBufferedReader(null,
+                                                         null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void newBufferedWriter() throws IOException {
         final Path dir = newTempDir();
-        final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(writer).isNotNull();
-        writer.write("content");
-        writer.close();
+        try (final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(writer).isNotNull();
+            writer.write("content");
+        }
 
-        final BufferedReader reader = Files.newBufferedReader(dir.resolve("myfile.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(reader).isNotNull();
-        assertThat(reader.readLine()).isNotNull().isEqualTo("content");
-        assertThat(reader.readLine()).isNull();
-        reader.close();
+        try (final BufferedReader reader = Files.newBufferedReader(dir.resolve("myfile.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(reader).isNotNull();
+            assertThat(reader.readLine()).isNotNull().isEqualTo("content");
+            assertThat(reader.readLine()).isNull();
+        }
 
         Files.newBufferedWriter(Files.createTempFile(null,
                                                      null),
                                 Charset.defaultCharset());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newBufferedWriterNull1() {
-        Files.newBufferedWriter(null,
-                                Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.newBufferedWriter(null,
+                                                         Charset.defaultCharset()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newBufferedWriterNull2() {
-        Files.newBufferedWriter(newTempDir().resolve("some"),
-                                null);
+        assertThatThrownBy(() -> Files.newBufferedWriter(newTempDir().resolve("some"),
+                                                         null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'cs' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newBufferedWriterNull3() {
-        Files.newBufferedWriter(null,
-                                null);
+        assertThatThrownBy(() -> Files.newBufferedWriter(null,
+                                                         null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void copyIn2Path() throws IOException {
         final Path dir = newTempDir();
-        final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(writer).isNotNull();
-        writer.write("content");
-        writer.close();
+        try (final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(writer).isNotNull();
+            writer.write("content");
+        }
 
-        final InputStream is = Files.newInputStream(dir.resolve("myfile.txt"));
-        Files.copy(is,
-                   dir.resolve("my_new_file.txt"));
-        is.close();
+        try (final InputStream is = Files.newInputStream(dir.resolve("myfile.txt"))) {
+            Files.copy(is,
+                       dir.resolve("my_new_file.txt"));
+        }
 
-        final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(reader).isNotNull();
-        assertThat(reader.readLine()).isNotNull().isEqualTo("content");
-        assertThat(reader.readLine()).isNull();
-        reader.close();
+        try (final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(reader).isNotNull();
+            assertThat(reader.readLine()).isNotNull().isEqualTo("content");
+            assertThat(reader.readLine()).isNull();
+        }
     }
 
     @Test
     public void copyIn2PathReplaceExisting() throws IOException {
         final Path dir = newTempDir();
-        final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(writer).isNotNull();
-        writer.write("content");
-        writer.close();
+        try (final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(writer).isNotNull();
+            writer.write("content");
+        }
 
-        final BufferedWriter writer2 = Files.newBufferedWriter(dir.resolve("my_new_file.txt"),
-                                                               Charset.defaultCharset());
-        assertThat(writer2).isNotNull();
-        writer2.write("empty_content");
-        writer2.close();
+        try (final BufferedWriter writer2 = Files.newBufferedWriter(dir.resolve("my_new_file.txt"),
+                                                                    Charset.defaultCharset())) {
+            assertThat(writer2).isNotNull();
+            writer2.write("empty_content");
+        }
 
-        final InputStream is = Files.newInputStream(dir.resolve("myfile.txt"));
-        Files.copy(is,
-                   dir.resolve("my_new_file.txt"),
-                   REPLACE_EXISTING);
-        is.close();
+        try (final InputStream is = Files.newInputStream(dir.resolve("myfile.txt"))) {
+            Files.copy(is,
+                       dir.resolve("my_new_file.txt"),
+                       REPLACE_EXISTING);
+        }
 
-        final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(reader).isNotNull();
-        assertThat(reader.readLine()).isNotNull().isEqualTo("content");
-        assertThat(reader.readLine()).isNull();
-        reader.close();
+        try (final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(reader).isNotNull();
+            assertThat(reader.readLine()).isNotNull().isEqualTo("content");
+            assertThat(reader.readLine()).isNull();
+        }
     }
 
     @Test
     public void copyIn2PathReplaceExistingNotExists() throws IOException {
         final Path dir = newTempDir();
-        final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(writer).isNotNull();
-        writer.write("content");
-        writer.close();
+        try (final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(writer).isNotNull();
+            writer.write("content");
+        }
 
-        final InputStream is = Files.newInputStream(dir.resolve("myfile.txt"));
-        Files.copy(is,
-                   dir.resolve("my_new_file.txt"),
-                   REPLACE_EXISTING);
-        is.close();
+        try (final InputStream is = Files.newInputStream(dir.resolve("myfile.txt"))) {
+            Files.copy(is,
+                       dir.resolve("my_new_file.txt"),
+                       REPLACE_EXISTING);
+        }
 
-        final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(reader).isNotNull();
-        assertThat(reader.readLine()).isNotNull().isEqualTo("content");
-        assertThat(reader.readLine()).isNull();
-        reader.close();
+        try (final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(reader).isNotNull();
+            assertThat(reader.readLine()).isEqualTo("content");
+            assertThat(reader.readLine()).isNull();
+        }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyIn2PathNull1() {
-        Files.copy((InputStream) null,
-                   newTempDir().resolve("my_new_file.txt"),
-                   REPLACE_EXISTING);
+        assertThatThrownBy(() -> Files.copy((InputStream) null,
+                                            newTempDir().resolve("my_new_file.txt"),
+                                            REPLACE_EXISTING))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'in' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyIn2PathNull2() {
-        Files.copy(Files.newInputStream(Files.createTempFile("foo",
-                                                             "bar")),
-                   null,
-                   REPLACE_EXISTING);
+        assertThatThrownBy(() -> Files.copy(Files.newInputStream(Files.createTempFile("foo",
+                                                                                      "bar")),
+                                            null,
+                                            REPLACE_EXISTING))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'target' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyIn2PathNull3() {
-        Files.copy(Files.newInputStream(Files.createTempFile("foo",
-                                                             "bar")),
-                   newTempDir().resolve("my_new_file.txt"),
-                   null);
+        assertThatThrownBy(() -> Files.copy(Files.newInputStream(Files.createTempFile("foo",
+                                                                                      "bar")),
+                                            newTempDir().resolve("my_new_file.txt"),
+                                            null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'options' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyIn2PathNull4() {
-        Files.copy(Files.newInputStream(Files.createTempFile("foo",
-                                                             "bar")),
-                   newTempDir().resolve("my_new_file.txt"),
-                   new CopyOption[]{null});
+        assertThatThrownBy(() -> Files.copy(Files.newInputStream(Files.createTempFile("foo",
+                                                                                      "bar")),
+                                            newTempDir().resolve("my_new_file.txt"),
+                                            new CopyOption[]{null}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'opt' should be not null!");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void copyIn2PathInvalidOption() {
-        Files.copy(Files.newInputStream(Files.createTempFile("foo",
-                                                             "bar")),
-                   newTempDir().resolve("my_new_file.txt"),
-                   NOFOLLOW_LINKS);
+        assertThatThrownBy(() -> Files.copy(Files.newInputStream(Files.createTempFile("foo",
+                                                                                      "bar")),
+                                            newTempDir().resolve("my_new_file.txt"),
+                                            NOFOLLOW_LINKS))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("NOFOLLOW_LINKS not supported");
     }
 
     @Test
     public void copyPath2Out() throws IOException {
         final Path dir = newTempDir();
-        final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(writer).isNotNull();
-        writer.write("content");
-        writer.close();
+        try (final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(writer).isNotNull();
+            writer.write("content");
+        }
 
-        final OutputStream os = Files.newOutputStream(dir.resolve("my_new_file.txt"));
-        Files.copy(dir.resolve("myfile.txt"),
-                   os);
-        os.close();
+        try (final OutputStream os = Files.newOutputStream(dir.resolve("my_new_file.txt"))) {
+            Files.copy(dir.resolve("myfile.txt"), os);
+        }
 
-        final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(reader).isNotNull();
-        assertThat(reader.readLine()).isNotNull().isEqualTo("content");
-        assertThat(reader.readLine()).isNull();
-        reader.close();
-    }
-
-    @Test(expected = NoSuchFileException.class)
-    public void copyPath2OutNotExists() throws IOException {
-        try (OutputStream os = Files.newOutputStream(newTempDir().resolve("my_new_file.txt"))) {
-            Files.copy(newTempDir().resolve("myfile.txt"),
-                       os);
+        try (final BufferedReader reader = Files.newBufferedReader(dir.resolve("my_new_file.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(reader).isNotNull();
+            assertThat(reader.readLine()).isNotNull().isEqualTo("content");
+            assertThat(reader.readLine()).isNull();
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void copyPath2OutNull1() throws IOException {
-        try (OutputStream os = Files.newOutputStream(newTempDir().resolve("my_new_file.txt"))) {
-            Files.copy(null,
-                       os);
-        }
+    @Test
+    public void copyPath2OutNotExists() {
+        assertThatThrownBy(() -> {
+            try (OutputStream os = Files.newOutputStream(newTempDir().resolve("my_new_file.txt"))) {
+                Files.copy(newTempDir().resolve("myfile.txt"), os);
+            }
+        }).isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
+    public void copyPath2OutNull1() {
+        assertThatThrownBy(() -> {
+            try (OutputStream os = Files.newOutputStream(newTempDir().resolve("my_new_file.txt"))) {
+                Files.copy(null, os);
+            }
+        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'source' should be not null!");
+    }
+
+    @Test
     public void copyPath2OutNull2() {
-        Files.copy(Files.createTempFile("foo",
-                                        "bar"),
-                   null);
+        assertThatThrownBy(() -> Files.copy(Files.createTempFile("foo",
+                                                                 "bar"),
+                                            null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'out' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyPath2OutInvalidOption() {
-        Files.copy(null,
-                   null);
+        assertThatThrownBy(() -> Files.copy(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'source' should be not null!");
     }
 
     @Test
     public void readAllBytes() throws IOException {
         final Path dir = newTempDir();
-        final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
-                                                              Charset.defaultCharset());
-        assertThat(writer).isNotNull();
-        writer.write("content");
-        writer.close();
+        try (final BufferedWriter writer = Files.newBufferedWriter(dir.resolve("myfile.txt"),
+                                                                   Charset.defaultCharset())) {
+            assertThat(writer).isNotNull();
+            writer.write("content");
+        }
 
         final byte[] result = Files.readAllBytes(dir.resolve("myfile.txt"));
 
-        assertThat(result).isNotEmpty().hasSize("content".getBytes().length).isEqualTo("content".getBytes());
+        assertThat(result)
+                .hasSize("content".getBytes().length)
+                .isEqualTo("content".getBytes());
     }
 
     @Test(expected = OutOfMemoryError.class)
@@ -321,19 +354,23 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
         Files.readAllBytes(file);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAllBytesFileNotExists() {
-        Files.readAllBytes(newTempDir().resolve("file.big"));
+        assertThatThrownBy(() -> Files.readAllBytes(newTempDir().resolve("file.big")))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAllBytesDir() {
-        Files.readAllBytes(newTempDir());
+        assertThatThrownBy(() -> Files.readAllBytes(newTempDir()))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAllBytesNull() {
-        Files.readAllBytes(null);
+        assertThatThrownBy(() -> Files.readAllBytes(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -364,77 +401,94 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
                 .contains("line", atIndex(2));
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAllLinesFileNotExists() {
-        Files.readAllLines(newTempDir().resolve("file.big"),
-                           Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.readAllLines(newTempDir().resolve("file.big"),
+                                                    Charset.defaultCharset()))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAllLinesDir() {
-        Files.readAllLines(newTempDir(),
-                           Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.readAllLines(newTempDir(),
+                                                    Charset.defaultCharset()))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAllLinesNull1() {
-        Files.readAllLines(null,
-                           Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.readAllLines(null,
+                                                    Charset.defaultCharset()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAllLinesNull2() {
-        Files.readAllLines(Files.createTempFile(null,
-                                                null),
-                           null);
+        assertThatThrownBy(() -> Files.readAllLines(Files.createTempFile(null,
+                                                                         null),
+                                                    null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'cs' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAllLinesNull3() {
-        Files.readAllLines(null,
-                           null);
+        assertThatThrownBy(() -> Files.readAllLines(null,
+                                                    null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void write() {
         final Path dir = newTempDir();
 
-        Files.write(dir.resolve("file.txt"),
+        Path file = dir.resolve("file.txt");
+        Files.write(file,
                     "content".getBytes());
-        assertThat(Files.readAllBytes(dir.resolve("file.txt"))).hasSize("content".getBytes().length).isEqualTo("content".getBytes());
+
+        assertThat(Files.readAllBytes(file))
+                .hasSize("content".getBytes().length)
+                .isEqualTo("content".getBytes());
     }
 
-    @Test(expected = org.uberfire.java.nio.IOException.class)
+    @Test
     public void writeDir() {
-        Files.write(newTempDir(),
-                    "content".getBytes());
+        assertThatThrownBy(() -> Files.write(newTempDir(),
+                                             "content".getBytes()))
+                .isInstanceOf(org.uberfire.java.nio.IOException.class)
+                .hasMessage("Could not open output stream.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void writeNull1() {
-        Files.write(newTempDir().resolve("file.txt"),
-                    null);
+        assertThatThrownBy(() -> Files.write(newTempDir().resolve("file.txt"),
+                                             null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'bytes' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void writeNull2() {
-        Files.write(null,
-                    "".getBytes());
+        assertThatThrownBy(() -> Files.write(null,
+                                             "".getBytes()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void writeNull3() {
-        Files.write(null,
-                    null);
+        assertThatThrownBy(() -> Files.write(null,
+                                             null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void writeLines() {
         final Path dir = newTempDir();
-        final List<String> content = new ArrayList<String>() {{
-            add("some");
-            add("value");
-        }};
+        final List<String> content = Arrays.asList("some", "value");
 
         Files.write(dir.resolve("file.txt"),
                     content,
@@ -447,46 +501,50 @@ public class FileUtilityMethodsTest extends AbstractBaseTest {
                 .contains("value", atIndex(1));
     }
 
-    @Test(expected = org.uberfire.java.nio.IOException.class)
+    @Test
     public void writeLinesDir() {
-        final List<String> content = new ArrayList<String>() {{
-            add("some");
-            add("value");
-        }};
-
-        Files.write(newTempDir(),
-                    content,
-                    Charset.defaultCharset());
+        final List<String> content = Arrays.asList("some", "value");
+        assertThatThrownBy(() -> Files.write(newTempDir(),
+                                             content,
+                                             Charset.defaultCharset()))
+                .isInstanceOf(org.uberfire.java.nio.IOException.class)
+                .hasMessage("Could not open output stream.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void writeLinesNull1() {
-        Files.write(newTempDir().resolve("file.txt"),
-                    null,
-                    Charset.defaultCharset());
+        assertThatThrownBy(() -> Files.write(newTempDir().resolve("file.txt"),
+                                             null,
+                                             Charset.defaultCharset()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'lines' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void writeLinesNull2() {
-        final List<String> content = new ArrayList<String>();
-        Files.write(null,
-                    content,
-                    Charset.defaultCharset());
+        final List<String> content = new ArrayList<>();
+        assertThatThrownBy(() -> Files.write(null,
+                                             content,
+                                             Charset.defaultCharset()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void writeLinesNull4() {
-        final List<String> content = new ArrayList<String>();
-        Files.write(newTempDir().resolve("file.txt"),
-                    content,
-                    null);
+        final List<String> content = new ArrayList<>();
+        assertThatThrownBy(() -> Files.write(newTempDir().resolve("file.txt"),
+                                             content,
+                                             null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'cs' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void writeLinesNull5() {
-        final List<String> content = new ArrayList<String>();
-        Files.write(null,
-                    null,
-                    null);
+        assertThatThrownBy(() -> Files.write(null,
+                                             null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
@@ -62,31 +62,40 @@ public class FilesTest extends AbstractBaseTest {
         }
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void newInputStreamNonExistent() {
-        Files.newInputStream(Paths.get("/path/to/some/file.txt"));
+        assertThatThrownBy(() -> Files.newInputStream(Paths.get("/path/to/some/file.txt")))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void newInputStreamOnDir() {
         final Path dir = newTempDir();
-        Files.newInputStream(dir);
+        assertThatThrownBy(() -> Files.newInputStream(dir))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newInputStreamNull() {
-        Files.newInputStream(null);
+        assertThatThrownBy(() -> Files.newInputStream(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = org.uberfire.java.nio.IOException.class)
+    @Test
     public void newOutputStreamOnExistent() {
         final Path dir = newTempDir();
-        Files.newOutputStream(dir);
+
+        assertThatThrownBy(() -> Files.newOutputStream(dir))
+                .isInstanceOf(org.uberfire.java.nio.IOException.class)
+                .hasMessage("Could not open output stream.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newOutpurStreamNull() {
-        Files.newOutputStream(null);
+        assertThatThrownBy(() -> Files.newOutputStream(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -101,15 +110,17 @@ public class FilesTest extends AbstractBaseTest {
         }
     }
 
-    @Test(expected = FileAlreadyExistsException.class)
+    @Test
     public void newByteChannelFileAlreadyExists() {
-        Files.newByteChannel(Files.createTempFile("foo",
-                                                  "bar"));
+        assertThatThrownBy(() -> Files.newByteChannel(Files.createTempFile("foo", "bar")))
+                .isInstanceOf(FileAlreadyExistsException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newByteChannelNull() {
-        Files.newByteChannel(null);
+        assertThatThrownBy(() -> Files.newByteChannel(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -120,15 +131,17 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(path.toFile()).exists();
     }
 
-    @Test(expected = FileAlreadyExistsException.class)
+    @Test
     public void createFileAlreadyExists() {
-        Files.createFile(Files.createTempFile("foo",
-                                              "bar"));
+        assertThatThrownBy(() -> Files.createFile(Files.createTempFile("foo", "bar")))
+                .isInstanceOf(FileAlreadyExistsException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createFileNull() {
-        Files.createFile(null);
+        assertThatThrownBy(() -> Files.createFile(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -147,14 +160,17 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(file.toFile()).isFile();
     }
 
-    @Test(expected = FileAlreadyExistsException.class)
+    @Test
     public void createDirectoryFileAlreadyExists() {
-        Files.createDirectory(newTempDir());
+        assertThatThrownBy(() -> Files.createDirectory(newTempDir()))
+                .isInstanceOf(FileAlreadyExistsException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createDirectoryNull() {
-        Files.createDirectory(null);
+        assertThatThrownBy(() -> Files.createDirectory(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'dir' should be not null!");
     }
 
     @Test
@@ -173,14 +189,17 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(file.toFile()).isFile();
     }
 
-    @Test(expected = FileAlreadyExistsException.class)
+    @Test
     public void createDirectoriesFileAlreadyExists() {
-        Files.createDirectories(newTempDir());
+        assertThatThrownBy(() -> Files.createDirectories(newTempDir()))
+                .isInstanceOf(FileAlreadyExistsException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createDirectoriesNull() {
-        Files.createDirectories(null);
+        assertThatThrownBy(() -> Files.createDirectories(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'dir' should be not null!");
     }
 
     @Test
@@ -206,22 +225,26 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(dir.toFile()).doesNotExist();
     }
 
-    @Test(expected = DirectoryNotEmptyException.class)
+    @Test
     public void deleteDirectoryNotEmpty() {
         final Path dir = newTempDir();
         Files.createFile(dir.resolve("file.temp.txt"));
 
-        Files.delete(dir);
+        assertThatThrownBy(() -> Files.delete(dir))
+                .isInstanceOf(DirectoryNotEmptyException.class);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void deleteNoSuchFileException() {
-        Files.delete(newTempDir().resolve("file.temp.txt"));
+        assertThatThrownBy(() -> Files.delete(newTempDir().resolve("file.temp.txt")))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void deleteNull() {
-        Files.delete(null);
+        assertThatThrownBy(() -> Files.delete(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -249,17 +272,20 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(Files.deleteIfExists(newTempDir().resolve("file.temp.txt"))).isFalse();
     }
 
-    @Test(expected = DirectoryNotEmptyException.class)
+    @Test
     public void deleteIfExistsDirectoryNotEmpty() {
         final Path dir = newTempDir();
         Files.createFile(dir.resolve("file.temp.txt"));
 
-        Files.deleteIfExists(dir);
+        assertThatThrownBy(() -> Files.deleteIfExists(dir))
+                .isInstanceOf(DirectoryNotEmptyException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void deleteIfExistsNull() {
-        Files.deleteIfExists(null);
+        assertThatThrownBy(() -> Files.deleteIfExists(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -276,8 +302,7 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(tempFile2.getFileName().toString()).endsWith("tmp");
         assertThat(tempFile2.toFile()).exists();
 
-        final Path tempFile3 = Files.createTempFile("foo",
-                                                    "bar");
+        final Path tempFile3 = Files.createTempFile("foo", "bar");
         assertThat(tempFile3).isNotNull();
         assertThat(tempFile3.toFile()).exists();
         assertThat(tempFile3.getFileName().toString()).startsWith("foo").endsWith(".bar");
@@ -324,18 +349,19 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(dir.toFile().list()).isNotEmpty();
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void createTempFileNoSuchFile() {
-        Files.createTempFile(Paths.get("/path/to/"),
-                             null,
-                             null);
+        assertThatThrownBy(() -> Files.createTempFile(Paths.get("/path/to/"),
+                                                      null,
+                                                      null))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createTempFileNull() {
-        Files.createTempFile((Path) null,
-                             null,
-                             null);
+        assertThatThrownBy(() -> Files.createTempFile((Path) null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'dir' should be not null!");
     }
 
     @Test
@@ -373,16 +399,18 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(dir.toFile().list()).isNotEmpty();
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void createTempDirectoryNoSuchFile() {
-        Files.createTempDirectory(Paths.get("/path/to/"),
-                                  null);
+        assertThatThrownBy(() -> Files.createTempDirectory(Paths.get("/path/to/"),
+                                                           null))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createTempDirectoryNull() {
-        Files.createTempDirectory((Path) null,
-                                  null);
+        assertThatThrownBy(() -> Files.createTempDirectory((Path) null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'dir' should be not null!");
     }
 
     @Test
@@ -400,16 +428,14 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(source.toFile()).exists();
     }
 
-    @Test(expected = DirectoryNotEmptyException.class)
+    @Test
     public void copyDirDirectoryNotEmptyException() {
         final Path source = newTempDir();
         final Path dest = newDirToClean();
-        Files.createTempFile(source,
-                             "foo",
-                             "bar");
+        Files.createTempFile(source, "foo", "bar");
 
-        Files.copy(source,
-                   dest);
+        assertThatThrownBy(() -> Files.copy(source, dest))
+                .isInstanceOf(DirectoryNotEmptyException.class);
     }
 
     @Test
@@ -459,22 +485,25 @@ public class FilesTest extends AbstractBaseTest {
                 .hasMessage("Condition 'source must exist' is invalid!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyNull1() {
-        Files.copy(newTempDir(),
-                   (Path) null);
+        assertThatThrownBy(() -> Files.copy(newTempDir(), (Path) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'target' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyNull2() {
-        Files.copy((Path) null,
-                   Paths.get("/temp"));
+        assertThatThrownBy(() -> Files.copy((Path) null, Paths.get("/temp")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'source' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyNull3() {
-        Files.copy((Path) null,
-                   (Path) null);
+        assertThatThrownBy(() -> Files.copy((Path) null, (Path) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'source' should be not null!");
     }
 
     @Test
@@ -535,34 +564,41 @@ public class FilesTest extends AbstractBaseTest {
                 .hasMessage("Condition 'source must exist' is invalid!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void moveNull1() {
-        Files.move(newTempDir(),
-                   null);
+        assertThatThrownBy(() -> Files.move(newTempDir(), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'target' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void moveNull2() {
-        Files.move(null,
-                   newTempDir());
+        assertThatThrownBy(() -> Files.move(null, newTempDir()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'source' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void moveNull3() {
-        Files.move(null,
-                   null);
+        assertThatThrownBy(() -> Files.move(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'source' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileStoreNull() {
-        Files.getFileStore(null);
+        assertThatThrownBy(() -> Files.getFileStore(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = FileSystemNotFoundException.class)
+    @Test
     public void getFileStoreN() {
         final URI uri = URI.create("nothing:///testXXXXXXX");
 
-        Files.getFileStore(Paths.get(uri));
+        assertThatThrownBy(() -> Files.getFileStore(Paths.get(uri)))
+                .isInstanceOf(FileSystemNotFoundException.class)
+                .hasMessage("Provider 'nothing' not found");
     }
 
     @Test
@@ -599,44 +635,47 @@ public class FilesTest extends AbstractBaseTest {
 
     @Test
     public void getFileAttributeViewInvalidView() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.getFileAttributeView(path,
                                               MyAttrsView.class)).isNull();
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void getFileAttributeViewNoSuchFileException() {
         final Path path = Paths.get("/path/to/file.txt");
 
-        Files.getFileAttributeView(path,
-                                   BasicFileAttributeView.class);
+        assertThatThrownBy(() -> Files.getFileAttributeView(path,
+                                                            BasicFileAttributeView.class))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileAttributeViewNull1() {
-        Files.getFileAttributeView(null,
-                                   MyAttrsView.class);
+        assertThatThrownBy(() -> Files.getFileAttributeView(null, MyAttrsView.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileAttributeViewNull2() {
         final Path path = Paths.get("/path/to/file.txt");
-        Files.getFileAttributeView(path,
-                                   null);
+
+        assertThatThrownBy(() -> Files.getFileAttributeView(path, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'type' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileAttributeViewNull3() {
-        Files.getFileAttributeView(null,
-                                   null);
+        assertThatThrownBy(() -> Files.getFileAttributeView(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void readAttributesGeneral() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         final BasicFileAttributesImpl attrs = Files.readAttributes(path,
                                                                    BasicFileAttributesImpl.class);
@@ -650,8 +689,7 @@ public class FilesTest extends AbstractBaseTest {
 
     @Test
     public void readAttributesBasic() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         final BasicFileAttributes attrs = Files.readAttributes(path,
                                                                BasicFileAttributes.class);
@@ -664,46 +702,47 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(attrs.size()).isEqualTo(0L);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAttributesNonExistentFile() {
         final Path path = Paths.get("/path/to/file.txt");
-
-        Files.readAttributes(path,
-                             BasicFileAttributes.class);
+        assertThatThrownBy(() -> Files.readAttributes(path,
+                                                      BasicFileAttributes.class))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
     @Test
     public void readAttributesInvalid() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.readAttributes(path,
                                         MyAttrs.class)).isNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesNull1() {
-        Files.readAttributes(null,
-                             MyAttrs.class);
+        assertThatThrownBy(() -> Files.readAttributes(null, MyAttrs.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesNull2() {
         final Path path = Paths.get("/path/to/file.txt");
-        Files.readAttributes(path,
-                             (Class<MyAttrs>) null);
+        assertThatThrownBy(() -> Files.readAttributes(path, (Class<MyAttrs>) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'type' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesNull3() {
-        Files.readAttributes(null,
-                             (Class<MyAttrs>) null);
+        assertThatThrownBy(() -> Files.readAttributes(null, (Class<MyAttrs>) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void readAttributesMap() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         Assertions.assertThat(Files.readAttributes(path,
                                                    "*")).hasSize(9);
@@ -738,122 +777,123 @@ public class FilesTest extends AbstractBaseTest {
                 .hasMessage("View 'advanced' not available");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapNull1() {
-        Files.readAttributes(null,
-                             "*");
+        assertThatThrownBy(() -> Files.readAttributes(null, "*"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapNull2() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.readAttributes(path,
-                             (String) null);
+        assertThatThrownBy(() -> Files.readAttributes(path, (String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attributes' should be filled!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapNull3() {
-        Files.readAttributes(null,
-                             (String) null);
+        assertThatThrownBy(() -> Files.readAttributes(null,
+                                                      (String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapEmpty() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.readAttributes(path,
-                             "");
+        assertThatThrownBy(() -> Files.readAttributes(path, ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attributes' should be filled!");
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAttributesMapNoSuchFileException() {
         final Path path = Paths.get("/path/to/file.txt");
 
-        Files.readAttributes(path,
-                             "*");
+        assertThatThrownBy(() -> Files.readAttributes(path,
+                                                      "*"))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeNull1() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
-
-        Files.setAttribute(path,
-                           null,
-                           null);
+        final Path path = Files.createTempFile("foo", "bar");
+        assertThatThrownBy(() -> Files.setAttribute(path, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attribute' should be filled!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeNull2() {
-        Files.setAttribute(null,
-                           "some",
-                           null);
+        assertThatThrownBy(() -> Files.setAttribute(null, "some", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeNull3() {
-        Files.setAttribute(null,
-                           null,
-                           null);
+        assertThatThrownBy(() -> Files.setAttribute(null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeEmpty() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.setAttribute(path,
-                           "",
-                           null);
+        assertThatThrownBy(() -> Files.setAttribute(path, "", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attribute' should be filled!");
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void setAttributeInvalidAttr() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.setAttribute(path,
-                           "myattr",
-                           null);
+        assertThatThrownBy(() -> Files.setAttribute(path, "myattr", null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Condition 'invalid attribute' is invalid!");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void setAttributeInvalidView() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.setAttribute(path,
-                           "advanced:isRegularFile",
-                           null);
+        assertThatThrownBy(() -> Files.setAttribute(path,
+                                                    "advanced:isRegularFile",
+                                                    null))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("View 'advanced' not available");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeInvalidView2() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.setAttribute(path,
-                           ":isRegularFile",
-                           null);
+        assertThatThrownBy(() -> Files.setAttribute(path,
+                                                    ":isRegularFile",
+                                                    null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(":isRegularFile");
     }
 
-    @Test(expected = NotImplementedException.class)
+    @Test
     public void setAttributeNotImpl() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.setAttribute(path,
-                           "isRegularFile",
-                           null);
+        assertThatThrownBy(() -> Files.setAttribute(path,
+                                                    "isRegularFile",
+                                                    null))
+                .isInstanceOf(NotImplementedException.class);
     }
 
     @Test
     public void readAttribute() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.getAttribute(path,
                                       "basic:isRegularFile")).isNotNull();
@@ -866,87 +906,89 @@ public class FilesTest extends AbstractBaseTest {
                                       "someThing")).isNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributeInvalid() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        assertThat(Files.getAttribute(path,
-                                      "*")).isNotNull();
+        assertThatThrownBy(() -> Files.getAttribute(path, "*"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("*");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributeInvalid2() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
-
-        assertThat(Files.getAttribute(path,
-                                      "isRegularFile,isDirectory")).isNull();
+        final Path path = Files.createTempFile("foo", "bar");
+        assertThatThrownBy(() -> Files.getAttribute(path,
+                                                    "isRegularFile,isDirectory"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("isRegularFile,isDirectory");
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAttributeInvalid3() {
         final Path path = Paths.get("/path/to/file.txt");
 
-        Files.getAttribute(path,
-                           "isRegularFile");
+        assertThatThrownBy(() -> Files.getAttribute(path,
+                                                    "isRegularFile"))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
     @Test
     public void getLastModifiedTime() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.getLastModifiedTime(path)).isNotNull();
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void getLastModifiedTimeNoSuchFileException() {
         final Path path = Paths.get("/path/to/file");
 
-        Files.getLastModifiedTime(path);
+        assertThatThrownBy(() -> Files.getLastModifiedTime(path))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getLastModifiedTimeNull() {
-        Files.getLastModifiedTime(null);
+        assertThatThrownBy(() -> Files.getLastModifiedTime(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = NotImplementedException.class)
+    @Test
     public void setLastModifiedTime() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.setLastModifiedTime(path,
-                                  null);
+        assertThatThrownBy(() -> Files.setLastModifiedTime(path, null))
+                .isInstanceOf(NotImplementedException.class);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void setLastModifiedTimeNoSuchFileException() {
         final Path path = Paths.get("/path/to/file");
 
-        Files.setLastModifiedTime(path,
-                                  null);
+        assertThatThrownBy(() -> Files.setLastModifiedTime(path, null))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setLastModifiedTimeNull() {
-        Files.setLastModifiedTime(null,
-                                  null);
+        assertThatThrownBy(() -> Files.setLastModifiedTime(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = NotImplementedException.class)
+    @Test
     public void setLastModifiedTimeNull2() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
-        Files.setLastModifiedTime(path,
-                                  null);
+        final Path path = Files.createTempFile("foo", "bar");
+
+        assertThatThrownBy(() -> Files.setLastModifiedTime(path, null))
+                .isInstanceOf(NotImplementedException.class);
     }
 
     @Test
     public void size() throws IOException {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.size(path)).isEqualTo(0L);
 
@@ -958,37 +1000,40 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(Files.size(sourceFile)).isEqualTo(1L);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void sizeNoSuchFileException() {
         final Path path = Paths.get("/path/to/file");
 
-        Files.size(path);
+        assertThatThrownBy(() -> Files.size(path))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void sizeNull() {
-        Files.size(null);
+        assertThatThrownBy(() -> Files.size(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void exists() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.exists(path)).isTrue();
         assertThat(Files.exists(newTempDir())).isTrue();
         assertThat(Files.exists(Paths.get("/some/path/here"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void existsNull() {
-        Files.exists(null);
+        assertThatThrownBy(() -> Files.exists(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void notExists() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.notExists(path)).isFalse();
         assertThat(Files.notExists(newTempDir())).isFalse();
@@ -996,21 +1041,21 @@ public class FilesTest extends AbstractBaseTest {
         assertThat(Files.notExists(newTempDir().resolve("some.text"))).isTrue();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void notExistsNull() {
-        Files.notExists(null);
+        assertThatThrownBy(() -> Files.notExists(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isSameFile() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isSameFile(path,
                                     Paths.get(path.toString()))).isTrue();
         assertThat(Files.isSameFile(path,
-                                    Files.createTempFile("foo",
-                                                         "bar"))).isFalse();
+                                    Files.createTempFile("foo", "bar"))).isFalse();
         assertThat(Files.isSameFile(newTempDir(),
                                     newTempDir())).isFalse();
 
@@ -1024,135 +1069,143 @@ public class FilesTest extends AbstractBaseTest {
                                     Paths.get("/path/to/some/place/a"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isSameFileNull1() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.isSameFile(path,
-                         null);
+        assertThatThrownBy(() -> Files.isSameFile(path, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path2' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isSameFileNull2() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
-        Files.isSameFile(null,
-                         path);
+        assertThatThrownBy(() -> Files.isSameFile(null, path))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isSameFileNull3() {
-        Files.isSameFile(null,
-                         null);
+        assertThatThrownBy(() -> Files.isSameFile(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isHidden() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isHidden(path)).isFalse();
         assertThat(Files.isHidden(newTempDir())).isFalse();
         assertThat(Files.isHidden(Paths.get("/some/file"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isHiddenNull() {
-        Files.isHidden(null);
+        assertThatThrownBy(() -> Files.isHidden(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isReadable() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isReadable(path)).isTrue();
         assertThat(Files.isReadable(newTempDir())).isTrue();
         assertThat(Files.isReadable(Paths.get("/some/file"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isReadableNull() {
-        Files.isReadable(null);
+        assertThatThrownBy(() -> Files.isReadable(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isWritable() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isWritable(path)).isTrue();
         assertThat(Files.isWritable(newTempDir())).isTrue();
         assertThat(Files.isWritable(Paths.get("/some/file"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isWritableNull() {
-        Files.isWritable(null);
+        assertThatThrownBy(() -> Files.isWritable(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isExecutable() {
         Assume.assumeFalse(SimpleFileSystemProvider.OSType.currentOS().equals(SimpleFileSystemProvider.OSType.WINDOWS));
 
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isExecutable(path)).isFalse();
         assertThat(Files.isExecutable(newTempDir())).isTrue();
         assertThat(Files.isExecutable(Paths.get("/some/file"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isExecutableNull() {
-        Files.isExecutable(null);
+        assertThatThrownBy(() -> Files.isExecutable(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isSymbolicLink() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isSymbolicLink(path)).isFalse();
         assertThat(Files.isSymbolicLink(newTempDir())).isFalse();
         assertThat(Files.isSymbolicLink(Paths.get("/some/file"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isSymbolicLinkNull() {
-        Files.isSymbolicLink(null);
+        assertThatThrownBy(() -> Files.isSymbolicLink(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isDirectory() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isDirectory(path)).isFalse();
         assertThat(Files.isDirectory(newTempDir())).isTrue();
         assertThat(Files.isDirectory(Paths.get("/some/file"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isDirectoryNull() {
-        Files.isSymbolicLink(null);
+        assertThatThrownBy(() -> Files.isDirectory(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
     public void isRegularFile() {
-        final Path path = Files.createTempFile("foo",
-                                               "bar");
+        final Path path = Files.createTempFile("foo", "bar");
 
         assertThat(Files.isRegularFile(path)).isTrue();
         assertThat(Files.isRegularFile(newTempDir())).isFalse();
         assertThat(Files.isRegularFile(Paths.get("/some/file"))).isFalse();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isRegularFileNull() {
-        Files.isRegularFile(null);
+        assertThatThrownBy(() -> Files.isRegularFile(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     private interface MyAttrsView extends BasicFileAttributeView {

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
@@ -30,9 +30,9 @@ import org.uberfire.java.nio.channels.SeekableByteChannel;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
-
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class FilesTest extends AbstractBaseTest {
 
@@ -733,27 +733,27 @@ public class FilesTest extends AbstractBaseTest {
         final Path path = Files.createTempFile("foo",
                                                "bar");
 
-        assertThat(Files.readAttributes(path,
-                                        "*")).isNotNull().hasSize(9);
-        assertThat(Files.readAttributes(path,
-                                        "basic:*")).isNotNull().hasSize(9);
-        assertThat(Files.readAttributes(path,
-                                        "basic:isRegularFile")).isNotNull().hasSize(1);
-        assertThat(Files.readAttributes(path,
-                                        "basic:isRegularFile,isDirectory")).isNotNull().hasSize(2);
-        assertThat(Files.readAttributes(path,
-                                        "basic:isRegularFile,isDirectory,someThing")).isNotNull().hasSize(2);
-        assertThat(Files.readAttributes(path,
-                                        "basic:someThing")).isNotNull().hasSize(0);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "*")).hasSize(9);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "basic:*")).hasSize(9);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "basic:isRegularFile")).hasSize(1);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "basic:isRegularFile,isDirectory")).hasSize(2);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "basic:isRegularFile,isDirectory,someThing")).hasSize(2);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "basic:someThing")).hasSize(0);
 
-        assertThat(Files.readAttributes(path,
-                                        "isRegularFile")).isNotNull().hasSize(1);
-        assertThat(Files.readAttributes(path,
-                                        "isRegularFile,isDirectory")).isNotNull().hasSize(2);
-        assertThat(Files.readAttributes(path,
-                                        "isRegularFile,isDirectory,someThing")).isNotNull().hasSize(2);
-        assertThat(Files.readAttributes(path,
-                                        "someThing")).isNotNull().hasSize(0);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "isRegularFile")).hasSize(1);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "isRegularFile,isDirectory")).hasSize(2);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "isRegularFile,isDirectory,someThing")).hasSize(2);
+        Assertions.assertThat(Files.readAttributes(path,
+                                        "someThing")).hasSize(0);
 
         try {
             Files.readAttributes(path,

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/PathsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/PathsTest.java
@@ -20,7 +20,7 @@ import java.net.URI;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class PathsTest {
 

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/SimpleFileVisitorTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/SimpleFileVisitorTest.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 import org.uberfire.java.nio.IOException;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class SimpleFileVisitorTest extends AbstractBaseTest {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
@@ -55,11 +55,13 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         assertThat(fsProvider.isHidden(path2)).isEqualTo(tempFile.isHidden());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void isHiddenNull() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.isHidden(null);
+        assertThatThrownBy(() -> fsProvider.isHidden(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -114,34 +116,37 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         fsProvider.checkAccess(path2, READ, WRITE, EXECUTE);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void checkAccessNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.checkAccess(null,
-                               null);
+        assertThatThrownBy(() -> fsProvider.checkAccess(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void checkAccessNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
                                                  false);
 
-        fsProvider.checkAccess(path,
-                               null);
+        assertThatThrownBy(() -> fsProvider.checkAccess(path, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'modes' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void checkAccessNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.checkAccess(null,
-                               READ);
+        assertThatThrownBy(() -> fsProvider.checkAccess(null, READ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void checkAccessNull4() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
         final File tempFile = File.createTempFile("foo",
@@ -149,9 +154,9 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.checkAccess(path,
-                               null,
-                               READ);
+        assertThatThrownBy(() -> fsProvider.checkAccess(path, null, READ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'mode' should be not null!");
     }
 
     @Test
@@ -165,11 +170,13 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         assertThat(fsProvider.getFileSystem(path.toUri()).getFileStores()).isNotNull().contains(fsProvider.getFileStore(path));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileStoreNull() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.getFileStore(null);
+        assertThatThrownBy(() -> fsProvider.getFileStore(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -225,31 +232,35 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
                                                    MyAttrsView.class)).isNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileAttributeViewNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.getFileAttributeView(null,
-                                        MyAttrsView.class);
+        assertThatThrownBy(() -> fsProvider.getFileAttributeView(null, MyAttrsView.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileAttributeViewNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
                                                  false);
-        fsProvider.getFileAttributeView(path,
-                                        null);
+
+        assertThatThrownBy(() -> fsProvider.getFileAttributeView(path, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'type' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileAttributeViewNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.getFileAttributeView(null,
-                                        null);
+        assertThatThrownBy(() -> fsProvider.getFileAttributeView(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -291,16 +302,16 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         assertThat(attrs.size()).isEqualTo(0L);
     }
 
-    @Test(expected = NoSuchFileException.class)
+    @Test
     public void readAttributesNonExistentFile() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
                                                  false);
-
-        fsProvider.readAttributes(path,
-                                  BasicFileAttributes.class);
+        assertThatThrownBy(() -> fsProvider.readAttributes(path,
+                                                           BasicFileAttributes.class))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
     @Test
@@ -316,31 +327,38 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
                                              MyAttrs.class)).isNull();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.readAttributes(null,
-                                  MyAttrs.class);
+        assertThatThrownBy(() -> fsProvider.readAttributes(null,
+                                                           MyAttrs.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
                                                  false);
-        fsProvider.readAttributes(path,
-                                  (Class<MyAttrs>) null);
+
+        assertThatThrownBy(() -> fsProvider.readAttributes(path,
+                                                           (Class<MyAttrs>) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'type' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.readAttributes(null,
-                                  (Class<MyAttrs>) null);
+        assertThatThrownBy(() -> fsProvider.readAttributes(null,
+                                                           (Class<MyAttrs>) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
     @Test
@@ -383,15 +401,16 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
                 .hasMessage("View 'advanced' not available");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.readAttributes(null,
-                                  "*");
+        assertThatThrownBy(() -> fsProvider.readAttributes(null, "*"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapNull2() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -400,19 +419,21 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.readAttributes(path,
-                                  (String) null);
+        assertThatThrownBy(() -> fsProvider.readAttributes(path, (String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attributes' should be filled!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.readAttributes(null,
-                                  (String) null);
+        assertThatThrownBy(() -> fsProvider.readAttributes(null, (String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void readAttributesMapEmpty() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -421,11 +442,12 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.readAttributes(path,
-                                  "");
+        assertThatThrownBy(() -> fsProvider.readAttributes(path, ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attributes' should be filled!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeNull1() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -434,30 +456,30 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.setAttribute(path,
-                                null,
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(path, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attributes' should be filled!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.setAttribute(null,
-                                "some",
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(null, "some", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
-        fsProvider.setAttribute(null,
-                                null,
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeEmpty() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -465,13 +487,12 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
                                                   "bar");
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
-
-        fsProvider.setAttribute(path,
-                                "",
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(path, "", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'attributes' should be filled!");
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void setAttributeInvalidAttr() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -480,12 +501,12 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.setAttribute(path,
-                                "myattr",
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(path, "myattr", null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Condition 'invalid attribute' is invalid!");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void setAttributeInvalidView() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -494,12 +515,12 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.setAttribute(path,
-                                "advanced:isRegularFile",
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(path, "advanced:isRegularFile", null))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("View 'advanced' not available");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setAttributeInvalidView2() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -508,12 +529,12 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.setAttribute(path,
-                                ":isRegularFile",
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(path, ":isRegularFile", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(":isRegularFile");
     }
 
-    @Test(expected = NotImplementedException.class)
+    @Test
     public void setAttributeNotImpl() throws IOException {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
@@ -522,9 +543,8 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        fsProvider.setAttribute(path,
-                                "isRegularFile",
-                                null);
+        assertThatThrownBy(() -> fsProvider.setAttribute(path, "isRegularFile", null))
+                .isInstanceOf(NotImplementedException.class);
     }
 
     private interface MyAttrsView extends BasicFileAttributeView {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
@@ -29,8 +29,8 @@ import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.uberfire.java.nio.file.AccessMode.EXECUTE;
 import static org.uberfire.java.nio.file.AccessMode.READ;
 import static org.uberfire.java.nio.file.AccessMode.WRITE;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
@@ -24,13 +24,14 @@ import org.junit.Test;
 import org.uberfire.java.nio.base.BasicFileAttributesImpl;
 import org.uberfire.java.nio.base.GeneralPathImpl;
 import org.uberfire.java.nio.base.NotImplementedException;
+import org.uberfire.java.nio.file.AccessDeniedException;
 import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.uberfire.java.nio.file.AccessMode.EXECUTE;
 import static org.uberfire.java.nio.file.AccessMode.READ;
 import static org.uberfire.java.nio.file.AccessMode.WRITE;
@@ -68,100 +69,53 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
                                                  "/path/to/file.txt",
                                                  false);
 
-        try {
-            fsProvider.checkAccess(path,
-                                   WRITE);
-            fail("can't have write access on non existent file");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.checkAccess(path, WRITE))
+                .isInstanceOf(NoSuchFileException.class);
 
-        try {
-            fsProvider.checkAccess(path,
-                                   READ);
-            fail("can't have read access on non existent file");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.checkAccess(path, READ))
+                .isInstanceOf(NoSuchFileException.class);
 
-        try {
-            fsProvider.checkAccess(path,
-                                   EXECUTE);
-            fail("can't have execute access on non existent file");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.checkAccess(path, EXECUTE))
+                .isInstanceOf(NoSuchFileException.class);
 
         final File tempFile = File.createTempFile("foo",
                                                   "bar");
         final Path path2 = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                        tempFile);
 
-        try {
-            fsProvider.checkAccess(path2,
-                                   WRITE);
-        } catch (Exception ex) {
-            fail("write access should be ok");
-        }
+        fsProvider.checkAccess(path2, WRITE);
 
-        tempFile.setWritable(false);
+        assertThat(tempFile.setWritable(false)).isTrue();
 
-        try {
-            fsProvider.checkAccess(path2,
-                                   WRITE);
-            fail("can't have write access on file");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.checkAccess(path2, WRITE))
+                .isInstanceOf(AccessDeniedException.class);
 
-        tempFile.setWritable(true);
+        assertThat(tempFile.setWritable(true)).isTrue();
 
-        try {
-            fsProvider.checkAccess(path2,
-                                   READ);
-        } catch (Exception ex) {
-            fail("read access should be ok");
-        }
+        fsProvider.checkAccess(path2, READ);
 
-        tempFile.setReadable(false);
+        assertThat(tempFile.setReadable(false)).isTrue();
 
         if (SimpleFileSystemProvider.OSType.currentOS().equals(SimpleFileSystemProvider.OSType.UNIX_LIKE)) {
-            try {
-                fsProvider.checkAccess(path2,
-                                       READ);
-                fail("can't have read access on file");
-            } catch (Exception ex) {
-            }
+            assertThatThrownBy(() -> fsProvider.checkAccess(path2, READ))
+                    .isInstanceOf(AccessDeniedException.class);
         }
 
-        tempFile.setReadable(true);
+        assertThat(tempFile.setReadable(true)).isTrue();
 
         if (SimpleFileSystemProvider.OSType.currentOS().equals(SimpleFileSystemProvider.OSType.UNIX_LIKE)) {
-            try {
-                fsProvider.checkAccess(path2,
-                                       EXECUTE);
-                fail("can't have execute access on file");
-            } catch (Exception ex) {
-            }
+            assertThatThrownBy(() -> fsProvider.checkAccess(path2, EXECUTE))
+                    .isInstanceOf(AccessDeniedException.class);
         }
 
-        tempFile.setExecutable(true);
+        assertThat(tempFile.setExecutable(true)).isTrue();
 
-        try {
-            fsProvider.checkAccess(path2,
-                                   EXECUTE);
-        } catch (Exception ex) {
-            fail("execute access should be ok");
-        }
-
-        try {
-            fsProvider.checkAccess(path2,
-                                   READ,
-                                   WRITE,
-                                   EXECUTE);
-        } catch (Exception ex) {
-            fail("all access should be ok");
-        }
+        fsProvider.checkAccess(path2, EXECUTE);
+        fsProvider.checkAccess(path2, READ, WRITE, EXECUTE);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void checkAccessNull1() throws IOException {
+    public void checkAccessNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.checkAccess(null,
@@ -169,7 +123,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void checkAccessNull2() throws IOException {
+    public void checkAccessNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
@@ -180,7 +134,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void checkAccessNull3() throws IOException {
+    public void checkAccessNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.checkAccess(null,
@@ -272,7 +226,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getFileAttributeViewNull1() throws IOException {
+    public void getFileAttributeViewNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.getFileAttributeView(null,
@@ -280,7 +234,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getFileAttributeViewNull2() throws IOException {
+    public void getFileAttributeViewNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -291,7 +245,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getFileAttributeViewNull3() throws IOException {
+    public void getFileAttributeViewNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.getFileAttributeView(null,
@@ -338,7 +292,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void readAttributesNonExistentFile() throws IOException {
+    public void readAttributesNonExistentFile() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -363,7 +317,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAttributesNull1() throws IOException {
+    public void readAttributesNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.readAttributes(null,
@@ -371,7 +325,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAttributesNull2() throws IOException {
+    public void readAttributesNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -382,7 +336,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAttributesNull3() throws IOException {
+    public void readAttributesNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.readAttributes(null,
@@ -420,23 +374,17 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
         assertThat(fsProvider.readAttributes(path,
                                              "someThing")).isNotNull().hasSize(0);
 
-        try {
-            fsProvider.readAttributes(path,
-                                      ":someThing");
-            fail("undefined view");
-        } catch (IllegalArgumentException ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.readAttributes(path, ":someThing"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(":someThing");
 
-        try {
-            fsProvider.readAttributes(path,
-                                      "advanced:isRegularFile");
-            fail("undefined view");
-        } catch (UnsupportedOperationException ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.readAttributes(path, "advanced:isRegularFile"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("View 'advanced' not available");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAttributesMapNull1() throws IOException {
+    public void readAttributesMapNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.readAttributes(null,
@@ -457,7 +405,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readAttributesMapNull3() throws IOException {
+    public void readAttributesMapNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.readAttributes(null,
@@ -492,7 +440,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void setAttributeNull2() throws IOException {
+    public void setAttributeNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.setAttribute(null,
@@ -501,7 +449,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void setAttributeNull3() throws IOException {
+    public void setAttributeNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.setAttribute(null,
@@ -579,11 +527,11 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
                                 null);
     }
 
-    private static interface MyAttrsView extends BasicFileAttributeView {
+    private interface MyAttrsView extends BasicFileAttributeView {
 
     }
 
-    private static interface MyAttrs extends BasicFileAttributes {
+    private interface MyAttrs extends BasicFileAttributes {
 
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderTest.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.channels.FileChannel;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -43,7 +43,7 @@ import org.uberfire.java.nio.file.NotLinkException;
 import org.uberfire.java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.uberfire.java.nio.file.StandardDeleteOption.NON_EMPTY_DIRECTORIES;
 
 public class SimpleFileSystemProviderTest {
@@ -100,7 +100,7 @@ public class SimpleFileSystemProviderTest {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.newFileSystem(URI.create("file:///"),
-                                 new HashMap<String, Object>());
+                                 Collections.emptyMap());
     }
 
     @Test(expected = FileSystemAlreadyExistsException.class)
@@ -112,7 +112,7 @@ public class SimpleFileSystemProviderTest {
                                                  false);
 
         fsProvider.newFileSystem(path,
-                                 new HashMap<String, Object>());
+                                 Collections.emptyMap());
     }
 
     @Test
@@ -131,7 +131,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void inputStreamFileDoesntExists() throws IOException {
+    public void inputStreamFileDoesntExists() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -142,7 +142,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void inputStreamNull() throws IOException {
+    public void inputStreamNull() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.newInputStream(null);
@@ -164,7 +164,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = org.uberfire.java.nio.IOException.class)
-    public void outputStreamFileDoesntExists() throws IOException {
+    public void outputStreamFileDoesntExists() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -175,7 +175,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = org.uberfire.java.nio.IOException.class)
-    public void outputStreamOnDirectory() throws IOException {
+    public void outputStreamOnDirectory() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -186,7 +186,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void outputStreamNull() throws IOException {
+    public void outputStreamNull() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.newOutputStream(null);
@@ -209,7 +209,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = org.uberfire.java.nio.IOException.class)
-    public void fileChannelFileDoesntExists() throws IOException {
+    public void fileChannelFileDoesntExists() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -221,7 +221,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void fileChannelNull() throws IOException {
+    public void fileChannelNull() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.newFileChannel(null,
@@ -237,14 +237,14 @@ public class SimpleFileSystemProviderTest {
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  userBasedPath,
                                                  false);
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
 
         try (final SeekableByteChannel channel = fsProvider.newByteChannel(path, null)) {
             assertThat(channel).isNotNull();
-            assertThat(path.toFile().exists()).isTrue();
+            assertThat(path.toFile()).exists();
         }
         path.toFile().delete();
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
     }
 
     @Test(expected = FileAlreadyExistsException.class)
@@ -256,7 +256,7 @@ public class SimpleFileSystemProviderTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        assertThat(path.toFile().exists()).isTrue();
+        assertThat(path.toFile()).exists();
         assertThat(path.toFile()).isEqualTo(tempFile);
 
         fsProvider.newByteChannel(path,
@@ -264,7 +264,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = org.uberfire.java.nio.IOException.class)
-    public void newByteChannelInvalidPath() throws IOException {
+    public void newByteChannelInvalidPath() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userBasedPath = System.getProperty("user.dir") + "path/to/some_file_here.txt";
@@ -272,14 +272,14 @@ public class SimpleFileSystemProviderTest {
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  userBasedPath,
                                                  false);
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
 
         fsProvider.newByteChannel(path,
                                   null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newByteChannelNull() throws IOException {
+    public void newByteChannelNull() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.newByteChannel(null,
@@ -287,7 +287,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void newAsynchronousFileChannelUnsupportedOp() throws IOException {
+    public void newAsynchronousFileChannelUnsupportedOp() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
@@ -300,7 +300,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newAsynchronousFileChannelNull() throws IOException {
+    public void newAsynchronousFileChannelNull() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.newAsynchronousFileChannel(null,
@@ -317,13 +317,13 @@ public class SimpleFileSystemProviderTest {
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  userBasedPath,
                                                  false);
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
 
         final SeekableByteChannel channel = fsProvider.newByteChannel(path,
                                                                       null);
 
         assertThat(channel).isNotNull();
-        assertThat(path.toFile().exists()).isTrue();
+        assertThat(path.toFile()).exists();
 
         assertThat(channel.isOpen()).isTrue();
 
@@ -368,7 +368,7 @@ public class SimpleFileSystemProviderTest {
 //        }
 
         path.toFile().delete();
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
     }
 
     @Test
@@ -381,13 +381,13 @@ public class SimpleFileSystemProviderTest {
                                                  userBasedPath,
                                                  false);
         path.toFile().delete();
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
 
         fsProvider.createDirectory(path);
 
-        assertThat(path.toFile().exists()).isTrue();
+        assertThat(path.toFile()).exists();
         path.toFile().delete();
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
     }
 
     @Test(expected = FileAlreadyExistsException.class)
@@ -399,10 +399,10 @@ public class SimpleFileSystemProviderTest {
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  userBasedPath,
                                                  false);
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
 
         fsProvider.createDirectory(path);
-        assertThat(path.toFile().exists()).isTrue();
+        assertThat(path.toFile()).exists();
         fsProvider.createDirectory(path);
     }
 
@@ -458,7 +458,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void createSymbolicLinkTargetMustExists() throws IOException {
+    public void createSymbolicLinkTargetMustExists() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
@@ -556,20 +556,20 @@ public class SimpleFileSystemProviderTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        assertThat(path.toFile().exists()).isTrue();
+        assertThat(path.toFile()).exists();
         fsProvider.delete(path);
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
     }
 
     @Test(expected = NoSuchFileException.class)
-    public void checkDeleteNonExistent() throws IOException {
+    public void checkDeleteNonExistent() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
                                                  false);
 
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
         fsProvider.delete(path);
     }
 
@@ -589,22 +589,22 @@ public class SimpleFileSystemProviderTest {
         final Path path = GeneralPathImpl.newFromFile(fsProvider.getFileSystem(URI.create("file:///")),
                                                       tempFile);
 
-        assertThat(path.toFile().exists()).isTrue();
+        assertThat(path.toFile()).exists();
         assertThat(fsProvider.deleteIfExists(path)).isTrue();
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
     }
 
     @Test
-    public void checkDeleteIfExistsNonExistent() throws IOException {
+    public void checkDeleteIfExistsNonExistent() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "/path/to/file.txt",
                                                  false);
 
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
         assertThat(fsProvider.deleteIfExists(path)).isFalse();
-        assertThat(path.toFile().exists()).isFalse();
+        assertThat(path.toFile()).doesNotExist();
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -711,8 +711,8 @@ public class SimpleFileSystemProviderTest {
         fsProvider.copy(source,
                         dest);
 
-        assertThat(dest.toFile().exists()).isTrue();
-        assertThat(source.toFile().exists()).isTrue();
+        assertThat(dest.toFile()).exists();
+        assertThat(source.toFile()).exists();
 
         source.toFile().delete();
         dest.toFile().delete();
@@ -738,8 +738,8 @@ public class SimpleFileSystemProviderTest {
         fsProvider.copy(source,
                         dest);
 
-        assertThat(dest.toFile().exists()).isTrue();
-        assertThat(source.toFile().exists()).isTrue();
+        assertThat(dest.toFile()).exists();
+        assertThat(source.toFile()).exists();
         assertThat(dest.toFile().length()).isEqualTo(source.toFile().length());
 
         source.toFile().delete();
@@ -769,39 +769,26 @@ public class SimpleFileSystemProviderTest {
         stream.write('a');
         stream.close();
 
-        try {
-            fsProvider.copy(source,
-                            dest);
-            fail("source isn't empty");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.copy(source, dest))
+                .isInstanceOf(DirectoryNotEmptyException.class);
 
         sourceFile.toFile().delete();
         fsProvider.copy(source,
                         dest);
 
-        try {
-            fsProvider.copy(source,
-                            dest);
-            fail("dest already exists");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.copy(source, dest))
+                .isInstanceOf(FileAlreadyExistsException.class);
 
         dest.toFile().delete();
         source.toFile().delete();
 
-        try {
-            fsProvider.copy(source,
-                            dest);
-            fail("source doesn't exists");
-        } catch (Exception ex) {
-
-        } finally {
-        }
+        assertThatThrownBy(() -> fsProvider.copy(source, dest))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Condition 'source must exist' is invalid!");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyFileNull1() throws IOException {
+    public void copyFileNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userPath = System.getProperty("user.dir") + "/temp";
@@ -814,7 +801,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyFileNull2() throws IOException {
+    public void copyFileNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userPath = System.getProperty("user.dir") + "/temp";
@@ -827,7 +814,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void copyFileNull3() throws IOException {
+    public void copyFileNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.copy(null,
@@ -852,8 +839,8 @@ public class SimpleFileSystemProviderTest {
         fsProvider.move(source,
                         dest);
 
-        assertThat(source.toFile().exists()).isFalse();
-        assertThat(dest.toFile().exists()).isTrue();
+        assertThat(source.toFile()).doesNotExist();
+        assertThat(dest.toFile()).exists();
 
         dest.toFile().delete();
     }
@@ -879,8 +866,8 @@ public class SimpleFileSystemProviderTest {
         fsProvider.move(source,
                         dest);
 
-        assertThat(dest.toFile().exists()).isTrue();
-        assertThat(source.toFile().exists()).isFalse();
+        assertThat(dest.toFile()).exists();
+        assertThat(source.toFile()).doesNotExist();
         assertThat(dest.toFile().length()).isEqualTo(lenght);
 
         dest.toFile().delete();
@@ -909,39 +896,26 @@ public class SimpleFileSystemProviderTest {
         stream.write('a');
         stream.close();
 
-        try {
-            fsProvider.move(source,
-                            dest);
-            fail("source isn't empty");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.move(source, dest))
+                .isInstanceOf(DirectoryNotEmptyException.class);
 
         sourceFile.toFile().delete();
         fsProvider.copy(source,
                         dest);
 
-        try {
-            fsProvider.move(source,
-                            dest);
-            fail("dest already exists");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> fsProvider.move(source, dest))
+                .isInstanceOf(FileAlreadyExistsException.class);
 
         dest.toFile().delete();
         source.toFile().delete();
 
-        try {
-            fsProvider.move(source,
-                            dest);
-            fail("source doesn't exists");
-        } catch (Exception ex) {
-
-        } finally {
-        }
+        assertThatThrownBy(() -> fsProvider.move(source, dest))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Condition 'source must exist' is invalid!");
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void moveFileNull1() throws IOException {
+    public void moveFileNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userPath = System.getProperty("user.dir") + "/temp";
@@ -954,7 +928,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void moveFileNull2() throws IOException {
+    public void moveFileNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userPath = System.getProperty("user.dir") + "/temp";
@@ -967,7 +941,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void moveFileNull3() throws IOException {
+    public void moveFileNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.move(null,
@@ -987,20 +961,12 @@ public class SimpleFileSystemProviderTest {
         fsProvider.createDirectory(dir);
 
         final DirectoryStream<Path> stream = fsProvider.newDirectoryStream(dir,
-                                                                           new DirectoryStream.Filter<Path>() {
-                                                                               @Override
-                                                                               public boolean accept(Path entry) throws org.uberfire.java.nio.IOException {
-                                                                                   return true;
-                                                                               }
-                                                                           });
+                                                                           entry -> true);
 
         assertThat(stream).hasSize(0);
 
-        try {
-            stream.iterator().next();
-            fail("can't navigate to next on empty iterator");
-        } catch (NoSuchElementException ex) {
-        }
+        assertThatThrownBy(() -> stream.iterator().next())
+                .isInstanceOf(NoSuchElementException.class);
 
         final File tempFile = File.createTempFile("foo",
                                                   "bar",
@@ -1009,30 +975,20 @@ public class SimpleFileSystemProviderTest {
                                                       tempFile);
 
         final DirectoryStream<Path> stream2 = fsProvider.newDirectoryStream(dir,
-                                                                            new DirectoryStream.Filter<Path>() {
-                                                                                @Override
-                                                                                public boolean accept(Path entry) throws org.uberfire.java.nio.IOException {
-                                                                                    return true;
-                                                                                }
-                                                                            });
+                                                                            entry -> true);
 
         assertThat(stream2).hasSize(1);
 
         final Iterator<Path> iterator = stream2.iterator();
         iterator.next();
-        try {
-            iterator.remove();
-            fail("can't remove elements");
-        } catch (UnsupportedOperationException ex) {
-        }
+        assertThatThrownBy(() -> iterator.remove())
+                .isInstanceOf(UnsupportedOperationException.class);
 
         stream2.close();
 
-        try {
-            stream2.close();
-            fail("stram already closed");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> stream2.close())
+                .isInstanceOf(org.uberfire.java.nio.IOException.class)
+                .hasMessage("This stream is closed.");
 
         final File tempFile2 = File.createTempFile("bar",
                                                    "foo",
@@ -1041,34 +997,19 @@ public class SimpleFileSystemProviderTest {
                                                        tempFile2);
 
         final DirectoryStream<Path> stream3 = fsProvider.newDirectoryStream(dir,
-                                                                            new DirectoryStream.Filter<Path>() {
-                                                                                @Override
-                                                                                public boolean accept(Path entry) throws org.uberfire.java.nio.IOException {
-                                                                                    return true;
-                                                                                }
-                                                                            });
+                                                                            entry -> true);
 
         assertThat(stream3).hasSize(2).contains(path,
                                                 path2);
 
         stream3.close();
 
-        try {
-            stream3.iterator().next();
-            fail("can't interact in an already closed stream");
-        } catch (Exception ex) {
-        }
+        assertThatThrownBy(() -> stream3.iterator().next())
+                .isInstanceOf(org.uberfire.java.nio.IOException.class)
+                .hasMessage("This stream is closed.");
 
         final DirectoryStream<Path> stream4 = fsProvider.newDirectoryStream(dir,
-                                                                            new DirectoryStream.Filter<Path>() {
-                                                                                @Override
-                                                                                public boolean accept(final Path entry) throws org.uberfire.java.nio.IOException {
-                                                                                    if (entry.getFileName().toString().startsWith("foo")) {
-                                                                                        return true;
-                                                                                    }
-                                                                                    return false;
-                                                                                }
-                                                                            });
+                                                                            entry -> entry.getFileName().toString().startsWith("foo"));
 
         assertThat(stream4).hasSize(1).contains(path);
 
@@ -1099,20 +1040,12 @@ public class SimpleFileSystemProviderTest {
         fsProvider.createDirectory(dir.resolve("other_dir"));
 
         final DirectoryStream<Path> stream5 = fsProvider.newDirectoryStream(dir,
-                                                                            new DirectoryStream.Filter<Path>() {
-                                                                                @Override
-                                                                                public boolean accept(final Path entry) throws org.uberfire.java.nio.IOException {
-                                                                                    return true;
-                                                                                }
-                                                                            });
+                                                                            entry -> true);
 
         assertThat(stream5).hasSize(4).contains(dir.resolve("other_dir"));
 
-        try {
-            fsProvider.delete(dir);
-            fail("must throw error");
-        } catch (final DirectoryNotEmptyException expection) {
-        }
+        assertThatThrownBy(() -> fsProvider.delete(dir))
+                .isInstanceOf(org.uberfire.java.nio.file.DirectoryNotEmptyException.class);
 
         fsProvider.delete(dir,
                           NON_EMPTY_DIRECTORIES);
@@ -1121,7 +1054,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = NotDirectoryException.class)
-    public void newDirectoryStreamInvalidDir() throws IOException {
+    public void newDirectoryStreamInvalidDir() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userSourcePath = System.getProperty("user.dir") + "/xxxxxx";
@@ -1131,29 +1064,19 @@ public class SimpleFileSystemProviderTest {
                                                 false);
 
         fsProvider.newDirectoryStream(dir,
-                                      new DirectoryStream.Filter<Path>() {
-                                          @Override
-                                          public boolean accept(Path entry) throws org.uberfire.java.nio.IOException {
-                                              return true;
-                                          }
-                                      });
+                                      entry -> true);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newDirectoryStreamNull1() throws IOException {
+    public void newDirectoryStreamNull1() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         fsProvider.newDirectoryStream(null,
-                                      new DirectoryStream.Filter<Path>() {
-                                          @Override
-                                          public boolean accept(Path entry) throws org.uberfire.java.nio.IOException {
-                                              return true;
-                                          }
-                                      });
+                                      entry -> true);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newDirectoryStreamNull2() throws IOException {
+    public void newDirectoryStreamNull2() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userSourcePath = System.getProperty("user.dir") + "/xxxxxx";
@@ -1167,7 +1090,7 @@ public class SimpleFileSystemProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void newDirectoryStreamNull3() throws IOException {
+    public void newDirectoryStreamNull3() {
         final SimpleFileSystemProvider fsProvider = new SimpleFileSystemProvider();
 
         final String userSourcePath = System.getProperty("user.dir") + "/xxxxxx";

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.io.FileUtils;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,8 +42,8 @@ import org.uberfire.java.nio.file.NotDirectoryException;
 import org.uberfire.java.nio.file.NotLinkException;
 import org.uberfire.java.nio.file.Path;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.uberfire.java.nio.file.StandardDeleteOption.NON_EMPTY_DIRECTORIES;
 
 public class SimpleFileSystemProviderTest {
@@ -74,7 +75,7 @@ public class SimpleFileSystemProviderTest {
 
         final Path path = fsProvider.getPath(uri);
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.isAbsolute()).isTrue();
         assertThat(path.getFileSystem()).isEqualTo(fsProvider.getFileSystem(uri));
         assertThat(path.getFileSystem().provider()).isEqualTo(fsProvider);

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderWindowsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderWindowsTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.uberfire.java.nio.base.GeneralPathImpl;
 import org.uberfire.java.nio.file.Path;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.uberfire.java.nio.fs.file.SimpleFileSystemProvider.OSType.WINDOWS;
 
 public class SimpleFileSystemProviderWindowsTest {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderWindowsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderWindowsTest.java
@@ -35,13 +35,13 @@ public class SimpleFileSystemProviderWindowsTest {
     @Test
     public void simpleStateTest() {
         assertThat(fsProvider).isNotNull();
-        assertThat(fsProvider.getScheme()).isNotEmpty().isEqualTo("file");
+        assertThat(fsProvider.getScheme()).isEqualTo("file");
 
         final Path path = GeneralPathImpl.create(fsProvider.getFileSystem(URI.create("file:///")),
                                                  "c:\\path\\to\\file.txt",
                                                  false);
 
-        assertThat(path.getFileSystem()).isNotNull().isInstanceOf(SimpleWindowsFileSystem.class);
+        assertThat(path.getFileSystem()).isInstanceOf(SimpleWindowsFileSystem.class);
     }
 
     @Test
@@ -50,7 +50,7 @@ public class SimpleFileSystemProviderWindowsTest {
                                                  "c:\\path\\to\\file.txt",
                                                  false);
 
-        assertThat(fsProvider.getFileStore(path)).isNotNull().isInstanceOf(SimpleWindowsFileStore.class);
-        assertThat(fsProvider.getFileStore(path).name()).isNotNull().isEqualTo("c:\\");
+        assertThat(fsProvider.getFileStore(path)).isInstanceOf(SimpleWindowsFileStore.class);
+        assertThat(fsProvider.getFileStore(path).name()).isEqualTo("c:\\");
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileStoreTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileStoreTest.java
@@ -35,7 +35,7 @@ public class SimpleUnixFileStoreTest {
     public void simpleTests() {
         final FileStore fileStore = new SimpleUnixFileStore(null);
 
-        assertThat(fileStore.name()).isNotNull().isEqualTo("/");
+        assertThat(fileStore.name()).isEqualTo("/");
         assertThat(fileStore.type()).isNull();
         assertThat(fileStore.isReadOnly()).isFalse();
         assertThat(fileStore.getTotalSpace()).isEqualTo(File.listRoots()[0].getTotalSpace());
@@ -50,10 +50,10 @@ public class SimpleUnixFileStoreTest {
         assertThat(fileStore.supportsFileAttributeView(MyAlsoInvalidFileAttributeView.class.getName())).isFalse();
         assertThat(fileStore.getFileStoreAttributeView(FileStoreAttributeView.class)).isNull();
 
-        assertThat(fileStore.getAttribute("name")).isNotNull().isEqualTo(fileStore.name());
-        assertThat(fileStore.getAttribute("totalSpace")).isNotNull().isEqualTo(fileStore.getTotalSpace());
-        assertThat(fileStore.getAttribute("usableSpace")).isNotNull().isEqualTo(fileStore.getUsableSpace());
-        assertThat(fileStore.getAttribute("readOnly")).isNotNull().isEqualTo(fileStore.isReadOnly());
+        assertThat(fileStore.getAttribute("name")).isEqualTo(fileStore.name());
+        assertThat(fileStore.getAttribute("totalSpace")).isEqualTo(fileStore.getTotalSpace());
+        assertThat(fileStore.getAttribute("usableSpace")).isEqualTo(fileStore.getUsableSpace());
+        assertThat(fileStore.getAttribute("readOnly")).isEqualTo(fileStore.isReadOnly());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileStoreTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileStoreTest.java
@@ -27,7 +27,7 @@ import org.uberfire.java.nio.file.attribute.FileAttributeView;
 import org.uberfire.java.nio.file.attribute.FileStoreAttributeView;
 import org.uberfire.java.nio.file.attribute.FileTime;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SimpleUnixFileStoreTest {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileSystemTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileSystemTest.java
@@ -29,6 +29,7 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
@@ -48,30 +49,27 @@ public class SimpleUnixFileSystemTest {
         assertThat(fileSystem.provider()).isEqualTo(fsProvider);
         Assertions.assertThat(fileSystem.supportedFileAttributeViews()).hasSize(1).contains("basic");
 
-        assertThat(fileSystem.getPath("/path/to/file.txt")).isNotNull().isEqualTo(GeneralPathImpl.create(fileSystem,
-                                                                                                         "/path/to/file.txt",
-                                                                                                         false));
+        assertThat(fileSystem.getPath("/path/to/file.txt")).isEqualTo(GeneralPathImpl.create(fileSystem,
+                                                                                             "/path/to/file.txt",
+                                                                                             false));
         assertThat(fileSystem.getPath("/path/to/file.txt",
-                                      null)).isNotNull().isEqualTo(GeneralPathImpl.create(fileSystem,
-                                                                                          "/path/to/file.txt",
-                                                                                          false));
+                                      null)).isEqualTo(GeneralPathImpl.create(fileSystem,
+                                                                              "/path/to/file.txt",
+                                                                              false));
         assertThat(fileSystem.getPath("/path",
                                       "to",
-                                      "file.txt")).isNotNull().isEqualTo(GeneralPathImpl.create(fileSystem,
-                                                                                                "/path/to/file.txt",
-                                                                                                false));
+                                      "file.txt")).isEqualTo(GeneralPathImpl.create(fileSystem,
+                                                                                    "/path/to/file.txt",
+                                                                                    false));
         assertThat(fileSystem.getPath("/",
                                       "path",
                                       "to",
-                                      "file.txt")).isNotNull().isEqualTo(GeneralPathImpl.create(fileSystem,
-                                                                                                "/path/to/file.txt",
-                                                                                                false));
+                                      "file.txt")).isEqualTo(GeneralPathImpl.create(fileSystem,
+                                                                                    "/path/to/file.txt",
+                                                                                    false));
 
-        try {
-            fileSystem.close();
-            fail("can't close this fileSystem");
-        } catch (UnsupportedOperationException ex) {
-        }
+        assertThatThrownBy(() -> fileSystem.close())
+                .isInstanceOf(UnsupportedOperationException.class);
 
         Assertions.assertThat(fileSystem.getFileStores()).hasSize(1);
         assertThat(fileSystem.getFileStores().iterator().next().name()).isEqualTo("/");
@@ -95,8 +93,6 @@ public class SimpleUnixFileSystemTest {
         final URL childUrl = this.getClass().getResource("/Folder");
         final Path childNioPath = fs.getPath(childUrl.toURI());
         final Path childParentNioPath = childNioPath.getParent();
-
-        System.out.println(parentNioPath);
 
         assertThat(parentNioPath).isEqualTo(childParentNioPath);
     }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileSystemTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleUnixFileSystemTest.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.uberfire.java.nio.base.GeneralPathImpl;
 import org.uberfire.java.nio.file.FileStore;
@@ -28,9 +29,9 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class SimpleUnixFileSystemTest {
 
@@ -45,7 +46,7 @@ public class SimpleUnixFileSystemTest {
         assertThat(fileSystem.isReadOnly()).isFalse();
         assertThat(fileSystem.getSeparator()).isEqualTo(System.getProperty("file.separator"));
         assertThat(fileSystem.provider()).isEqualTo(fsProvider);
-        assertThat(fileSystem.supportedFileAttributeViews()).isNotEmpty().hasSize(1).contains("basic");
+        Assertions.assertThat(fileSystem.supportedFileAttributeViews()).hasSize(1).contains("basic");
 
         assertThat(fileSystem.getPath("/path/to/file.txt")).isNotNull().isEqualTo(GeneralPathImpl.create(fileSystem,
                                                                                                          "/path/to/file.txt",
@@ -72,10 +73,10 @@ public class SimpleUnixFileSystemTest {
         } catch (UnsupportedOperationException ex) {
         }
 
-        assertThat(fileSystem.getFileStores()).isNotNull().hasSize(1);
+        Assertions.assertThat(fileSystem.getFileStores()).hasSize(1);
         assertThat(fileSystem.getFileStores().iterator().next().name()).isEqualTo("/");
 
-        assertThat(fileSystem.getRootDirectories()).isNotNull().hasSize(1);
+        Assertions.assertThat(fileSystem.getRootDirectories()).hasSize(1);
         assertThat(fileSystem.getRootDirectories().iterator().next().toString()).isEqualTo("/");
         assertThat(fileSystem.getRootDirectories().iterator().next().isAbsolute()).isTrue();
     }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleWindowsFileStoreTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleWindowsFileStoreTest.java
@@ -31,8 +31,8 @@ import org.uberfire.java.nio.file.attribute.FileStoreAttributeView;
 import org.uberfire.java.nio.file.attribute.FileTime;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class SimpleWindowsFileStoreTest {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleWindowsFileSystemTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleWindowsFileSystemTest.java
@@ -20,22 +20,24 @@ import java.io.File;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.uberfire.java.nio.base.GeneralPathImpl;
 import org.uberfire.java.nio.file.FileStore;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
-import  org.assertj.core.api.Assertions;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class SimpleWindowsFileSystemTest {
 
     final FileSystemProvider fsProvider = mock(FileSystemProvider.class);
     final File[] roots = new File[]{new File("c:\\"), new File("a:\\")};
-    final File[] singleRoot = new File[] {new File("c:\\")};
+    final File[] singleRoot = new File[]{new File("c:\\")};
 
     @Test
     public void simpleTests() {
@@ -92,11 +94,8 @@ public class SimpleWindowsFileSystemTest {
                                                                                             "/c:/path",
                                                                                             false));
 
-        try {
-            fileSystem.close();
-            fail("can't close this fileSystem");
-        } catch (UnsupportedOperationException ex) {
-        }
+        assertThatThrownBy(() -> fileSystem.close())
+                .isInstanceOf(UnsupportedOperationException.class);
 
         Assertions.assertThat(fileSystem.getFileStores()).hasSize(2);
         assertThat(fileSystem.getFileStores().iterator().next().name()).isEqualTo("c:\\");

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleWindowsFileSystemTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleWindowsFileSystemTest.java
@@ -26,9 +26,9 @@ import org.uberfire.java.nio.file.FileStore;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
-
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import  org.assertj.core.api.Assertions;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class SimpleWindowsFileSystemTest {
@@ -48,7 +48,7 @@ public class SimpleWindowsFileSystemTest {
         assertThat(fileSystem.isReadOnly()).isFalse();
         assertThat(fileSystem.getSeparator()).isEqualTo("\\");
         assertThat(fileSystem.provider()).isEqualTo(fsProvider);
-        assertThat(fileSystem.supportedFileAttributeViews()).isNotEmpty().hasSize(1).contains("basic");
+        Assertions.assertThat(fileSystem.supportedFileAttributeViews()).hasSize(1).contains("basic");
 
         assertThat(fileSystem.getPath("c:\\path\\to\\file.txt")).isNotNull().isEqualTo(GeneralPathImpl.create(fileSystem,
                                                                                                               "c:\\path\\to\\file.txt",
@@ -98,10 +98,10 @@ public class SimpleWindowsFileSystemTest {
         } catch (UnsupportedOperationException ex) {
         }
 
-        assertThat(fileSystem.getFileStores()).isNotNull().hasSize(2);
+        Assertions.assertThat(fileSystem.getFileStores()).hasSize(2);
         assertThat(fileSystem.getFileStores().iterator().next().name()).isEqualTo("c:\\");
 
-        assertThat(fileSystem.getRootDirectories()).isNotNull().hasSize(2);
+        Assertions.assertThat(fileSystem.getRootDirectories()).hasSize(2);
         assertThat(fileSystem.getRootDirectories().iterator().next().toString()).isEqualTo("c:\\");
         assertThat(fileSystem.getRootDirectories().iterator().next().isAbsolute()).isTrue();
     }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderAsDefaultTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderAsDefaultTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class JGitFileSystemImplProviderAsDefaultTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderCpMvTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderCpMvTest.java
@@ -30,8 +30,8 @@ import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
 
@@ -75,22 +75,14 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
 
         assertThat(stream).isNotNull().hasSize(2);
 
-        try {
-            provider.copy(source,
-                          target);
-            failBecauseExceptionWasNotThrown(FileAlreadyExistsException.class);
-        } catch (FileAlreadyExistsException e) {
-        }
+        assertThatThrownBy(() -> provider.copy(source, target))
+                .isInstanceOf(FileAlreadyExistsException.class);
 
         final Path notExists = provider.getPath(URI.create("git://xxx_user_branch@copybranch-test-repo"));
         final Path notExists2 = provider.getPath(URI.create("git://xxx_other_branch@copybranch-test-repo"));
 
-        try {
-            provider.copy(notExists,
-                          notExists2);
-            failBecauseExceptionWasNotThrown(NoSuchFileException.class);
-        } catch (NoSuchFileException e) {
-        }
+        assertThatThrownBy(() -> provider.copy(notExists, notExists2))
+                .isInstanceOf(NoSuchFileException.class);
     }
 
     @Test
@@ -168,7 +160,7 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
             final DirectoryStream<Path> stream = provider.newDirectoryStream(target,
                                                                              null);
 
-            assertThat(stream).isNotNull().hasSize(3);
+            assertThat(stream).hasSize(3);
         }
 
         {
@@ -181,7 +173,7 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
             final DirectoryStream<Path> stream = provider.newDirectoryStream(target,
                                                                              null);
 
-            assertThat(stream).isNotNull().hasSize(2);
+            assertThat(stream).hasSize(2);
         }
 
         {
@@ -194,7 +186,7 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
             final DirectoryStream<Path> stream = provider.newDirectoryStream(target,
                                                                              null);
 
-            assertThat(stream).isNotNull().hasSize(2);
+            assertThat(stream).hasSize(2);
         }
 
         {
@@ -207,31 +199,23 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
             final DirectoryStream<Path> stream = provider.newDirectoryStream(target,
                                                                              null);
 
-            assertThat(stream).isNotNull().hasSize(1);
+            assertThat(stream).hasSize(1);
         }
 
         {
             final Path source = provider.getPath(URI.create("git://user_branch@copydir-test-repo/not_exists"));
             final Path target = provider.getPath(URI.create("git://master@copydir-test-repo/xxxxxxxxother_here/"));
 
-            try {
-                provider.copy(source,
-                              target);
-                failBecauseExceptionWasNotThrown(NoSuchFileException.class);
-            } catch (NoSuchFileException e) {
-            }
+            assertThatThrownBy(() -> provider.copy(source, target))
+                    .isInstanceOf(NoSuchFileException.class);
         }
 
         {
             final Path source = provider.getPath(URI.create("git://user_branch@copydir-test-repo/"));
             final Path target = provider.getPath(URI.create("git://master@copydir-test-repo/other_here/"));
 
-            try {
-                provider.copy(source,
-                              target);
-                failBecauseExceptionWasNotThrown(FileAlreadyExistsException.class);
-            } catch (FileAlreadyExistsException e) {
-            }
+            assertThatThrownBy(() -> provider.copy(source, target))
+                    .isInstanceOf(FileAlreadyExistsException.class);
         }
     }
 
@@ -339,24 +323,16 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
             final Path source = provider.getPath(URI.create("git://master@copydir-test-repo1/not_exists"));
             final Path target = provider.getPath(URI.create("git://master@copydir-test-repo2/xxxxxxxxother_here/"));
 
-            try {
-                provider.copy(source,
-                              target);
-                failBecauseExceptionWasNotThrown(NoSuchFileException.class);
-            } catch (NoSuchFileException e) {
-            }
+            assertThatThrownBy(() -> provider.copy(source, target))
+                    .isInstanceOf(NoSuchFileException.class);
         }
 
         {
             final Path source = provider.getPath(URI.create("git://master@copydir-test-repo2/path"));
             final Path target = provider.getPath(URI.create("git://master@copydir-test-repo1/some/place/here/"));
 
-            try {
-                provider.copy(source,
-                              target);
-                failBecauseExceptionWasNotThrown(FileAlreadyExistsException.class);
-            } catch (FileAlreadyExistsException e) {
-            }
+            assertThatThrownBy(() -> provider.copy(source, target))
+                    .isInstanceOf(FileAlreadyExistsException.class);
         }
     }
 
@@ -392,12 +368,8 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
         final Path source = provider.getPath(URI.create("git://user_branch@movebranch-test-repo/"));
         final Path target = provider.getPath(URI.create("git://master@movebranch-test-repo/"));
 
-        try {
-            provider.move(source,
-                          target);
-            failBecauseExceptionWasNotThrown(FileAlreadyExistsException.class);
-        } catch (org.uberfire.java.nio.IOException e) {
-        }
+        assertThatThrownBy(() -> provider.move(source, target))
+                .isInstanceOf(FileAlreadyExistsException.class);
 
         final Path source2 = provider.getPath(URI.create("git://user_branch@movebranch-test-repo/"));
         final Path target2 = provider.getPath(URI.create("git://xxxxddddkh@movebranch-test-repo/"));
@@ -485,7 +457,7 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
     }
 
     @Test
-    public void testCherryPick() throws IOException, InterruptedException {
+    public void testCherryPick() throws IOException {
         final URI newRepo = URI.create("git://cherrypick-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);
@@ -578,7 +550,7 @@ public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
         }
     }
 
-    static String convertStreamToString(java.io.InputStream is) {
+    private static String convertStreamToString(java.io.InputStream is) {
         java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
         return s.hasNext() ? s.next() : "";
     }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderCpMvTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderCpMvTest.java
@@ -29,9 +29,9 @@ import org.uberfire.java.nio.file.FileAlreadyExistsException;
 import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.Path;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderDiffTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderDiffTest.java
@@ -35,7 +35,7 @@ import org.uberfire.java.nio.fs.jgit.util.commands.Commit;
 import org.uberfire.java.nio.fs.jgit.util.commands.CreateBranch;
 import org.uberfire.java.nio.fs.jgit.util.commands.CreateRepository;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitFileSystemImplProviderDiffTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderEncodingTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderEncodingTest.java
@@ -28,7 +28,7 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.fs.jgit.util.commands.Commit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class JGitFileSystemImplProviderEncodingTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderGCTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderGCTest.java
@@ -25,8 +25,8 @@ import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
 import org.uberfire.java.nio.file.Path;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class JGitFileSystemImplProviderGCTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHookTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHookTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitFileSystemImplProviderHookTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMergeTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMergeTest.java
@@ -31,7 +31,7 @@ import org.uberfire.java.nio.fs.jgit.util.commands.GetTreeFromRef;
 import org.uberfire.java.nio.fs.jgit.util.commands.ListDiffs;
 import org.uberfire.java.nio.fs.jgit.util.exceptions.GitException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMergeTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMergeTest.java
@@ -21,7 +21,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
 
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.junit.Test;
 import org.uberfire.java.nio.base.options.MergeCopyOption;
@@ -36,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
 
     @Test
-    public void testMergeSuccessful() throws IOException, GitAPIException {
+    public void testMergeSuccessful() throws IOException {
         final URI newRepo = URI.create("git://merge-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);
@@ -86,7 +85,7 @@ public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
     }
 
     @Test(expected = GitException.class)
-    public void testMergeConflicts() throws IOException, GitAPIException {
+    public void testMergeConflicts() throws IOException {
         final URI newRepo = URI.create("git://merge-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);
@@ -140,7 +139,7 @@ public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
     }
 
     @Test
-    public void testMergeBinarySuccessful() throws IOException, GitAPIException {
+    public void testMergeBinarySuccessful() throws IOException {
         final URI newRepo = URI.create("git://merge-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);
@@ -189,7 +188,7 @@ public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
     }
 
     @Test(expected = GitException.class)
-    public void testBinaryMergeConflicts() throws IOException, GitAPIException {
+    public void testBinaryMergeConflicts() throws IOException {
         final URI newRepo = URI.create("git://merge-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);
@@ -243,7 +242,7 @@ public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
     }
 
     @Test(expected = GitException.class)
-    public void testTryToMergeNonexistentBranch() throws IOException, GitAPIException {
+    public void testTryToMergeNonexistentBranch() throws IOException {
         final URI newRepo = URI.create("git://merge-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);
@@ -265,7 +264,7 @@ public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testMissingParemeter() throws IOException, GitAPIException {
+    public void testMissingParemeter() throws IOException {
         final URI newRepo = URI.create("git://merge-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMigrationTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMigrationTest.java
@@ -21,12 +21,9 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Ignore;
 import org.junit.Test;
-import org.uberfire.java.nio.file.FileSystemNotFoundException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitFileSystemImplProviderMigrationTest extends AbstractTestInfra {
 
@@ -50,5 +47,4 @@ public class JGitFileSystemImplProviderMigrationTest extends AbstractTestInfra {
                             "test/old" + ".git").exists()).isTrue();
         assertThat(provider.getFileSystem(newUri)).isNotNull();
     }
-
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMigrationTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMigrationTest.java
@@ -44,7 +44,7 @@ public class JGitFileSystemImplProviderMigrationTest extends AbstractTestInfra {
 
         provider.getFileSystem(newUri);
         assertThat(new File(provider.getGitRepoContainerDir(),
-                            "test/old" + ".git").exists()).isTrue();
+                            "test/old" + ".git")).exists();
         assertThat(provider.getFileSystem(newUri)).isNotNull();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderTest.java
@@ -72,12 +72,13 @@ import org.uberfire.java.nio.fs.jgit.util.exceptions.GitException;
 import org.uberfire.java.nio.fs.jgit.util.model.PathInfo;
 import org.uberfire.java.nio.fs.jgit.util.model.PathType;
 
+import org.assertj.core.api.AssertionsForClassTypes;
 import static junit.framework.Assert.assertNotSame;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.uberfire.java.nio.file.StandardDeleteOption.NON_EMPTY_DIRECTORIES;
@@ -254,13 +255,13 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
         for (final Path root : fs.getRootDirectories()) {
             if (root.toAbsolutePath().toUri().toString().contains("upstream")) {
                 assertThat(provider.newDirectoryStream(root,
-                                                       null)).isNotEmpty().hasSize(2);
+                                                       null)).hasSize(2);
             } else if (root.toAbsolutePath().toUri().toString().contains("origin")) {
                 assertThat(provider.newDirectoryStream(root,
-                                                       null)).isNotEmpty().hasSize(1);
+                                                       null)).hasSize(1);
             } else {
                 assertThat(provider.newDirectoryStream(root,
-                                                       null)).isNotEmpty().hasSize(2);
+                                                       null)).hasSize(2);
             }
         }
 
@@ -487,7 +488,7 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
 
         final Path path = provider.getPath(URI.create("git://master@new-get-repo-name/home"));
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.getRoot().toString()).isEqualTo("/");
         Path root = path.getRoot();
         Path path1 = root.toRealPath();
@@ -495,7 +496,7 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
         assertThat(path.toString()).isEqualTo("/home");
 
         final Path pathRelative = provider.getPath(URI.create("git://master@new-get-repo-name/:home"));
-        assertThat(pathRelative).isNotNull();
+        AssertionsForClassTypes.assertThat(pathRelative).isNotNull();
         assertThat(pathRelative.toRealPath().toUri().toString()).isEqualTo("git://master@new-get-repo-name/:home");
         assertThat(pathRelative.getRoot().toString()).isEqualTo("");
         assertThat(pathRelative.toString()).isEqualTo("home");
@@ -522,12 +523,12 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
 
         final Path path = provider.getPath(URI.create("git://origin/master@new-complex-get-repo-name/home"));
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.getRoot().toString()).isEqualTo("/");
         assertThat(path.toString()).isEqualTo("/home");
 
         final Path pathRelative = provider.getPath(URI.create("git://origin/master@new-complex-get-repo-name/:home"));
-        assertThat(pathRelative).isNotNull();
+        AssertionsForClassTypes.assertThat(pathRelative).isNotNull();
         assertThat(pathRelative.getRoot().toString()).isEqualTo("");
         assertThat(pathRelative.toString()).isEqualTo("home");
     }
@@ -541,18 +542,18 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
 
         final Path path1 = provider.getPath(URI.create("git://new-complex-get-repo-name/composed/home"));
 
-        assertThat(path1).isNotNull();
+        AssertionsForClassTypes.assertThat(path1).isNotNull();
         assertThat(path1.getRoot().toString()).isEqualTo("/");
         assertThat(path1.toString()).isEqualTo("/home");
 
         final Path path = provider.getPath(URI.create("git://origin/master@new-complex-get-repo-name/composed/home"));
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.getRoot().toString()).isEqualTo("/");
         assertThat(path.toString()).isEqualTo("/home");
 
         final Path pathRelative = provider.getPath(URI.create("git://origin/master@new-complex-get-repo-name/composed/:home"));
-        assertThat(pathRelative).isNotNull();
+        AssertionsForClassTypes.assertThat(pathRelative).isNotNull();
         assertThat(pathRelative.getRoot().toString()).isEqualTo("");
         assertThat(pathRelative.toString()).isEqualTo("home");
     }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
 
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.errors.MissingObjectException;
@@ -72,15 +73,16 @@ import org.uberfire.java.nio.fs.jgit.util.exceptions.GitException;
 import org.uberfire.java.nio.fs.jgit.util.model.PathInfo;
 import org.uberfire.java.nio.fs.jgit.util.model.PathType;
 
-import org.assertj.core.api.AssertionsForClassTypes;
 import static junit.framework.Assert.assertNotSame;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 import static org.uberfire.java.nio.file.StandardDeleteOption.NON_EMPTY_DIRECTORIES;
 
 public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
@@ -101,7 +103,7 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
 
     @Test
     @Ignore
-    public void testDaemob() throws InterruptedException {
+    public void testDaemob() {
         final URI newRepo = URI.create("git://repo-name");
 
         final Map<String, ?> env = new HashMap<String, Object>() {{
@@ -112,8 +114,7 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
         FileSystem fs = provider.newFileSystem(newRepo,
                                                env);
 
-        WatchService ws = null;
-        ws = fs.newWatchService();
+        WatchService ws = fs.newWatchService();
         final Path path = fs.getRootDirectories().iterator().next();
         path.register(ws,
                       StandardWatchEventKind.ENTRY_CREATE,
@@ -1063,7 +1064,7 @@ public class JGitFileSystemImplProviderTest extends AbstractTestInfra {
     }
 
     @Test
-    public void testCreateDirectory() throws Exception {
+    public void testCreateDirectory()  {
         final URI newRepo = URI.create("git://xcreatedir-test-repo");
         provider.newFileSystem(newRepo,
                                EMPTY_ENV);

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderUnsupportedOpTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderUnsupportedOpTest.java
@@ -25,7 +25,7 @@ import org.uberfire.java.nio.file.OpenOption;
 import org.uberfire.java.nio.file.Path;
 
 import static java.util.Collections.emptySet;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderUnsupportedOpTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderUnsupportedOpTest.java
@@ -25,7 +25,7 @@ import org.uberfire.java.nio.file.OpenOption;
 import org.uberfire.java.nio.file.Path;
 
 import static java.util.Collections.emptySet;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInfra {
 
@@ -41,12 +41,8 @@ public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInf
                                               "repo2-name",
                                               false);
 
-        try {
-            provider.newFileSystem(path,
-                                   EMPTY_ENV);
-            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> provider.newFileSystem(path, EMPTY_ENV))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -59,12 +55,8 @@ public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInf
         final Path path = provider.getPath(URI.create("git://newfcrepo-name/file.txt"));
 
         final Set<? extends OpenOption> options = emptySet();
-        try {
-            provider.newFileChannel(path,
-                                    options);
-            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> provider.newFileChannel(path, options))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -77,13 +69,8 @@ public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInf
         final Path path = provider.getPath(URI.create("git://newasyncrepo-name/file.txt"));
 
         final Set<? extends OpenOption> options = emptySet();
-        try {
-            provider.newAsynchronousFileChannel(path,
-                                                options,
-                                                null);
-            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> provider.newAsynchronousFileChannel(path, options, null))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -96,12 +83,8 @@ public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInf
         final Path link = provider.getPath(URI.create("git://symbolic-repo-name/link.lnk"));
         final Path path = provider.getPath(URI.create("git://symbolic-repo-name/file.txt"));
 
-        try {
-            provider.createSymbolicLink(link,
-                                        path);
-            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> provider.createSymbolicLink(link, path))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -114,12 +97,8 @@ public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInf
         final Path link = provider.getPath(URI.create("git://link-repo-name/link.lnk"));
         final Path path = provider.getPath(URI.create("git://link-repo-name/file.txt"));
 
-        try {
-            provider.createLink(link,
-                                path);
-            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> provider.createLink(link, path))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -131,10 +110,7 @@ public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInf
 
         final Path link = provider.getPath(URI.create("git://read-link-repo-name/link.lnk"));
 
-        try {
-            provider.readSymbolicLink(link);
-            failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-        } catch (Exception e) {
-        }
+        assertThatThrownBy(() -> provider.readSymbolicLink(link))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderWithFoldersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderWithFoldersTest.java
@@ -46,7 +46,7 @@ public class JGitFileSystemImplProviderWithFoldersTest extends AbstractTestInfra
 
         final DirectoryStream<Path> stream = provider.newDirectoryStream(provider.getPath(newRepo),
                                                                          null);
-        assertThat(stream).isNotNull().hasSize(0);
+        assertThat(stream).isEmpty();
     }
 
     @Test
@@ -72,7 +72,7 @@ public class JGitFileSystemImplProviderWithFoldersTest extends AbstractTestInfra
         outStream.close();
 
         assertThat(new File(provider.getGitRepoContainerDir(),
-                            "test/old" + ".git").exists()).isTrue();
+                            "test/old" + ".git")).exists();
 
         int commitsCount = 0;
         for (RevCommit com : ((GitImpl) fs.getGit())._log().all().call()) {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderWithFoldersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderWithFoldersTest.java
@@ -32,7 +32,7 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.fs.jgit.util.GitImpl;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitFileSystemImplProviderWithFoldersTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplTest.java
@@ -19,6 +19,7 @@ package org.uberfire.java.nio.fs.jgit;
 import java.io.File;
 import java.io.IOException;
 
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
@@ -29,8 +30,12 @@ import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 import org.uberfire.java.nio.fs.jgit.util.GitImpl;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class JGitFileSystemImplTest extends AbstractTestInfra {
 
@@ -169,7 +174,7 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
 
         final Path path = fileSystem.getPath("/path/to/some/place.txt");
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.isAbsolute()).isTrue();
         assertThat(path.toString()).isEqualTo("/path/to/some/place.txt");
         assertThat(path.toUri().toString()).isEqualTo("git://master@my-repo/path/to/some/place.txt");
@@ -197,7 +202,7 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
 
         final Path path = fileSystem.getPath("path/to/some/place.txt");
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.isAbsolute()).isFalse();
         assertThat(path.toString()).isEqualTo("path/to/some/place.txt");
         assertThat(path.toUri().toString()).isEqualTo("git://master@my-repo/:path/to/some/place.txt");
@@ -226,7 +231,7 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
         final Path path = fileSystem.getPath("test-branch",
                                              "/path/to/some/place.txt");
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.isAbsolute()).isTrue();
         assertThat(path.toString()).isEqualTo("/path/to/some/place.txt");
         assertThat(path.toUri().toString()).isEqualTo("git://test-branch@my-repo/path/to/some/place.txt");
@@ -255,7 +260,7 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
         final Path path = fileSystem.getPath("test-branch",
                                              "path/to/some/place.txt");
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.isAbsolute()).isFalse();
         assertThat(path.toString()).isEqualTo("path/to/some/place.txt");
         assertThat(path.toUri().toString()).isEqualTo("git://test-branch@my-repo/:path/to/some/place.txt");
@@ -285,7 +290,7 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
                                              "/path/to",
                                              "some/place.txt");
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.isAbsolute()).isTrue();
         assertThat(path.toString()).isEqualTo("/path/to/some/place.txt");
         assertThat(path.toUri().toString()).isEqualTo("git://test-branch@my-repo/path/to/some/place.txt");
@@ -315,7 +320,7 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
                                              "path/to",
                                              "some/place.txt");
 
-        assertThat(path).isNotNull();
+        AssertionsForClassTypes.assertThat(path).isNotNull();
         assertThat(path.isAbsolute()).isFalse();
         assertThat(path.toString()).isEqualTo("path/to/some/place.txt");
         assertThat(path.toUri().toString()).isEqualTo("git://test-branch@my-repo/:path/to/some/place.txt");
@@ -375,9 +380,9 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
         final Path path2 = fileSystem2.getPath("master",
                                                "/path/to/some.txt");
 
-        assertThat(path1).isNotEqualTo(path2);
+        AssertionsForClassTypes.assertThat(path1).isNotEqualTo(path2);
 
-        assertThat(path1).isEqualTo(fileSystem1.getPath("/path/to/some.txt"));
+        AssertionsForClassTypes.assertThat(path1).isEqualTo(fileSystem1.getPath("/path/to/some.txt"));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplTest.java
@@ -432,7 +432,7 @@ public class JGitFileSystemImplTest extends AbstractTestInfra {
     }
 
     @Test
-    public void lockShouldSupportMultiplieInnerLocksForTheSameThreadTest() throws IOException, GitAPIException {
+    public void lockShouldSupportMultipleInnerLocksForTheSameThreadTest() throws IOException, GitAPIException {
         final JGitFileSystemProvider fsProvider = mock(JGitFileSystemProvider.class);
 
         final Git git = setupGit();

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
@@ -42,8 +42,9 @@ import static org.assertj.core.api.Assertions.fail;
 
 public class JGitForkTest extends AbstractTestInfra {
 
-    public static final String TARGET_GIT = "target/target";
-    public static final String SOURCE_GIT = "source/source";
+    private static final String
+            TARGET_GIT = "target/target",
+            SOURCE_GIT = "source/source";
     private static Logger logger = LoggerFactory.getLogger(JGitForkTest.class);
 
     @Test
@@ -158,7 +159,7 @@ public class JGitForkTest extends AbstractTestInfra {
     }
 
     @Test
-    public void testToForkWrongSource() throws IOException, GitAPIException {
+    public void testToForkWrongSource() throws IOException {
         final File parentFolder = createTempDirectory();
 
         try {
@@ -206,7 +207,7 @@ public class JGitForkTest extends AbstractTestInfra {
     }
 
     @Test(expected = FileSystemAlreadyExistsException.class)
-    public void testForkRepositoryThatAlreadyExists() throws GitAPIException {
+    public void testForkRepositoryThatAlreadyExists() {
 
         String SOURCE = "testforkA/source";
         String TARGET = "testforkB/target";

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
@@ -37,8 +37,8 @@ import org.uberfire.java.nio.fs.jgit.util.commands.Fork;
 import org.uberfire.java.nio.fs.jgit.util.commands.ListRefs;
 import org.uberfire.java.nio.fs.jgit.util.exceptions.GitException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class JGitForkTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitMergeTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitMergeTest.java
@@ -21,11 +21,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 import org.uberfire.java.nio.fs.jgit.util.GitImpl;
 import org.uberfire.java.nio.fs.jgit.util.commands.Commit;
@@ -40,11 +37,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitMergeTest extends AbstractTestInfra {
 
-    private static Logger logger = LoggerFactory.getLogger(JGitMergeTest.class);
-    public static final String SOURCE_GIT = "source/source";
+    private static final String SOURCE_GIT = "source/source";
 
     @Test
-    public void testMergeSuccessful() throws IOException, GitAPIException {
+    public void testMergeSuccessful() throws IOException {
         final File parentFolder = createTempDirectory();
 
         final File gitSource = new File(parentFolder,
@@ -130,11 +126,11 @@ public class JGitMergeTest extends AbstractTestInfra {
                                                      new GetTreeFromRef(origin,
                                                                         "develop").execute()).execute();
 
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result).isEmpty();
     }
 
     @Test
-    public void testMergeConflict() throws IOException, GitAPIException {
+    public void testMergeConflict() throws IOException {
         final File parentFolder = createTempDirectory();
 
         final File gitSource = new File(parentFolder,
@@ -181,11 +177,11 @@ public class JGitMergeTest extends AbstractTestInfra {
                                                      new GetTreeFromRef(origin,
                                                                         "develop").execute()).execute();
 
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result).isEmpty();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testParametersNotNull() throws IOException, GitAPIException {
+    public void testParametersNotNull() {
 
         new Merge(null,
                   "develop",
@@ -193,7 +189,7 @@ public class JGitMergeTest extends AbstractTestInfra {
     }
 
     @Test(expected = GitException.class)
-    public void testTryToMergeNonexistentBranch() throws IOException, GitAPIException {
+    public void testTryToMergeNonexistentBranch() throws IOException {
         final File parentFolder = createTempDirectory();
 
         final File gitSource = new File(parentFolder,
@@ -275,7 +271,7 @@ public class JGitMergeTest extends AbstractTestInfra {
     }
 
     @Test(expected = GitException.class)
-    public void testMergeBinaryInformationButHasConflicts() throws IOException, GitAPIException {
+    public void testMergeBinaryInformationButHasConflicts() throws IOException {
 
         final byte[] contentA = this.loadImage("images/drools.png");
         final byte[] contentB = this.loadImage("images/jbpm.png");
@@ -340,11 +336,11 @@ public class JGitMergeTest extends AbstractTestInfra {
                                                      new GetTreeFromRef(origin,
                                                                         "develop").execute()).execute();
 
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result).isEmpty();
     }
 
     @Test
-    public void testMergeBinaryInformationSuccessful() throws IOException, GitAPIException {
+    public void testMergeBinaryInformationSuccessful() throws IOException {
 
         final byte[] contentA = this.loadImage("images/drools.png");
         final byte[] contentB = this.loadImage("images/jbpm.png");
@@ -395,6 +391,6 @@ public class JGitMergeTest extends AbstractTestInfra {
                                                      new GetTreeFromRef(origin,
                                                                         "develop").execute()).execute();
 
-        assertThat(result.size()).isEqualTo(0);
+        assertThat(result).isEmpty();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitMergeTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitMergeTest.java
@@ -36,7 +36,7 @@ import org.uberfire.java.nio.fs.jgit.util.commands.ListDiffs;
 import org.uberfire.java.nio.fs.jgit.util.commands.Merge;
 import org.uberfire.java.nio.fs.jgit.util.exceptions.GitException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JGitMergeTest extends AbstractTestInfra {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitMirrorTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitMirrorTest.java
@@ -21,20 +21,20 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Condition;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.URIish;
-import org.fest.assertions.core.Condition;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.java.nio.fs.jgit.util.commands.Clone;
 import org.uberfire.java.nio.fs.jgit.util.commands.ListRefs;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -133,9 +133,9 @@ public class JGitMirrorTest extends AbstractTestInfra {
 
         assertThat(cloned).isNotNull();
 
-        assertThat(new ListRefs(cloned.getRepository()).execute()).is(new Condition<List<Ref>>() {
+        assertThat(new ListRefs(cloned.getRepository()).execute()).is(new Condition<List<? extends Ref>>() {
             @Override
-            public boolean matches(final List<Ref> refs) {
+            public boolean matches(final List<? extends Ref> refs) {
                 return refs.size() > 0;
             }
         });

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitPathTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitPathTest.java
@@ -22,8 +22,8 @@ import org.uberfire.java.nio.EncodingUtil;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.mockito.Mockito.*;
 
 public class JGitPathTest {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitPathTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitPathTest.java
@@ -22,14 +22,15 @@ import org.uberfire.java.nio.EncodingUtil;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class JGitPathTest {
 
-    final FileSystemProvider fsp = mock(FileSystemProvider.class);
-    final JGitFileSystem fs = mock(JGitFileSystem.class);
+    private final FileSystemProvider fsp = mock(FileSystemProvider.class);
+    private final JGitFileSystem fs = mock(JGitFileSystem.class);
 
     @Before
     public void setup() {
@@ -54,7 +55,7 @@ public class JGitPathTest {
 
         assertThat(path.getNameCount()).isEqualTo(0);
 
-        assertThat(path.getRoot()).isNotNull().isEqualTo(path);
+        assertThat(path.getRoot()).isEqualTo(path);
     }
 
     @Test
@@ -109,8 +110,8 @@ public class JGitPathTest {
 
         assertThat(path.getNameCount()).isEqualTo(4);
 
-        assertThat(path.getName(0).toString()).isNotNull().isEqualTo("path");
-        assertThat(path.getRoot().toString()).isNotNull().isEqualTo("/");
+        assertThat(path.getName(0).toString()).isEqualTo("path");
+        assertThat(path.getRoot().toString()).isEqualTo("/");
     }
 
     @Test
@@ -129,8 +130,8 @@ public class JGitPathTest {
 
         assertThat(path.getNameCount()).isEqualTo(4);
 
-        assertThat(path.getName(0).toString()).isNotNull().isEqualTo("path");
-        assertThat(path.getRoot().toString()).isNotNull().isEqualTo("/");
+        assertThat(path.getName(0).toString()).isEqualTo("path");
+        assertThat(path.getRoot().toString()).isEqualTo("/");
     }
 
     @Test
@@ -149,8 +150,8 @@ public class JGitPathTest {
 
         assertThat(path.getNameCount()).isEqualTo(4);
 
-        assertThat(path.getName(0).toString()).isNotNull().isEqualTo("path");
-        assertThat(path.getRoot().toString()).isNotNull().isEqualTo("/");
+        assertThat(path.getName(0).toString()).isEqualTo("path");
+        assertThat(path.getRoot().toString()).isEqualTo("/");
     }
 
     @Test
@@ -170,12 +171,9 @@ public class JGitPathTest {
 
         assertThat(path.getNameCount()).isEqualTo(0);
 
-        assertThat(path.getRoot().toString()).isNotNull().isEqualTo("/");
-        try {
-            assertThat(path.getName(0).toString()).isNotNull().isEqualTo("");
-            failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
-        } catch (IllegalArgumentException ex) {
-        }
+        assertThat(path.getRoot().toString()).isEqualTo("/");
+        assertThatThrownBy(() -> path.getName(0))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSquashingTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSquashingTest.java
@@ -40,8 +40,8 @@ import org.uberfire.java.nio.fs.jgit.util.commands.GetRef;
 import org.uberfire.java.nio.fs.jgit.util.commands.Squash;
 import org.uberfire.java.nio.fs.jgit.util.exceptions.GitException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.uberfire.java.nio.fs.jgit.util.model.PathType.DIRECTORY;
 import static org.uberfire.java.nio.fs.jgit.util.model.PathType.FILE;
 import static org.uberfire.java.nio.fs.jgit.util.model.PathType.NOT_FOUND;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSquashingTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSquashingTest.java
@@ -57,7 +57,7 @@ public class JGitSquashingTest extends AbstractTestInfra {
 
     /*
      * This test make 5 commits and then squah the last 4 into a single commit
-    */
+     */
     @Test
     public void testSquash4Of5Commits() throws IOException, GitAPIException {
 
@@ -259,7 +259,7 @@ public class JGitSquashingTest extends AbstractTestInfra {
     /*
      * This test also perform 5 commits and squash the last 4 into a single commit
      *  but now the changes are in different paths
-    */
+     */
     @Test
     public void testSquashCommitsWithDifferentPaths() throws IOException, GitAPIException {
 
@@ -363,20 +363,5 @@ public class JGitSquashingTest extends AbstractTestInfra {
         }
 
         assertThat(commitsCount).isEqualTo(2);
-    }
-
-    private void createAddAndCommitFile(GitImpl git,
-                                        String file) throws GitAPIException, IOException {
-        File myfile = new File(git.getRepository().getDirectory().getParent(),
-                               file);
-        myfile.createNewFile();
-
-        git._add()
-                .addFilepattern(file)
-                .call();
-
-        git._commit()
-                .setMessage("Added " + file)
-                .call();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitUtilTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitUtilTest.java
@@ -37,7 +37,7 @@ import org.uberfire.java.nio.fs.jgit.util.commands.GetTreeFromRef;
 import org.uberfire.java.nio.fs.jgit.util.commands.ListDiffs;
 import org.uberfire.java.nio.fs.jgit.util.commands.ListRefs;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.uberfire.java.nio.fs.jgit.util.model.PathType.DIRECTORY;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/NewProviderDefineDirTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/NewProviderDefineDirTest.java
@@ -17,7 +17,6 @@
 package org.uberfire.java.nio.fs.jgit;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
@@ -65,7 +64,7 @@ public class NewProviderDefineDirTest extends AbstractTestInfra {
     }
 
     @Test
-    public void testUsingProvidedPath() throws IOException {
+    public void testUsingProvidedPath() {
         final URI newRepo = URI.create("git://repo-name");
 
         JGitFileSystemProxy fileSystem = (JGitFileSystemProxy) provider.newFileSystem(newRepo,
@@ -86,11 +85,11 @@ public class NewProviderDefineDirTest extends AbstractTestInfra {
 
         names = tempDir.list();
 
-        assertThat(names).isNotEmpty().contains(dirPathName);
+        assertThat(names).contains(dirPathName);
 
         repos = new File(tempDir,
                          dirPathName).list();
 
-        assertThat(repos).isNotEmpty().contains("repo-name.git");
+        assertThat(repos).contains("repo-name.git");
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/NewProviderDefineDirTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/NewProviderDefineDirTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration.GIT_NIO_DIR;
 import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration.GIT_NIO_DIR_NAME;
 import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration.REPOSITORIES_CONTAINER_DIR;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/URITest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/URITest.java
@@ -21,7 +21,7 @@ import java.net.URISyntaxException;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class URITest {
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHServiceTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHServiceTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.uberfire.commons.concurrent.ExecutorServiceProducer;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHServiceTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHServiceTest.java
@@ -32,12 +32,14 @@ import org.uberfire.commons.concurrent.ExecutorServiceProducer;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class GitSSHServiceTest {
 
-    private static final List<File> tempFiles = new ArrayList<File>();
+    private static final List<File> tempFiles = new ArrayList<>();
 
     private final ExecutorService executorService = new ExecutorServiceProducer().produceUnmanagedExecutorService();
 
@@ -65,7 +67,7 @@ public class GitSSHServiceTest {
             try {
                 FileUtils.delete(tempFile,
                                  FileUtils.RECURSIVE);
-            } catch (IOException e) {
+            } catch (IOException ignore) {
             }
         }
     }
@@ -117,9 +119,10 @@ public class GitSSHServiceTest {
         final GitSSHService sshService = new GitSSHService();
         final File certDir = createTempDirectory();
 
+        String idleTimeout = "10000";
         sshService.setup(certDir,
                          null,
-                         "10000",
+                         idleTimeout,
                          "RSA",
                          mock(ReceivePackFactory.class),
                          mock(JGitFileSystemProvider.RepositoryResolverImpl.class),
@@ -128,7 +131,7 @@ public class GitSSHServiceTest {
         sshService.start();
         assertTrue(sshService.isRunning());
 
-        assertTrue("10000".equals(sshService.getSshServer().getProperties().get(SshServer.IDLE_TIMEOUT)));
+        assertThat(sshService.getSshServer().getProperties().get(SshServer.IDLE_TIMEOUT)).isEqualTo(idleTimeout);
 
         sshService.stop();
 

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathEqualsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathEqualsTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.*;
 
 public class GeneralPathEqualsTest {

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathTest.java
@@ -25,6 +25,7 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.Assert.*;
@@ -524,7 +525,7 @@ public class GeneralPathTest {
     }
 
     @Test
-    public void testAbsloluteSimpleToURIUnix() throws Exception {
+    public void testAbsloluteSimpleToURIUnix() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(false);
         when(fsprovider.getScheme()).thenReturn("file");
@@ -543,7 +544,7 @@ public class GeneralPathTest {
     }
 
     @Test
-    public void testAbsoluteToURIUnix() throws Exception {
+    public void testAbsoluteToURIUnix() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
         when(fsprovider.getScheme()).thenReturn("file");
@@ -568,7 +569,7 @@ public class GeneralPathTest {
     }
 
     @Test
-    public void testRelativeToURIUnix() throws Exception {
+    public void testRelativeToURIUnix() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
         when(fsprovider.getScheme()).thenReturn("file");
@@ -590,7 +591,7 @@ public class GeneralPathTest {
     }
 
     @Test
-    public void testAbsoluteToURIWindows() throws Exception {
+    public void testAbsoluteToURIWindows() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
         when(fsprovider.getScheme()).thenReturn("file");
@@ -616,7 +617,7 @@ public class GeneralPathTest {
     }
 
     @Test
-    public void testRelativeToURIWindows() throws Exception {
+    public void testRelativeToURIWindows() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
         when(fsprovider.getScheme()).thenReturn("file");
@@ -681,7 +682,7 @@ public class GeneralPathTest {
         assertThat(resolvedPath5).isEqualTo(path2);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void checkResolveNull() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -694,10 +695,12 @@ public class GeneralPathTest {
                                  "/path/to/",
                                  false);
 
-        path.resolve((String) null);
+        assertThatThrownBy(() -> path.resolve((String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void checkResolveNull2() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -710,7 +713,9 @@ public class GeneralPathTest {
                                  "/path/to/",
                                  false);
 
-        path.resolve((Path) null);
+        assertThatThrownBy(() -> path.resolve((Path) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
     @Test
@@ -934,7 +939,7 @@ public class GeneralPathTest {
         assertThat(relative11).isNotNull().isEqualTo(other11);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeIlegal1() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -950,10 +955,12 @@ public class GeneralPathTest {
                                   "some/place",
                                   false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'isAbsolute()' for 'this' and 'otherx' should be equal.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeIlegal2() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -969,10 +976,12 @@ public class GeneralPathTest {
                                   "/path/to",
                                   false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'isAbsolute()' for 'this' and 'otherx' should be equal.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeIlegal3() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -988,7 +997,9 @@ public class GeneralPathTest {
                                   "/path/to",
                                   false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'isAbsolute()' for 'this' and 'otherx' should be equal.");
     }
 
     @Test
@@ -1188,7 +1199,7 @@ public class GeneralPathTest {
         assertThat(other17.relativize(path17).toString().isEmpty());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeWindowsIllegal1() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -1204,10 +1215,12 @@ public class GeneralPathTest {
                                   "some\\place",
                                   false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'isAbsolute()' for 'this' and 'otherx' should be equal.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeWindowsIllegal2() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -1223,10 +1236,12 @@ public class GeneralPathTest {
                                   "c:\\path\\to",
                                   false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'isAbsolute()' for 'this' and 'otherx' should be equal.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeWindowsIllegal3() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -1242,10 +1257,12 @@ public class GeneralPathTest {
                                   "c:\\path\\to",
                                   false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'isAbsolute()' for 'this' and 'otherx' should be equal.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeWindowsIllegal4() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -1261,10 +1278,12 @@ public class GeneralPathTest {
                                   "c:\\path\\to",
                                   false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'getRoot()' for 'this' and 'otherx' should be equal.");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRelativizeWindowsIllegal5() {
         final FileSystemProvider fsprovider = mock(FileSystemProvider.class);
         when(fsprovider.isDefault()).thenReturn(true);
@@ -1274,13 +1293,15 @@ public class GeneralPathTest {
         when(fs.getSeparator()).thenReturn("\\");
 
         final Path path = create(fs,
-                "/d:/path/to",
-                false);
+                                 "/d:/path/to",
+                                 false);
         final Path other = create(fs,
-                "c:\\path\\to",
-                false);
+                                  "c:\\path\\to",
+                                  false);
 
-        path.relativize(other);
+        assertThatThrownBy(() -> path.relativize(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not relativize path 'otherx', 'getRoot()' for 'this' and 'otherx' should be equal.");
     }
 
     private void assertWindowsUri(String actualUri,

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathTest.java
@@ -25,8 +25,8 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.uberfire.java.nio.base.GeneralPathImpl.create;

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathValidationTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/test/java/org/uberfire/java/nio/base/GeneralPathValidationTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 public class GeneralPathValidationTest {
@@ -34,161 +35,210 @@ public class GeneralPathValidationTest {
         when(fs.getSeparator()).thenReturn("/");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createNull1() {
-        GeneralPathImpl.create(null,
-                               "/path/to/file.txt",
-                               false);
+        assertThatThrownBy(() -> GeneralPathImpl.create(null,
+                                                        "/path/to/file.txt",
+                                                        false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'fs' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createNull2() {
-        GeneralPathImpl.create(fs,
-                               null,
-                               false);
+        assertThatThrownBy(() -> GeneralPathImpl.create(fs,
+                                                        null,
+                                                        false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'path' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFromFileNull1() {
-        GeneralPathImpl.newFromFile(null,
-                                    new File(""));
+        assertThatThrownBy(() -> GeneralPathImpl.newFromFile(null,
+                                                             new File("")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'fs' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void newFromFileNull2() {
-        GeneralPathImpl.newFromFile(fs,
-                                    null);
+        assertThatThrownBy(() -> GeneralPathImpl.newFromFile(fs,
+                                                             null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'file' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getNameNegative() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.getName(-1);
+
+        assertThatThrownBy(() -> path.getName(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid index argument: -1");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void subpathInvaligRange1() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.subpath(-1,
-                     1);
+
+        assertThatThrownBy(() -> path.subpath(-1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid beginIndex argument: -1");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void subpathInvaligRange2() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.subpath(5,
-                     7);
+        assertThatThrownBy(() -> path.subpath(5, 7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid beginIndex argument: 5");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void subpathInvaligRange3() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.subpath(0,
-                     7);
+        assertThatThrownBy(() -> path.subpath(0, 7))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid endIndex argument: 7");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void subpathInvaligRange4() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.subpath(2,
-                     1);
+        assertThatThrownBy(() -> path.subpath(2, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid arguments, beginIndex must be < endIndex, but they were: bI 2, eI 1");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void startsWith() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.startsWith((String) null);
+
+        assertThatThrownBy(() -> path.startsWith((String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void startsWithPath() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.startsWith((Path) null);
+
+        assertThatThrownBy(() -> path.startsWith((Path) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void endsWith() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.endsWith((String) null);
+
+        assertThatThrownBy(() -> path.endsWith((String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void endsWithPath() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.endsWith((Path) null);
+
+        assertThatThrownBy(() -> path.endsWith((Path) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void resolve() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.resolve((String) null);
+
+        assertThatThrownBy(() -> path.resolve((String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void resolvePath() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.resolve((Path) null);
+
+        assertThatThrownBy(() -> path.resolve((Path) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void resolveSibling() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.resolveSibling((String) null);
+
+        assertThatThrownBy(() -> path.resolveSibling((String) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void resolveSiblingPath() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.resolveSibling((Path) null);
+
+        assertThatThrownBy(() -> path.resolveSibling((Path) null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void relativize() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.relativize(null);
+
+        assertThatThrownBy(() -> path.relativize(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'otherx' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void compareTo() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.compareTo(null);
+
+        assertThatThrownBy(() -> path.compareTo(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'other' should be not null!");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void checkEquals() {
         final Path path = GeneralPathImpl.create(fs,
                                                  "/path/to/file.txt",
                                                  false);
-        path.equals(null);
+
+        assertThatThrownBy(() -> path.equals(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'o' should be not null!");
     }
 }

--- a/uberfire-project/uberfire-project-api/src/test/java/org/guvnor/common/services/project/model/WorkspaceProjectTest.java
+++ b/uberfire-project/uberfire-project-api/src/test/java/org/guvnor/common/services/project/model/WorkspaceProjectTest.java
@@ -21,49 +21,52 @@ import org.guvnor.structure.repositories.Repository;
 import org.junit.Test;
 import org.uberfire.backend.vfs.Path;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class WorkspaceProjectTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void OUCanNotBeNull() throws Exception {
-        new WorkspaceProject(null,
-                             mock(Repository.class),
-                             mock(Branch.class),
-                             mock(Module.class));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void ProjectCanNotBeNull() throws Exception {
-        new WorkspaceProject(mock(OrganizationalUnit.class),
-                             null,
-                             mock(Branch.class),
-                             mock(Module.class));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void BranchCanNotBeNull() throws Exception {
-        new WorkspaceProject(mock(OrganizationalUnit.class),
-                             mock(Repository.class),
-                             null,
-                             mock(Module.class));
+    @Test
+    public void OUCanNotBeNull() {
+        assertThatThrownBy(() -> new WorkspaceProject(null,
+                                                      mock(Repository.class),
+                                                      mock(Branch.class),
+                                                      mock(Module.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'organizationalUnit' should be not null!");
     }
 
     @Test
-    public void ModuleCanBeNull() throws Exception {
-        try {
-            new WorkspaceProject(mock(OrganizationalUnit.class),
-                                 mock(Repository.class),
-                                 mock(Branch.class),
-                                 null);
-        } catch (final Exception e) {
-            fail();
-        }
+    public void ProjectCanNotBeNull() {
+        assertThatThrownBy(() -> new WorkspaceProject(mock(OrganizationalUnit.class),
+                                                      null,
+                                                      mock(Branch.class),
+                                                      mock(Module.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'repository' should be not null!");
     }
 
     @Test
-    public void getNameNoModule() throws Exception {
+    public void BranchCanNotBeNull() {
+        assertThatThrownBy(() -> new WorkspaceProject(mock(OrganizationalUnit.class),
+                                                      mock(Repository.class),
+                                                      null,
+                                                      mock(Module.class)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Parameter named 'branch' should be not null!");
+    }
+
+    @Test
+    public void ModuleCanBeNull() {
+        new WorkspaceProject(mock(OrganizationalUnit.class),
+                             mock(Repository.class),
+                             mock(Branch.class),
+                             null);
+    }
+
+    @Test
+    public void getNameNoModule() {
         final Repository repository = mock(Repository.class);
         doReturn("my-repo").when(repository).getAlias();
 
@@ -77,7 +80,7 @@ public class WorkspaceProjectTest {
     }
 
     @Test
-    public void getName() throws Exception {
+    public void getName() {
         final Repository repository = mock(Repository.class);
         doReturn("my-repo").when(repository).getAlias();
 
@@ -94,7 +97,7 @@ public class WorkspaceProjectTest {
     }
 
     @Test
-    public void getNameNoModuleName() throws Exception {
+    public void getNameNoModuleName() {
         final Repository repository = mock(Repository.class);
         doReturn("my-repo").when(repository).getAlias();
 
@@ -111,10 +114,10 @@ public class WorkspaceProjectTest {
     }
 
     @Test
-    public void getRootPath() throws Exception {
+    public void getRootPath() {
         final Branch branch = mock(Branch.class);
         final Path branchPath = mock(Path.class);
-        doReturn(branchPath).when(branch).getPath();
+        when(branch.getPath()).thenReturn(branchPath);
 
         final WorkspaceProject workspaceProject = new WorkspaceProject(mock(OrganizationalUnit.class),
                                                                        mock(Repository.class),
@@ -126,7 +129,7 @@ public class WorkspaceProjectTest {
     }
 
     @Test
-    public void requiresRefresh() throws Exception {
+    public void requiresRefresh() {
         final WorkspaceProject workspaceProject = new WorkspaceProject(mock(OrganizationalUnit.class),
                                                                        mock(Repository.class),
                                                                        mock(Branch.class),

--- a/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/AuthorizationManagerTest.java
+++ b/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/AuthorizationManagerTest.java
@@ -40,6 +40,7 @@ import org.uberfire.security.authz.PermissionTypeRegistry;
 import org.uberfire.security.authz.RuntimeResource;
 import org.uberfire.security.authz.VotingStrategy;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -132,12 +133,15 @@ public class AuthorizationManagerTest {
                         .build());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void avoidPermissionTypesCollision() {
         PermissionType permissionType = mock(PermissionType.class);
         when(permissionType.getType()).thenReturn("type");
         permissionTypeRegistry.register(permissionType);
-        permissionTypeRegistry.register(permissionType);
+
+        assertThatThrownBy(() -> permissionTypeRegistry.register(permissionType))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("PermissionType already exists: type");
     }
 
     @Test

--- a/uberfire-server/pom.xml
+++ b/uberfire-server/pom.xml
@@ -87,6 +87,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-fs</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/uberfire-server/src/test/java/org/uberfire/server/UberFireGeneralFactoryTest.java
+++ b/uberfire-server/src/test/java/org/uberfire/server/UberFireGeneralFactoryTest.java
@@ -33,6 +33,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.server.cdi.UberFireGeneralFactory;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -68,7 +69,7 @@ public class UberFireGeneralFactoryTest {
     }
 
     @Test
-    public void returnDefaultUserOutsideOfSessionThread() throws Exception {
+    public void returnDefaultUserOutsideOfSessionThread() {
         when(userInstance.isAmbiguous()).thenReturn(false);
         when(userInstance.isUnsatisfied()).thenReturn(false);
         when(userInstance.get()).thenReturn(defaultUser);
@@ -79,7 +80,7 @@ public class UberFireGeneralFactoryTest {
     }
 
     @Test
-    public void returnAuthenticatedUserInSessionThread() throws Exception {
+    public void returnAuthenticatedUserInSessionThread() {
         when(userInstance.isAmbiguous()).thenReturn(false);
         when(userInstance.isUnsatisfied()).thenReturn(false);
         when(userInstance.get()).thenReturn(defaultUser);
@@ -92,12 +93,14 @@ public class UberFireGeneralFactoryTest {
                    sessionInfo.getIdentity());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void throwIllegalStateExceptionOutsideOfSessionThreadWithoutDefaultUser() throws Exception {
+    @Test
+    public void throwIllegalStateExceptionOutsideOfSessionThreadWithoutDefaultUser() {
         when(userInstance.isAmbiguous()).thenReturn(false);
         when(userInstance.isUnsatisfied()).thenReturn(true);
         when(userInstance.get()).thenReturn(defaultUser);
 
-        factory.getSessionInfo(authService);
+        assertThatThrownBy(() -> factory.getSessionInfo(authService))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Cannot get session info outside of servlet thread when no default user is provided.");
     }
 }


### PR DESCRIPTION
@ederign please check. This is the followup to fest-assert cleanup as promised yesterday.

- got rid of fest-assert-core completely
- replaced all occurrences with assertJ
- removed duplicate declarations of assertj-core from poms (we only need one in uberfire parent)
- cleaned up assertJ usage (e.g better way to test for exceptions being thrown, removed redundant `.isNotNull()` calls, 
```
assertThat(dir.toFile().exists()).isTrue(); -> assertThat(dir.toFile()).exists();
```
etc.
Note that sometimes it was necessary to use `AssertionsForClassTypes` instead of `Assertions`, because e.g. `Path` is also `Iterable` so `Assertions.assertThat(path)...` was ambiguous