### PR TITLE
updated to correct Zanata version

### DIFF
--- a/dashbuilder/src/main/config/zanata.xml
+++ b/dashbuilder/src/main/config/zanata.xml
@@ -2,7 +2,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://vendors.zanata.redhat.com/</url>
   <project>dashbuilderuf</project>
-  <project-version>1.1.0</project-version>
+  <project-version>2.0.0</project-version>
   <project-type>utf8properties</project-type>
 
   <locales>


### PR DESCRIPTION
since dashbuilder is in appformer (so in uberfire) it doesn't make sense to have different Zanata projects. There is right now existing a Uberfire 2.0.0 and Dashbuilder UF 2.0.0 as Zanata projects.