### PR TITLE
RHBA-506: Use Initial context to retrieve connection factory

### DIFF
--- a/uberfire-commons/pom.xml
+++ b/uberfire-commons/pom.xml
@@ -50,56 +50,14 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <!-- ActiveMQ (artemis) -->
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>artemis-jms-client</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.geronimo.specs</groupId>
-          <artifactId>geronimo-jms_2.0_spec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-all</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.jms</groupId>
       <artifactId>jboss-jms-api_2.0_spec</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-buffer</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <classifier>${netty-transport-native-epoll-classifier}</classifier>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
-      <classifier>${netty-transport-native-kqueue-classifier}</classifier>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-    </dependency>
-    <!-- /ActiveMQ (artemis) -->
   </dependencies>
 
 

--- a/uberfire-commons/src/main/java/org/uberfire/commons/cluster/ClusterParameters.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/cluster/ClusterParameters.java
@@ -15,27 +15,29 @@
  */
 package org.uberfire.commons.cluster;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ClusterParameters {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ClusterParameters.class);
 
     public static final String APPFORMER_CLUSTER = "appformer-cluster";
     public static final String APPFORMER_DEFAULT_CLUSTER_CONFIGS = "appformer-default-cluster-configs";
-    public static final String APPFORMER_JMS_URL = "appformer-jms-url";
+    public static final String APPFORMER_PROVIDER_URL = "appformer-jms-url";
+    public static final String APPFORMER_INITIAL_CONTEXT_FACTORY = "appformer-initial-context-factory";
+    public static final String APPFORMER_JMS_CONNECTION_FACTORY = "appformer-jms-connection-factory";
     public static final String APPFORMER_JMS_USERNAME = "appformer-jms-username";
     public static final String APPFORMER_JMS_PASSWORD = "appformer-jms-password";
     private Boolean appFormerClustered;
