### PR TITLE
JBPM-6907: Last breadcrumb element should be text only

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.css
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.css
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-.breadcrumb {
+.breadcrumb-link {
     cursor: pointer;
 }
 
 .breadcrumb-last{
     color: inherit;
-    cursor: default;
     text-decoration-line: none;
     pointer-events: none;
 }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.java
@@ -62,6 +62,6 @@ public class BreadcrumbsView implements UberElement<BreadcrumbsPresenter>,
     @Override
     public void deactivate() {
         breadcrumb.setClassName("");
-        breadcrumbLink.setClassName("");
+        breadcrumbLink.setClassName("breadcrumb-link");
     }
 }


### PR DESCRIPTION
Changing the css styles to have only cursor over the breadcrumb links