### PR TITLE
Fix for internal QE Jenkins

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
@@ -69,7 +69,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Aether.class)
-@PowerMockIgnore({"javax.crypto.*", "javax.net.ssl.*", "javax.net.*"})
+@PowerMockIgnore({"javax.crypto.*", "javax.net.ssl.*", "javax.net.*", "javax.security.auth.x500.X500Principal"})
 public class GuvnorM2RepositoryTest {
 
     public static final String KIE_SETTINGS_CUSTOM_KEY = "kie.maven.settings.custom";


### PR DESCRIPTION
Prevent Jenkins fail with:

**Error Message**
```
loader constraint violation: loader (instance of org/powermock/core/classloader/MockClassLoader) previously initiated loading for a different type with name "javax/security/auth/x500/X500Principal"
```
**Stacktrace**
```
java.lang.LinkageError: loader constraint violation: loader (instance of org/powermock/core/classloader/MockClassLoader) previously initiated loading for a different type with name "javax/security/auth/x500/X500Principal"
	at org.guvnor.m2repo.backend.server.GuvnorM2RepositoryTest.setup(GuvnorM2RepositoryTest.java:134)
```