-    private String jmsURL;
+    private String providerUrl;
+    private String initialContextFactory;
+    private String jmsConnectionFactoryJndiName;
     private String jmsUserName;
     private String jmsPassword;
 
     public ClusterParameters() {
-
         this.appFormerClustered = Boolean.valueOf(System.getProperty(APPFORMER_CLUSTER,
                                                                      "false"));
+        this.initialContextFactory = System.getProperty(APPFORMER_INITIAL_CONTEXT_FACTORY,
+                                                        "org.wildfly.naming.client.WildFlyInitialContextFactory");
+        this.jmsConnectionFactoryJndiName = System.getProperty(APPFORMER_JMS_CONNECTION_FACTORY,
+                                                               "java:/ConnectionFactory");
         if (appFormerClustered) {
 
             Boolean defaultConfigs = Boolean.valueOf(System.getProperty(APPFORMER_DEFAULT_CLUSTER_CONFIGS,
@@ -49,16 +51,15 @@ public class ClusterParameters {
     }
 
     private void setupDefaultConfigs() {
-        this.jmsURL = "tcp://localhost:61616";
         this.jmsUserName = "admin";
         this.jmsPassword = "admin";
     }
 
     private void loadConfigs() {
-        this.jmsURL = System.getProperty(APPFORMER_JMS_URL);
+        this.providerUrl = System.getProperty(APPFORMER_PROVIDER_URL);
         this.jmsUserName = System.getProperty(APPFORMER_JMS_USERNAME);
         this.jmsPassword = System.getProperty(APPFORMER_JMS_PASSWORD);
-        if (jmsURL == null || jmsPassword == null || jmsPassword == null) {
+        if (jmsUserName == null || jmsPassword == null) {
             throw new RuntimeException(buildErrorMessage().toString());
         }
     }
@@ -66,9 +67,9 @@ public class ClusterParameters {
     private StringBuilder buildErrorMessage() {
         StringBuilder sb = new StringBuilder();
         sb.append("There is a error on appFormer cluster configurations: ");
-        sb.append(APPFORMER_CLUSTER + ": " + appFormerClustered);
-        sb.append(APPFORMER_JMS_URL + ": " + jmsURL);
-        sb.append(APPFORMER_JMS_USERNAME + ": " + jmsPassword);
+        sb.append(APPFORMER_CLUSTER + ": " + appFormerClustered + ", ");
+        sb.append(APPFORMER_PROVIDER_URL + ": " + providerUrl + ", ");
+        sb.append(APPFORMER_JMS_USERNAME + ": " + jmsUserName + ", ");
         sb.append(APPFORMER_JMS_PASSWORD + ": " + jmsPassword);
         return sb;
     }
@@ -77,8 +78,8 @@ public class ClusterParameters {
         return appFormerClustered;
     }
 
-    public String getJmsURL() {
-        return jmsURL;
+    public String getProviderUrl() {
+        return providerUrl;
     }
 
     public String getJmsUserName() {
@@ -87,5 +88,13 @@ public class ClusterParameters {
 
     public String getJmsPassword() {
         return jmsPassword;
+    }
+
+    public String getInitialContextFactory() {
+        return initialContextFactory;
+    }
+
+    public String getJmsConnectionFactoryJndiName() {
+        return jmsConnectionFactoryJndiName;
     }
 }

--- a/uberfire-commons/src/main/java/org/uberfire/commons/cluster/context/ClusterContextProperties.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/cluster/context/ClusterContextProperties.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.commons.cluster.context;
+
+import java.util.Properties;
+
+import org.uberfire.commons.cluster.ClusterParameters;
+
+public interface ClusterContextProperties {
+
+    Properties getClusterContextEnvironment(ClusterParameters clusterParameters);
+}

--- a/uberfire-commons/src/main/java/org/uberfire/commons/cluster/context/LocalClusterContextProperties.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/cluster/context/LocalClusterContextProperties.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.commons.cluster.context;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.uberfire.commons.cluster.ClusterParameters;
+
+public class LocalClusterContextProperties implements ClusterContextProperties {
+
+    @Override
+    public Properties getClusterContextEnvironment(ClusterParameters clusterParameters) {
+        String initialContextFactory = clusterParameters.getInitialContextFactory();
+
+        validateInitialContextFactory(initialContextFactory);
+
+        final Properties env = new Properties();
+        env.put(Context.INITIAL_CONTEXT_FACTORY,
+                initialContextFactory);
+
+        return env;
+    }
+
+    private void validateInitialContextFactory(String initialContextFactory) {
+        if (initialContextFactory == null || initialContextFactory.isEmpty()) {
+            throw new RuntimeException("Required parameter " + ClusterParameters.APPFORMER_INITIAL_CONTEXT_FACTORY + " is not defined.");
+        }
+    }
+}

--- a/uberfire-commons/src/main/java/org/uberfire/commons/cluster/context/RemoteClusterContextProperties.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/cluster/context/RemoteClusterContextProperties.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.commons.cluster.context;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import javax.naming.Context;
+
+import org.uberfire.commons.cluster.ClusterParameters;
+
+public class RemoteClusterContextProperties implements ClusterContextProperties {
+
+    @Override
+    public Properties getClusterContextEnvironment(ClusterParameters clusterParameters) {
+        String initialContextFactory = clusterParameters.getInitialContextFactory();
+        String providerUrl = clusterParameters.getProviderUrl();
+        String providerUserName = clusterParameters.getJmsUserName();
+        String providerPassword = clusterParameters.getJmsPassword();
+
+        validateClusterParameters(clusterParameters);
+
+        final Properties env = new Properties();
+        env.put(Context.INITIAL_CONTEXT_FACTORY,
+                initialContextFactory);
+        env.put(Context.PROVIDER_URL,
+                providerUrl);
+        env.put(Context.SECURITY_PRINCIPAL, providerUserName);
+        env.put(Context.SECURITY_CREDENTIALS, providerPassword);
+
+        return env;
+    }
+
+    private void validateClusterParameters(ClusterParameters clusterParameters) {
+        List<String> missingProperties = new ArrayList<>();
+
+        if (clusterParameters.getInitialContextFactory() == null || clusterParameters.getInitialContextFactory().isEmpty()) {
+            missingProperties.add(ClusterParameters.APPFORMER_INITIAL_CONTEXT_FACTORY);
+        }
+        if (clusterParameters.getProviderUrl() == null || clusterParameters.getProviderUrl().isEmpty()) {
+            missingProperties.add(ClusterParameters.APPFORMER_PROVIDER_URL);
+        }
+        if (clusterParameters.getJmsUserName() == null || clusterParameters.getJmsUserName().isEmpty()) {
+            missingProperties.add(ClusterParameters.APPFORMER_JMS_USERNAME);
+        }
+        if (clusterParameters.getJmsPassword() == null || clusterParameters.getJmsPassword().isEmpty()) {
+            missingProperties.add(ClusterParameters.APPFORMER_JMS_PASSWORD);
+        }
+
+        if (!missingProperties.isEmpty()) {
+            String missingPropertiesString = missingProperties.stream().collect(Collectors.joining(", "));
+            throw new RuntimeException("Required parameters " + missingPropertiesString + " are not defined.");
+        }
+    }
+}

--- a/uberfire-commons/src/test/java/org/uberfire/commons/cluster/ClusterJMSServiceTest.java
+++ b/uberfire-commons/src/test/java/org/uberfire/commons/cluster/ClusterJMSServiceTest.java
@@ -15,50 +15,67 @@
  */
 package org.uberfire.commons.cluster;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Hashtable;
+
 import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
 import javax.jms.Session;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
 
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import static org.assertj.core.api.Assertions.*;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.mockito.Mockito.*;
+import org.uberfire.commons.cluster.context.LocalClusterContextProperties;
+import org.uberfire.commons.cluster.context.RemoteClusterContextProperties;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterJMSServiceTest {
 
-    private ClusterService clusterService;
-    private ActiveMQConnectionFactory factory;
+    private static ConnectionFactory factory;
     private Connection connection;
     private Session session1;
     private Session session2;
 
     @Before
     public void setup() throws JMSException {
+        System.setProperty(ClusterParameters.APPFORMER_INITIAL_CONTEXT_FACTORY,
+                this.getClass().getCanonicalName() + "$MyContextFactory");
 
-        factory = mock(ActiveMQConnectionFactory.class);
+        factory = mock(ConnectionFactory.class);
         connection = mock(Connection.class);
-        when(factory.createConnection()).thenReturn(connection);
+        when(factory.createConnection(any(), any())).thenReturn(connection);
         session1 = mock(Session.class);
         session2 = mock(Session.class);
         when(connection.createSession(eq(false),
                                       eq(Session.AUTO_ACKNOWLEDGE)))
                 .thenReturn(session1, session2);
-        clusterService = new ClusterJMSService() {
-            @Override
-            ActiveMQConnectionFactory createConnectionFactory(String jmsURL,
-                                                              String jmsUserName,
-                                                              String jmsPassword) {
-                return factory;
-            }
-        };
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(ClusterParameters.APPFORMER_CLUSTER);
+        System.clearProperty(ClusterParameters.APPFORMER_PROVIDER_URL);
+        System.clearProperty(ClusterParameters.APPFORMER_INITIAL_CONTEXT_FACTORY);
+        System.clearProperty(ClusterParameters.APPFORMER_JMS_USERNAME);
+        System.clearProperty(ClusterParameters.APPFORMER_JMS_PASSWORD);
     }
 
     @Test
     public void connectTest() throws JMSException {
+        ClusterJMSService clusterService = new ClusterJMSService();
         clusterService.connect();
         verify(connection).setExceptionListener(any());
         verify(connection).start();
@@ -66,6 +83,7 @@ public class ClusterJMSServiceTest {
 
     @Test
     public void sessionConsumersCreatedShouldBeClosed() throws JMSException {
+        ClusterJMSService clusterService = new ClusterJMSService();
         clusterService.connect();
 
         clusterService.createConsumer(ClusterJMSService.DestinationType.PubSub,
@@ -83,5 +101,45 @@ public class ClusterJMSServiceTest {
         verify(session1).close();
         verify(session2).close();
         verify(connection).close();
+    }
+
+    @Test
+    public void testLocalClusterContextProperties() {
+        System.setProperty(ClusterParameters.APPFORMER_CLUSTER,
+                "true");
+        System.setProperty(ClusterParameters.APPFORMER_JMS_USERNAME,
+                "admin");
+        System.setProperty(ClusterParameters.APPFORMER_JMS_PASSWORD,
+                "admin");
+        ClusterJMSService clusterService = new ClusterJMSService();
+
+        clusterService.connect();
+        assertThat(clusterService.getClusterContextProperties()).isInstanceOf(LocalClusterContextProperties.class);
+    }
+
+    @Test
+    public void testRemoteClusterContextProperties() {
+        System.setProperty(ClusterParameters.APPFORMER_CLUSTER,
+                "true");
+        System.setProperty(ClusterParameters.APPFORMER_PROVIDER_URL,
+                "http-remote://localhost:8080");
+        System.setProperty(ClusterParameters.APPFORMER_JMS_USERNAME,
+                "admin");
+        System.setProperty(ClusterParameters.APPFORMER_JMS_PASSWORD,
+                "admin");
+        ClusterJMSService clusterService = new ClusterJMSService();
+
+        clusterService.connect();
+        assertThat(clusterService.getClusterContextProperties()).isInstanceOf(RemoteClusterContextProperties.class);
+    }
+
+    public static class MyContextFactory implements InitialContextFactory {
+
+        @Override
+        public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
+            InitialContext mockCtx = mock(InitialContext.class);
+            when(mockCtx.lookup("java:/ConnectionFactory")).thenReturn(factory);
+            return mockCtx;
+        }
     }
 }

--- a/uberfire-commons/src/test/java/org/uberfire/commons/cluster/context/LocalClusterContextPropertiesTest.java
+++ b/uberfire-commons/src/test/java/org/uberfire/commons/cluster/context/LocalClusterContextPropertiesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.commons.cluster.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.commons.cluster.ClusterParameters;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LocalClusterContextPropertiesTest {
+
+    @Test
+    public void testGetClusterContextEnvironment() {
+        ClusterParameters clusterParameters = mock(ClusterParameters.class);
+        when(clusterParameters.getInitialContextFactory()).thenReturn("org.wildfly.naming.client.WildFlyInitialContextFactory");
+
+        LocalClusterContextProperties contextProperties = new LocalClusterContextProperties();
+        Properties environment = contextProperties.getClusterContextEnvironment(clusterParameters);
+
+        assertThat(environment).hasSize(1)
+                               .containsKey(Context.INITIAL_CONTEXT_FACTORY)
+                               .containsValue("org.wildfly.naming.client.WildFlyInitialContextFactory");
+    }
+
+    @Test
+    public void testGetClusterContextEnvironmentNullInitialContextFactory() {
+        ClusterParameters clusterParameters = mock(ClusterParameters.class);
+
+        LocalClusterContextProperties contextProperties = new LocalClusterContextProperties();
+        assertThatCode(() -> contextProperties.getClusterContextEnvironment(clusterParameters)).isExactlyInstanceOf(RuntimeException.class);
+    }
+}

--- a/uberfire-commons/src/test/java/org/uberfire/commons/cluster/context/RemoteClusterContextPropertiesTest.java
+++ b/uberfire-commons/src/test/java/org/uberfire/commons/cluster/context/RemoteClusterContextPropertiesTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.commons.cluster.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.commons.cluster.ClusterParameters;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoteClusterContextPropertiesTest {
+
+    @Test
+    public void testGetClusterContextEnvironment() {
+        ClusterParameters clusterParameters = mock(ClusterParameters.class);
+        when(clusterParameters.getInitialContextFactory()).thenReturn("org.wildfly.naming.client.WildFlyInitialContextFactory");
+        when(clusterParameters.getProviderUrl()).thenReturn("http-remote://localhost:8080");
+        when(clusterParameters.getJmsUserName()).thenReturn("admin");
+        when(clusterParameters.getJmsPassword()).thenReturn("adminPassword");
+
+        RemoteClusterContextProperties contextProperties = new RemoteClusterContextProperties();
+        Properties environment = contextProperties.getClusterContextEnvironment(clusterParameters);
+
+        assertThat(environment).hasSize(4)
+                               .containsKeys(Context.INITIAL_CONTEXT_FACTORY,
+                                             Context.PROVIDER_URL,
+                                             Context.SECURITY_PRINCIPAL,
+                                             Context.SECURITY_CREDENTIALS)
+                               .containsValues("org.wildfly.naming.client.WildFlyInitialContextFactory",
+                                               "http-remote://localhost:8080",
+                                               "admin",
+                                               "adminPassword");
+    }
+
+    @Test
+    public void testGetClusterContextEnvironmentNullClusterParametersValues() {
+        ClusterParameters clusterParameters = mock(ClusterParameters.class);
+
+        RemoteClusterContextProperties contextProperties = new RemoteClusterContextProperties();
+        assertThatCode(() -> contextProperties.getClusterContextEnvironment(clusterParameters)).isExactlyInstanceOf(RuntimeException.class);
+    }
+}

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
@@ -88,6 +88,11 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
 


### PR DESCRIPTION
@ederign Please take a look on this.

There are two possibilities how connect into the JMS broker.

- Use local Initial context. This is the default option, use Initial context of application server where the Workbench is running. External JMS broker can be specified using this option by adding connection factory backed by proper resource adapter to the application server.

- Use remote Initial context. This can be used for the case if the user wants to connect to external application server. In this case the user needs to add proper connection factory classes into server classpath (for example adding `org.apache.activemq.artemis` module as dependency of the Workbench).

By default there is used connection factory with JNDI `java:/ConnectionFactory` from local context, which is available by default.