### PR TITLE
[AF-1091]: Fixed error that appears after using the Contributors tab

### DIFF
--- a/uberfire-project/uberfire-project-client/src/main/java/org/guvnor/common/services/project/client/context/WorkspaceProjectContext.java
+++ b/uberfire-project/uberfire-project-client/src/main/java/org/guvnor/common/services/project/client/context/WorkspaceProjectContext.java
@@ -67,11 +67,19 @@ public class WorkspaceProjectContext {
     }
 
     public void onOrganizationalUnitUpdated(@Observes final UpdatedOrganizationalUnitEvent event) {
-        contextChangeEvent.fire(new WorkspaceProjectContextChangeEvent(event.getOrganizationalUnit()));
+        WorkspaceProject updatedWorkspaceProject = new WorkspaceProject(event.getOrganizationalUnit(),
+                                                                        activeWorkspaceProject.getRepository(),
+                                                                        activeWorkspaceProject.getBranch(),
+                                                                        activeWorkspaceProject.getMainModule());
+        contextChangeEvent.fire(new WorkspaceProjectContextChangeEvent(updatedWorkspaceProject,
+                                                                       activeModule,
+                                                                       activePackage));
     }
 
     public void onProjectContextChanged(@Observes final WorkspaceProjectContextChangeEvent event) {
-        WorkspaceProjectContextChangeEvent previous = new WorkspaceProjectContextChangeEvent(activeWorkspaceProject, activeModule, activePackage);
+        WorkspaceProjectContextChangeEvent previous = new WorkspaceProjectContextChangeEvent(activeWorkspaceProject,
+                                                                                             activeModule,
+                                                                                             activePackage);
 
         this.setActiveOrganizationalUnit(event.getOrganizationalUnit());
         this.setActiveWorkspaceProject(event.getWorkspaceProject());
@@ -79,7 +87,8 @@ public class WorkspaceProjectContext {
         this.setActivePackage(event.getPackage());
 
         for (WorkspaceProjectContextChangeHandler handler : changeHandlers.values()) {
-            handler.onChange(previous, event);
+            handler.onChange(previous,
+                             event);
         }
     }
 


### PR DESCRIPTION
The error happened when saving contributor in Contributors Tab. In that moment an UpdatedOrganizationalUnit event is thrown, and it contains the Organization Unit updated. 

WorkspaceProjectContext observes that event and update the context, but in that method all values are set to null but Organizational Unit.

I kept with the old active values but organizational unit because that is the only one that changed.

@barboras7 @Rikkola would you mind to review it please?