### PR TITLE
JBPM-6110 - Adding support to export a canvas context to SVG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         produces a conflict with the UF ace js plugin once trying to create a new jsPDF
         instance.-->
     <version.org.webjars.bower.jspdf>1.2.61</version.org.webjars.bower.jspdf>
+    <version.org.webjars.bowergithub.gliffy.canvas2svg>0.1</version.org.webjars.bowergithub.gliffy.canvas2svg>
     <version.org.gwtbootstrap3>0.9.3</version.org.gwtbootstrap3>
 
     <version.org.jboss.byteman>3.0.10</version.org.jboss.byteman>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -144,6 +144,29 @@
               <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
+
+          <execution>
+            <id>unpack-canvas2svg</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.webjars.bowergithub.gliffy</groupId>
+                  <artifactId>canvas2svg</artifactId>
+                  <version>${version.org.webjars.bowergithub.gliffy.canvas2svg}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/canvas2svg</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+
         </executions>
       </plugin>
       <plugin>
@@ -181,6 +204,25 @@
                   <directory>${project.build.directory}/jspdf/META-INF/resources/webjars/jspdf/${version.org.webjars.bower.jspdf}/dist/</directory>
                   <includes>
                     <include>jspdf.min.js</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+
+          <execution>
+            <id>copy-canvas2svg-resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/org/uberfire/ext/editor/commons/client/file/exports/js</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/canvas2svg/META-INF/resources/webjars/canvas2svg/</directory>
+                  <includes>
+                    <include>canvas2svg.js</include>
                   </includes>
                 </resource>
               </resources>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/AbstractFileExport.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/AbstractFileExport.java
@@ -34,7 +34,7 @@ public abstract class AbstractFileExport<T> implements FileExport<T> {
         });
     }
 
