### PR TITLE
RHBA-415: After rename, designer is not marked as dirty more

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/backend/vfs/PathFactory.java
+++ b/uberfire-api/src/main/java/org/uberfire/backend/vfs/PathFactory.java
@@ -198,7 +198,7 @@ public final class PathFactory {
 
             final Path path = (Path) o;
 
-            return uri.equals(path.toURI());
+            return this.toURI().equals(path.toURI());
         }
 
         @Override

--- a/uberfire-client-api/src/main/java/org/uberfire/client/mvp/RenameInProgressEvent.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/mvp/RenameInProgressEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.mvp;
+
+import org.uberfire.backend.vfs.Path;
+
+/**
+ * Client-local event to indicate that a rename command has been executed
+ */
+public class RenameInProgressEvent {
+
+    private final Path path;
+
+    public RenameInProgressEvent(final Path path) {
+        this.path = path;
+    }
+
+    public Path getPath() {
+        return path;
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorRenameTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorRenameTest.java
@@ -86,7 +86,7 @@ public class BaseEditorRenameTest {
 
             @Override
             protected SaveAndRenameCommandBuilder getSaveAndRenameCommandBuilder() {
-                return new SaveAndRenameCommandBuilder<>(null, null, null);
+                return new SaveAndRenameCommandBuilder<>(null, null, null, null);
             }
 
             @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBA-415

Before:
![before-1](https://user-images.githubusercontent.com/1079279/38328702-f2123d02-3821-11e8-9eef-1adb3416492b.gif)
![before-2](https://user-images.githubusercontent.com/1079279/38328740-058ea9ba-3822-11e8-8ac3-2473cadddae3.gif)

After:
![after-1](https://user-images.githubusercontent.com/1079279/38328748-0baaa72c-3822-11e8-9ad2-f2575ea9672c.gif)
![after-2](https://user-images.githubusercontent.com/1079279/38328841-532649da-3822-11e8-8031-ae006e43956b.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/275
- https://github.com/kiegroup/drools-wb/pull/842