-    AbstractFileExport(final BiConsumer<Blob, String> saveAs) {
+    protected AbstractFileExport(final BiConsumer<Blob, String> saveAs) {
         this.fileSaver = saveAs;
     }
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportProducer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportProducer.java
@@ -22,6 +22,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import org.uberfire.ext.editor.commons.client.file.exports.jso.FileExportScriptInjector;
+import org.uberfire.ext.editor.commons.client.file.exports.svg.SvgFileExport;
 
 /**
  * The FileExport bean factory.
@@ -59,5 +60,10 @@ public class FileExportProducer {
     @Produces
     public ImageFileExport forImage() {
         return new ImageFileExport();
+    }
+
+    @Produces
+    public SvgFileExport forSvg() {
+        return new SvgFileExport();
     }
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportResources.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/FileExportResources.java
@@ -34,4 +34,7 @@ public interface FileExportResources extends ClientBundle {
     // The jsPDF js.
     @Source("js/jspdf.min.js")
     TextResource jsPdf();
+
+    @Source("js/canvas2svg.js")
+    TextResource canvas2svg();
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
@@ -18,6 +18,8 @@ package org.uberfire.ext.editor.commons.client.file.exports.jso;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import com.google.gwt.core.client.ScriptInjector;
@@ -37,6 +39,7 @@ public class FileExportScriptInjector {
     public static final String NS = "org.uberfire.ext.editor.commons.client.file.exports.jso.";
     public static final String NS_SEPARATOR = ".";
     public static final String JS_OBJ_SUFFIX = " || {};";
+    private static Logger LOGGER = Logger.getLogger(FileExportScriptInjector.class.getName());
 
     private final Consumer<String> scriptInjector;
 
@@ -51,8 +54,10 @@ public class FileExportScriptInjector {
     public void inject() {
         final String fileSaver = getFileSaverSource();
         final String jsPdf = getJsPdfSource();
+        final String c2sSource = getC2SSource();
         scriptInjector.accept("var " + fileSaver + "\n" +
-                                      jsPdf + "\n");
+                                      jsPdf + "\n" +
+                                      c2sSource + "\n");
     }
 
     private String getFileSaverSource() {
@@ -70,6 +75,10 @@ public class FileExportScriptInjector {
                 jsPdfScript + "\n" +
                 "var saveAs = " + NS + "JsFileSaver.saveAs; " +
                 "return new jsPDF(settings);};";
+    }
+
+    private String getC2SSource() {
+        return FileExportResources.INSTANCE.canvas2svg().getText();
     }
 
     private static void inject(final String raw) {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
@@ -18,7 +18,6 @@ package org.uberfire.ext.editor.commons.client.file.exports.jso;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -39,7 +38,6 @@ public class FileExportScriptInjector {
     public static final String NS = "org.uberfire.ext.editor.commons.client.file.exports.jso.";
     public static final String NS_SEPARATOR = ".";
     public static final String JS_OBJ_SUFFIX = " || {};";
-    private static Logger LOGGER = Logger.getLogger(FileExportScriptInjector.class.getName());
 
     private final Consumer<String> scriptInjector;
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
+
+import elemental2.core.Array;
+import elemental2.dom.CanvasGradient;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLCanvasElement;
+import elemental2.dom.ImageData;
+import elemental2.dom.Node;
+import elemental2.dom.TextMetrics;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+/**
+ * This is a JsInterop class responsible to make the interface to the <b>canvas2svg</b> library,
+ * and the overlay operations to export canvas to SVG.
+ * @see <a href="https://github.com/gliffy/canvas2svg">https://github.com/gliffy/canvas2svg</a>
+ */
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
+class C2S {
+
+    @JsOverlay
+    protected static final C2S create(double width, double height, Object nativeContext) {
+        C2SSettings settings = new C2SSettings();
+        settings.setWidth(width);
+        settings.setHeight(height);
+        settings.setEnableMirroring(true);
+        settings.setCtx(nativeContext);
+        C2S c2S = new C2S(settings);
+        c2S.setImageSmoothingEnabled(false);
+        return c2S;
+    }
+
+    protected C2S(C2SSettings options) {
+    }
+
+    //----------------------------- C2S Methods  -----------------------------
+
+    @JsProperty
+    private final native void setOptions(C2SSettings settings);
+
+    public final native String getSerializedSvg();
+
+    public final native Element getSvg();
+
+    //----------------------------- Native Context Methods -----------------------------
+    @JsProperty
+    public final native void setFillStyle(String fillStyleColor);
+
+    @JsProperty
+    public final native void setStrokeStyle(String fillStyleColor);
+
+    @JsProperty
+    public final native void setLineWidth(double var1);
+
+    @JsProperty
+    public final native void setLineCap(String lineCap);
+
+    @JsProperty
+    public final native void setLineJoin(String lineJoin);
+
+    @JsProperty
+    public final native void setImageSmoothingEnabled(boolean enabled);
+
+    @JsProperty
+    public final native void setFont(String font);
+
+    @JsProperty
+    public final native void setTextBaseline(String baseline);
+
+    @JsProperty
+    public final native void setTextAlign(String align);
+
+    @JsProperty
+    public final native void setGlobalAlpha(double alpha);
+
+    @JsProperty
+    public final native void setShadowColor(String color);
+
+    @JsProperty
+    public final native void setShadowOffsetX(double color);
+
+    @JsProperty
+    public final native void setShadowOffsetY(double color);
+
+    @JsProperty
+    public final native void setShadowBlur(int color);
+
+    @JsProperty
+    public final native void setMiterLimit(double limit);
+
+    @JsProperty
+    public final native void setLineDashOffset(double offset);
+
+    public final native void save();
+
+    public final native void restore();
+
+    public final native void beginPath();
+
+    public final native void closePath();
+
+    public final native void moveTo(double x, double y);
+
+    public final native void lineTo(double x, double y);
+
+    public final native void setGlobalCompositeOperation(String operation);
+
+    public final native void quadraticCurveTo(double cpx, double cpy, double x, double y);
+
+    public final native void arc(double x, double y, double radius, double startAngle, double endAngle);
+
+    public final native void arc(double x, double y, double radius, double startAngle, double endAngle, boolean antiClockwise);
+
+    public final native void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea, boolean ac);
+
+    public final native void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea);
+
+    public final native void arcTo(double x1, double y1, double x2, double y2, double radius);
+
+    public final native void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y);
+
+    public final native void clearRect(double x, double y, double w, double h);
+
+    public final native void clip();
+
+    public final native void fill();
+
+    public final native void stroke();
+
+    public final native void fillRect(double x, double y, double w, double h);
+
+    public final native void fillText(String text, double x, double y);
+
+    public final native CanvasGradient createLinearGradient(double x0, double y0, double x1, double y1);
+
+    public final native CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1);
+
+    public final native void rect(double x, double y, double w, double h);
+
+    public final native void rotate(double angle);
+
+    public final native void scale(double sx, double sy);
+
+    public final native void transform(double d0, double d1, double d2, double d3, double d4, double d5);
+
+    public final native void setTransform(double d0, double d1, double d2, double d3, double d4, double d5);
+
+    public final native void strokeText(String text, double x, double y);
+
+    public final native void translate(double x, double y);
+
+    public final native boolean isPointInPath(double x, double y);
+
+    public final native void putImageData(ImageData imageData, double x, double y);
+
+    public final native void putImageData(ImageData imageData, double x, double y, double dx, double dy, double dw, double dh);
+
+    public final native void resetClip();
+
+    public final native void setLineDash(double[] dashes);
+
+    public final native TextMetrics measureText(String text);
+
+    public final native HTMLCanvasElement createImageData(ImageData data);
+
+    public final native ImageData getImageData(double x, double y, double width, double height);
+
+    public final native ImageData createImageData(double width, double height);
+
+    public final native void drawImage(Element image, double x, double y);
+
+    public final native void drawImage(Element image, double x, double y, double w, double h);
+
+    public final native void drawImage(Element image, double sx, double sy, double sw, double sh, double x, double y, double w, double h);
+
+    // -----------------------------JS overlay save/restore group -----------------------------
+    @JsOverlay
+    public final void saveGroup() {
+        Element group = this.__createElement("g");
+        Element parent = this.__closestGroupOrSvg(null);
+        this.__groupStack.push(parent);
+        parent.appendChild(group);
+        this.__currentElement = group;
+    }
+
+    @JsOverlay
+    public final void restoreGroup() {
+        this.__currentElement = (Node) this.__groupStack.pop();
+        //Clearing canvas will make the poped group invalid, currentElement is set to the root group node.
+        if (this.__currentElement == null) {
+            this.__currentElement = this.__root.childNodes.item(1);
+        }
+    }
+
+    @JsOverlay
+    public final void saveStyle() {
+        this.__stack.push(this.__getStyleState());
+    }
+
+    @JsOverlay
+    public final void restoreStyle() {
+        this.__currentElementsToStyle = null;
+        Object state = this.__stack.pop();
+        this.__applyStyleState(state);
+    }
+
+    public final native Element __createElement(String elementName);
+
+    public final native Element __closestGroupOrSvg(Object node);
+
+    public final native Object __getStyleState();
+
+    public final native void __applyStyleState(Object styleState);
+
+    @JsProperty
+    public Array __groupStack;
+
+    @JsProperty
+    public Array __stack;
+
+    @JsProperty
+    public Node __currentElement;
+
+    @JsProperty
+    public Node __root;
+
+    @JsProperty
+    public Object __currentElementsToStyle;
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2D.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2D.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
+
+import elemental2.dom.CanvasGradient;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLCanvasElement;
+import elemental2.dom.ImageData;
+import elemental2.dom.TextMetrics;
+import jsinterop.annotations.JsOverlay;
+import org.uberfire.ext.editor.commons.client.file.exports.svg.IContext2D;
+
+/**
+ * Delegation class to allow the abstraction of {@link IContext2D}, since the JsInterop classes does not allow
+ * methods override with {@link JsOverlay} annotation.
+ */
+public class C2SContext2D implements IContext2D {
+
+    private final C2S delegate;
+
+    public C2SContext2D(double width, double height, Object nativeContext) {
+        delegate = C2S.create(width, height, nativeContext);
+    }
+
+    protected C2SContext2D(C2S delegate) {
+        this.delegate = delegate;
+    }
+
+    public String getSerializedSvg() {
+        return delegate.getSerializedSvg();
+    }
+
+    public void setFillStyle(String fillStyleColor) {
+        delegate.setFillStyle(fillStyleColor);
+    }
+
+    public void setStrokeStyle(String fillStyleColor) {
+        delegate.setStrokeStyle(fillStyleColor);
+    }
+
+    public void setLineWidth(double var1) {
+        delegate.setLineWidth(var1);
+    }
+
+    public void setLineCap(String lineCap) {
+        delegate.setLineCap(lineCap);
+    }
+
+    public void setLineJoin(String lineJoin) {
+        delegate.setLineJoin(lineJoin);
+    }
+
+    public void setImageSmoothingEnabled(boolean enabled) {
+        delegate.setImageSmoothingEnabled(enabled);
+    }
+
+    public void setFont(String font) {
+        delegate.setFont(font);
+    }
+
+    public void setTextBaseline(String baseline) {
+        delegate.setTextBaseline(baseline);
+    }
+
+    public void setTextAlign(String align) {
+        delegate.setTextAlign(align);
+    }
+
+    public void setGlobalAlpha(double alpha) {
+        delegate.setGlobalAlpha(alpha);
+    }
+
+    public void setShadowColor(String color) {
+        delegate.setShadowColor(color);
+    }
+
+    public void setShadowOffsetX(double color) {
+        delegate.setShadowOffsetX(color);
+    }
+
+    public void setShadowOffsetY(double color) {
+        delegate.setShadowOffsetY(color);
+    }
+
+    public void setShadowBlur(int color) {
+        delegate.setShadowBlur(color);
+    }
+
+    public void setMiterLimit(double limit) {
+        delegate.setMiterLimit(limit);
+    }
+
+    public void setLineDashOffset(double offset) {
+        delegate.setLineDashOffset(offset);
+    }
+
+    public void saveGroup() {
+        delegate.saveGroup();
+    }
+
+    public void restoreGroup() {
+        delegate.restoreGroup();
+    }
+
+    public void saveStyle() {
+        delegate.saveStyle();
+    }
+
+    public void restoreStyle() {
+        delegate.restoreStyle();
+    }
+
+    public void save() {
+        delegate.save();
+    }
+
+    public void restore() {
+        delegate.restore();
+    }
+
+    public void beginPath() {
+        delegate.beginPath();
+    }
+
+    public void closePath() {
+        delegate.closePath();
+    }
+
+    public void moveTo(double x, double y) {
+        delegate.moveTo(x, y);
+    }
+
+    public void lineTo(double x, double y) {
+        delegate.lineTo(x, y);
+    }
+
+    public void setGlobalCompositeOperation(String operation) {
+        delegate.setGlobalCompositeOperation(operation);
+    }
+
+    public void quadraticCurveTo(double cpx, double cpy, double x, double y) {
+        delegate.quadraticCurveTo(cpx, cpy, x, y);
+    }
+
+    public void arc(double x, double y, double radius, double startAngle, double endAngle) {
+        delegate.arc(x, y, radius, startAngle, endAngle);
+    }
+
+    public void arc(double x, double y, double radius, double startAngle, double endAngle, boolean antiClockwise) {
+        delegate.arc(x, y, radius, startAngle, endAngle, antiClockwise);
+    }
+
+    public void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea, boolean ac) {
+        delegate.ellipse(x, y, rx, ry, ro, sa, ea, ac);
+    }
+
+    public void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea) {
+        delegate.ellipse(x, y, rx, ry, ro, sa, ea);
+    }
+
+    public void arcTo(double x1, double y1, double x2, double y2, double radius) {
+        delegate.arcTo(x1, y1, x2, y2, radius);
+    }
+
+    public void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y) {
+        delegate.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
+    }
+
+    public void clearRect(double x, double y, double w, double h) {
+        delegate.clearRect(x, y, w, h);
+    }
+
+    public void clip() {
+        delegate.clip();
+    }
+
+    public void fill() {
+        delegate.fill();
+    }
+
+    public void stroke() {
+        delegate.stroke();
+    }
+
+    public void fillRect(double x, double y, double w, double h) {
+        delegate.fillRect(x, y, w, h);
+    }
+
+    public void fillText(String text, double x, double y) {
+        delegate.fillText(text, x, y);
+    }
+
+    public CanvasGradient createLinearGradient(double x0, double y0, double x1, double y1) {
+        return delegate.createLinearGradient(x0, y0, x1, y1);
+    }
+
+    public CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1) {
+        return delegate.createRadialGradient(x0, y0, r0, x1, y1, r1);
+    }
+
+    public void rect(double x, double y, double w, double h) {
+        delegate.rect(x, y, w, h);
+    }
+
+    public void rotate(double angle) {
+        delegate.rotate(angle);
+    }
+
+    public void scale(double sx, double sy) {
+        delegate.scale(sx, sy);
+    }
+
+    public void transform(double d0, double d1, double d2, double d3, double d4, double d5) {
+        delegate.transform(d0, d1, d2, d3, d4, d5);
+    }
+
+    public void setTransform(double d0, double d1, double d2, double d3, double d4, double d5) {
+        delegate.setTransform(d0, d1, d2, d3, d4, d5);
+    }
+
+    public void strokeText(String text, double x, double y) {
+        delegate.strokeText(text, x, y);
+    }
+
+    public void translate(double x, double y) {
+        delegate.translate(x, y);
+    }
+
+    public boolean isPointInPath(double x, double y) {
+        return delegate.isPointInPath(x, y);
+    }
+
+    public void putImageData(ImageData imageData, double x, double y) {
+        delegate.putImageData(imageData, x, y);
+    }
+
+    public void putImageData(ImageData imageData, double x, double y, double dx, double dy, double dw, double dh) {
+        delegate.putImageData(imageData, x, y, dx, dy, dw, dh);
+    }
+
+    public void resetClip() {
+        delegate.resetClip();
+    }
+
+    public void setLineDash(double[] dashes) {
+        delegate.setLineDash(dashes);
+    }
+
+    public TextMetrics measureText(String text) {
+        return delegate.measureText(text);
+    }
+
+    public HTMLCanvasElement createImageData(ImageData data) {
+        return delegate.createImageData(data);
+    }
+
+    public ImageData getImageData(double x, double y, double width, double height) {
+        return delegate.getImageData(x, y, width, height);
+    }
+
+    public ImageData createImageData(double width, double height) {
+        return delegate.createImageData(width, height);
+    }
+
+    public void drawImage(Element image, double x, double y) {
+        delegate.drawImage(image, x, y);
+    }
+
+    public void drawImage(Element image, double x, double y, double w, double h) {
+        delegate.drawImage(image, x, y, w, h);
+    }
+
+    public void drawImage(Element image, double sx, double sy, double sw, double sh, double x, double y, double w, double h) {
+        delegate.drawImage(image, sx, sy, sw, sh, x, y, w, h);
+    }
+
+    protected C2S getDelegate() {
+        return delegate;
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SSettings.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SSettings.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+/**
+ * Represents the constructor parameter to be used on the {@link C2S}.
+ */
+@JsType(isNative = true, name = "Object", namespace = JsPackage.GLOBAL)
+class C2SSettings {
+
+    @JsOverlay
+    protected static C2SSettings create(double width, double height, Object ctx) {
+        final C2SSettings instance = new C2SSettings();
+        instance.setWidth(width);
+        instance.setHeight(height);
+        instance.setCtx(ctx);
+        instance.setEnableMirroring(true);
+        return instance;
+    }
+
+    @JsProperty
+    public native void setWidth(double width);
+
+    @JsProperty
+    public native void setHeight(double height);
+
+    @JsProperty
+    public native void setCtx(Object ctx);
+
+    @JsProperty
+    public native void setEnableMirroring(boolean enableMirroring);
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/Context2DFactory.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/Context2DFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.svg;
+
+import org.uberfire.ext.editor.commons.client.file.exports.jso.svg.C2SContext2D;
+
+/**
+ * Create {@link IContext2D} concrete instances to be used on the SVG exporting,
+ * abstracting which library implementation is used, allowing to change or use multiple implementations if necessary.
+ */
+public class Context2DFactory {
+
+    public static IContext2D create(SvgExportSettings settings){
+        //choose the implementation, for now just the canvas2svg.
+        return new C2SContext2D(settings.getWidth(), settings.getHeight(), settings.getContext());
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/IContext2D.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/IContext2D.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.svg;
+
+import elemental2.dom.CanvasGradient;
+import elemental2.dom.Element;
+import elemental2.dom.HTMLCanvasElement;
+import elemental2.dom.ImageData;
+import elemental2.dom.TextMetrics;
+
+/**
+ * Represents a canvas context 2D that is used to wrap calls to canvas used to generate SVG files based on canvas.
+ */
+public interface IContext2D {
+
+    String getSerializedSvg();
+
+    void setFillStyle(String fillStyleColor);
+
+    void setStrokeStyle(String fillStyleColor);
+
+    void setLineWidth(double var1);
+
+    void setLineCap(String lineCap);
+
+    void setLineJoin(String lineJoin);
+
+    void setImageSmoothingEnabled(boolean enabled);
+
+    void setFont(String font);
+
+    void setTextBaseline(String baseline);
+
+    void setTextAlign(String align);
+
+    void setGlobalAlpha(double alpha);
+
+    void setShadowColor(String color);
+
+    void setShadowOffsetX(double color);
+
+    void setShadowOffsetY(double color);
+
+    void setShadowBlur(int color);
+
+    void setMiterLimit(double limit);
+
+    void setLineDashOffset(double offset);
+
+    void saveGroup();
+
+    void saveStyle();
+
+    void restoreGroup();
+
+    void restoreStyle();
+
+    void save();
+
+    void restore();
+
+    void beginPath();
+
+    void closePath();
+
+    void moveTo(double x, double y);
+
+    void lineTo(double x, double y);
+
+    void setGlobalCompositeOperation(String operation);
+
+    void quadraticCurveTo(double cpx, double cpy, double x, double y);
+
+    void arc(double x, double y, double radius, double startAngle, double endAngle);
+
+    void arc(double x, double y, double radius, double startAngle, double endAngle, boolean antiClockwise);
+
+    void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea, boolean ac);
+
+    void ellipse(double x, double y, double rx, double ry, double ro, double sa, double ea);
+
+    void arcTo(double x1, double y1, double x2, double y2, double radius);
+
+    void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y);
+
+    void clearRect(double x, double y, double w, double h);
+
+    void clip();
+
+    void fill();
+
+    void stroke();
+
+    void fillRect(double x, double y, double w, double h);
+
+    void fillText(String text, double x, double y);
+
+    void rect(double x, double y, double w, double h);
+
+    void rotate(double angle);
+
+    void scale(double sx, double sy);
+
+    void transform(double d0, double d1, double d2, double d3, double d4, double d5);
+
+    void setTransform(double d0, double d1, double d2, double d3, double d4, double d5);
+
+    void strokeText(String text, double x, double y);
+
+    void translate(double x, double y);
+
+    boolean isPointInPath(double x, double y);
+
+    void putImageData(ImageData imageData, double x, double y);
+
+    void putImageData(ImageData imageData, double x, double y, double dx, double dy, double dw, double dh);
+
+    void resetClip();
+
+    void setLineDash(double[] dashes);
+
+    TextMetrics measureText(String text);
+
+    HTMLCanvasElement createImageData(ImageData data);
+
+    ImageData getImageData(double x, double y, double width, double height);
+
+    ImageData createImageData(double width, double height);
+
+    void drawImage(Element image, double x, double y);
+
+    void drawImage(Element image, double x, double y, double w, double h);
+
+    void drawImage(Element image, double sx, double sy, double sw, double sh, double x, double y, double w, double h);
+
+    CanvasGradient createLinearGradient(double x0, double y0, double x1, double y1);
+
+    CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1);
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/SvgExportSettings.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/SvgExportSettings.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.svg;
+
+/**
+ * Contains all attributes used on the SVG Export process.
+ */
+public class SvgExportSettings {
+
+    private final double width;
+    private final double height;
+    private final Object context;
+
+    public SvgExportSettings(final double width, final double height, final Object context) {
+        this.width = width;
+        this.height = height;
+        this.context = context;
+    }
+
+    public double getWidth() {
+        return width;
+    }
+
+    public double getHeight() {
+        return height;
+    }
+
+    public Object getContext() {
+        return context;
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/SvgFileExport.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/SvgFileExport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.svg;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.jboss.errai.common.client.dom.Blob;
+import org.jboss.errai.common.client.dom.BlobImpl;
+import org.uberfire.ext.editor.commons.client.file.exports.AbstractFileExport;
+
+/**
+ * Exports an {@link IContext2D} to a serialized SVG file.
+ */
+public class SvgFileExport extends AbstractFileExport<IContext2D> {
+
+    public SvgFileExport() {
+    }
+
+    protected SvgFileExport(BiConsumer<Blob, String> saveAs) {
+        super(saveAs);
+    }
+
+    @Override
+    protected Optional<Blob> getContent(IContext2D entity) {
+        return Optional.of(BlobImpl.create(entity.getSerializedSvg()));
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/AbstractFileExportTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/AbstractFileExportTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports;
+
+import java.util.function.BiConsumer;
+
+import org.jboss.errai.common.client.dom.Blob;
+import org.mockito.Mock;
+
+public abstract class AbstractFileExportTest {
+
+    protected static final String FILE_NAME = "file1";
+
+    @Mock
+    protected BiConsumer<Blob, String> fileSaver;
+
+
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/ImageFileExportTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/ImageFileExportTest.java
@@ -16,24 +16,20 @@
 
 package org.uberfire.ext.editor.commons.client.file.exports;
 
-import java.util.function.BiConsumer;
-
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.dom.Blob;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class ImageFileExportTest {
-
-    @Mock
-    private BiConsumer<Blob, String> fileSaver;
+public class ImageFileExportTest extends AbstractFileExportTest {
 
     private ImageFileExport tested;
 
@@ -52,9 +48,9 @@ public class ImageFileExportTest {
         assertEquals("9j/4AAQSkZJRgABAQEASABIAAD",
                      imageContent.getData());
         tested.export(imageContent,
-                      "image-file");
+                      FILE_NAME);
         verify(fileSaver,
                times(1)).accept(any(Blob.class),
-                                eq("image-file"));
+                                eq(FILE_NAME));
     }
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjectorTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjectorTest.java
@@ -24,9 +24,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.uberfire.ext.editor.commons.client.file.exports.FileExportResources;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class FileExportScriptInjectorTest {
@@ -50,6 +52,7 @@ public class FileExportScriptInjectorTest {
         final String script = scriptCaptor.getValue();
         final String fsNsObject = FileExportScriptInjector.buildNamespaceObject(JsFileSaver.class.getName() + ".saveAs");
         final String jsPdfNsObject = FileExportScriptInjector.buildNamespaceObject(JsPdf.class.getName());
+        final String c2sNsObject = FileExportResources.INSTANCE.canvas2svg().getText();
         assertEquals("var " +
                              fsNsObject +
                              " = function(blob, fileName, disableAutoBOM) {\n" +
@@ -59,7 +62,8 @@ public class FileExportScriptInjectorTest {
                              " = function(settings) {\n" +
                              "jsPdf\n" +
                              "var saveAs = org.uberfire.ext.editor.commons.client.file.exports.jso.JsFileSaver.saveAs; " +
-                             "return new jsPDF(settings);};" + "\n",
+                             "return new jsPDF(settings);};" + "\n" +
+                             c2sNsObject + "\n",
                      script);
     }
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2DTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2DTest.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import elemental2.core.Array;
+import elemental2.dom.CanvasRenderingContext2D;
+import elemental2.dom.Element;
+import elemental2.dom.ImageData;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub(Array.class)
+public class C2SContext2DTest {
+
+    private C2SContext2D c2SContext2D;
+
+    @Mock
+    private Element element;
+
+    @Mock
+    private Array groupStack;
+
+    @Mock
+    private Array stack;
+
+    @Mock
+    private CanvasRenderingContext2D nativeContext;
+
+    private C2S c2S;
+
+    @Before
+    public void setUp() throws Exception {
+        c2S = spy(C2S.create(100, 100, nativeContext));
+        c2SContext2D = new C2SContext2D(c2S);
+        c2S.__groupStack = groupStack;
+        when(groupStack.pop()).thenReturn(element);
+        c2S.__stack = stack;
+    }
+
+    @Test
+    public void getSerializedSvg() {
+        c2SContext2D.getSerializedSvg();
+        verify(c2S).getSerializedSvg();
+    }
+
+    @Test
+    public void setFillStyle() {
+        c2SContext2D.setFillStyle("black");
+        verify(c2S).setFillStyle("black");
+    }
+
+    @Test
+    public void setStrokeStyle() {
+        c2SContext2D.setStrokeStyle("black");
+        verify(c2S).setStrokeStyle("black");
+    }
+
+    @Test
+    public void setLineWidth() {
+        c2SContext2D.setLineWidth(1);
+        verify(c2S).setLineWidth(1);
+    }
+
+    @Test
+    public void setLineCap() {
+        c2SContext2D.setLineCap("line");
+        verify(c2S).setLineCap("line");
+    }
+
+    @Test
+    public void setLineJoin() {
+        c2SContext2D.setLineCap("line");
+        verify(c2S).setLineCap("line");
+    }
+
+    @Test
+    public void setImageSmoothingEnabled() {
+        c2SContext2D.setImageSmoothingEnabled(true);
+        verify(c2S).setImageSmoothingEnabled(true);
+    }
+
+    @Test
+    public void setFont() {
+        c2SContext2D.setFont("font");
+        verify(c2S).setFont("font");
+    }
+
+    @Test
+    public void setTextBaseline() {
+        c2SContext2D.setTextBaseline("text");
+        verify(c2S).setTextBaseline("text");
+    }
+
+    @Test
+    public void setTextAlign() {
+        c2SContext2D.setTextAlign("left");
+        verify(c2S).setTextAlign("left");
+    }
+
+    @Test
+    public void setGlobalAlpha() {
+        c2SContext2D.setGlobalAlpha(1);
+        verify(c2S).setGlobalAlpha(1);
+    }
+
+    @Test
+    public void setShadowColor() {
+        c2SContext2D.setShadowColor("blue");
+        verify(c2S).setShadowColor("blue");
+    }
+
+    @Test
+    public void setShadowOffsetX() {
+        c2SContext2D.setShadowOffsetX(1);
+        verify(c2S).setShadowOffsetX(1);
+    }
+
+    @Test
+    public void setShadowOffsetY() {
+        c2SContext2D.setShadowOffsetY(1);
+        verify(c2S).setShadowOffsetY(1);
+    }
+
+    @Test
+    public void setShadowBlur() {
+        c2SContext2D.setShadowBlur(1);
+        verify(c2S).setShadowBlur(1);
+    }
+
+    @Test
+    public void setMiterLimit() {
+        c2SContext2D.setMiterLimit(1);
+        verify(c2S).setMiterLimit(1);
+    }
+
+    @Test
+    public void setLineDashOffset() {
+        c2SContext2D.setLineDashOffset(1);
+        verify(c2S).setLineDashOffset(1);
+    }
+
+    @Test
+    public void saveGroup() {
+        c2SContext2D.saveGroup();
+        verify(c2S).saveGroup();
+    }
+
+    @Test
+    public void restoreGroup() {
+        c2SContext2D.restoreGroup();
+        verify(c2S).restoreGroup();
+    }
+
+    @Test
+    public void saveStyle() {
+        c2SContext2D.saveStyle();
+        verify(c2S).saveStyle();
+    }
+
+    @Test
+    public void restoreStyle() {
+        c2SContext2D.restoreStyle();
+        verify(c2S).restoreStyle();
+    }
+
+    @Test
+    public void save() {
+        c2SContext2D.save();
+        verify(c2S).save();
+    }
+
+    @Test
+    public void restore() {
+        c2SContext2D.restore();
+        verify(c2S).restore();
+    }
+
+    @Test
+    public void beginPath() {
+        c2SContext2D.beginPath();
+        verify(c2S).beginPath();
+    }
+
+    @Test
+    public void closePath() {
+        c2SContext2D.closePath();
+        verify(c2S).closePath();
+    }
+
+    @Test
+    public void moveTo() {
+        c2SContext2D.moveTo(1, 1);
+        verify(c2S).moveTo(1, 1);
+    }
+
+    @Test
+    public void lineTo() {
+        c2SContext2D.lineTo(1, 1);
+        verify(c2S).lineTo(1, 1);
+    }
+
+    @Test
+    public void setGlobalCompositeOperation() {
+        c2SContext2D.setGlobalCompositeOperation("op");
+        verify(c2S).setGlobalCompositeOperation("op");
+    }
+
+    @Test
+    public void quadraticCurveTo() {
+        c2SContext2D.quadraticCurveTo(1, 1, 1, 1);
+        verify(c2S).quadraticCurveTo(1, 1, 1, 1);
+    }
+
+    @Test
+    public void arc() {
+        c2SContext2D.arc(1, 1, 1, 1, 1);
+        verify(c2S).arc(1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void arc1() {
+        c2SContext2D.arc(1, 1, 1, 1, 1, true);
+        verify(c2S).arc(1, 1, 1, 1, 1, true);
+    }
+
+    @Test
+    public void ellipse() {
+        c2SContext2D.ellipse(1, 1, 1, 1, 1, 1, 1);
+        verify(c2S).ellipse(1, 1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void ellipse1() {
+        c2SContext2D.ellipse(1, 1, 1, 1, 1, 1, 1, true);
+        verify(c2S).ellipse(1, 1, 1, 1, 1, 1, 1, true);
+    }
+
+    @Test
+    public void arcTo() {
+        c2SContext2D.arcTo(1, 1, 1, 1, 1);
+        verify(c2S).arcTo(1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void bezierCurveTo() {
+        c2SContext2D.bezierCurveTo(1, 1, 1, 1, 1, 1);
+        verify(c2S).bezierCurveTo(1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void clearRect() {
+        c2SContext2D.clearRect(1, 1, 1, 1);
+        verify(c2S).clearRect(1, 1, 1, 1);
+    }
+
+    @Test
+    public void clip() {
+        c2SContext2D.clip();
+        verify(c2S).clip();
+    }
+
+    @Test
+    public void fill() {
+        c2SContext2D.fill();
+        verify(c2S).fill();
+    }
+
+    @Test
+    public void stroke() {
+        c2SContext2D.stroke();
+        verify(c2S).stroke();
+    }
+
+    @Test
+    public void fillRect() {
+        c2SContext2D.fillRect(1, 1, 1, 1);
+        verify(c2S).fillRect(1, 1, 1, 1);
+    }
+
+    @Test
+    public void fillText() {
+        c2SContext2D.fillText("text", 1, 1);
+        verify(c2S).fillText("text", 1, 1);
+    }
+
+    @Test
+    public void createLinearGradient() {
+        c2SContext2D.createLinearGradient(1, 1, 1, 1);
+        verify(c2S).createLinearGradient(1, 1, 1, 1);
+    }
+
+    @Test
+    public void createRadialGradient() {
+        c2SContext2D.createRadialGradient(1, 1, 1, 1, 1, 1);
+        verify(c2S).createRadialGradient(1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void rect() {
+        c2SContext2D.rect(1, 1, 1, 1);
+        verify(c2S).rect(1, 1, 1, 1);
+    }
+
+    @Test
+    public void rotate() {
+        c2SContext2D.rotate(1);
+        verify(c2S).rotate(1);
+    }
+
+    @Test
+    public void scale() {
+        c2SContext2D.scale(1, 1);
+        verify(c2S).scale(1, 1);
+    }
+
+    @Test
+    public void transform() {
+        c2SContext2D.transform(1, 1, 1, 1, 1, 1);
+        verify(c2S).transform(1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void setTransform() {
+        c2SContext2D.setTransform(1, 1, 1, 1, 1, 1);
+        verify(c2S).setTransform(1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void strokeText() {
+        c2SContext2D.setTransform(1, 1, 1, 1, 1, 1);
+        verify(c2S).setTransform(1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void translate() {
+        c2SContext2D.translate(1, 1);
+        verify(c2S).translate(1, 1);
+    }
+
+    @Test
+    public void isPointInPath() {
+        c2SContext2D.isPointInPath(1, 1);
+        verify(c2S).isPointInPath(1, 1);
+    }
+
+    @Test
+    public void putImageData() {
+        ImageData imageData = mock(ImageData.class);
+        c2SContext2D.putImageData(imageData, 1, 1);
+        verify(c2S).putImageData(imageData, 1, 1);
+    }
+
+    @Test
+    public void putImageData1() {
+        ImageData imageData = mock(ImageData.class);
+        c2SContext2D.putImageData(imageData, 1, 1, 1, 1, 1, 1);
+        verify(c2S).putImageData(imageData, 1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void resetClip() {
+        c2SContext2D.resetClip();
+        verify(c2S).resetClip();
+    }
+
+    @Test
+    public void setLineDash() {
+        double[] dashes = {1, 1};
+        c2SContext2D.setLineDash(dashes);
+        verify(c2S).setLineDash(dashes);
+    }
+
+    @Test
+    public void measureText() {
+        c2SContext2D.measureText("text");
+        verify(c2S).measureText("text");
+    }
+
+    @Test
+    public void createImageData() {
+        ImageData imageData = mock(ImageData.class);
+        c2SContext2D.createImageData(imageData);
+        verify(c2S).createImageData(imageData);
+    }
+
+    @Test
+    public void getImageData() {
+        c2SContext2D.getImageData(1, 1, 1, 1);
+        verify(c2S).getImageData(1, 1, 1, 1);
+    }
+
+    @Test
+    public void createImageData1() {
+        c2SContext2D.createImageData(1, 1);
+        verify(c2S).createImageData(1, 1);
+    }
+
+    @Test
+    public void drawImage() {
+        Element image = mock(Element.class);
+        c2SContext2D.drawImage(image, 1, 1, 1, 1, 1, 1, 1, 1);
+        verify(c2S).drawImage(image, 1, 1, 1, 1, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void drawImage1() {
+        Element image = mock(Element.class);
+        c2SContext2D.drawImage(image, 1, 1);
+        verify(c2S).drawImage(image, 1, 1);
+    }
+
+    @Test
+    public void drawImage2() {
+        Element image = mock(Element.class);
+        c2SContext2D.drawImage(image, 1, 1, 1, 1);
+        verify(c2S).drawImage(image, 1, 1, 1, 1);
+    }
+
+    @Test
+    public void testGetDelegate() {
+        Assert.assertTrue(C2S.class.isInstance(c2SContext2D.getDelegate()));
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/svg/Context2DFactoryTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/svg/Context2DFactoryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.file.exports.svg;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.CanvasRenderingContext2D;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.ext.editor.commons.client.file.exports.jso.svg.C2SContext2D;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class Context2DFactoryTest {
+
+    private Context2DFactory context2DFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        context2DFactory = new Context2DFactory();
+    }
+
+    @Test
+    public void testCreate() {
+        final CanvasRenderingContext2D nativeContext = mock(CanvasRenderingContext2D.class);
+        final SvgExportSettings settings = new SvgExportSettings(100, 100, nativeContext);
+        final IContext2D context2D = context2DFactory.create(settings);
+        assertTrue(C2SContext2D.class.isInstance(context2D));
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/svg/SvgFileExportTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/svg/SvgFileExportTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,35 +14,40 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.editor.commons.client.file.exports;
+package org.uberfire.ext.editor.commons.client.file.exports.svg;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.dom.Blob;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.uberfire.ext.editor.commons.client.file.exports.AbstractFileExportTest;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(GwtMockitoTestRunner.class)
-public class TextFileExportTest extends AbstractFileExportTest {
+public class SvgFileExportTest extends AbstractFileExportTest{
 
-    private TextFileExport tested;
+    private static final String SVG = "svg content";
+    private SvgFileExport svgFileExport;
+
+    @Mock
+    private IContext2D context;
 
     @Before
-    public void setup() {
-        tested = new TextFileExport(fileSaver);
+    public void setUp() throws Exception {
+        Mockito.when(context.getSerializedSvg()).thenReturn(SVG);
+        this.svgFileExport = new SvgFileExport(fileSaver);
     }
 
     @Test
     public void testExport() {
-        final TextContent content = TextContent.create("testing");
-        tested.export(content, FILE_NAME);
-        verify(fileSaver,
-               times(1)).accept(any(Blob.class),
-                                eq(FILE_NAME));
+        svgFileExport.export(context,FILE_NAME);
+        verify(context).getSerializedSvg();
+        verify(fileSaver).accept(any(Blob.class), eq(FILE_NAME));
     }
 }


### PR DESCRIPTION
_Stunner_ needs to export diagrams presented on canvas to SVG files, the idea is to add this feature and an abstraction of canvas and the library implementation used for that on _Uberfire,_ in this way any other components that need to export a canvas to SVG may use this feature.

* Added a `FileExport` implementation to support SVG on `SvgFileExport`
* Abstraction interface to the Context2D that is used to generate the SVG
* _JsInterop_ to the library **[canvas2svg](https://github.com/gliffy/canvas2svg)** with an overlay to distinguish save/restore from groups, that is the containers nodes, the idea is to open a PR to add this feature on the native canvas2svg, then we could remove the overlay
* _Webjar_ configuration to **canvas2svg**

Related JIRA https://issues.jboss.org/browse/JBPM-6110

@romartin 
@mdproctor 