### PR TITLE
[7.7.x] AF-1171: "Reset All perspective layouts" button breaks the "Settings" and "Library" perspectives

### DIFF
--- a/uberfire-extensions/uberfire-preferences-ui-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPagePerspective.java
+++ b/uberfire-extensions/uberfire-preferences-ui-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPagePerspective.java
@@ -16,6 +16,9 @@
 
 package org.uberfire.ext.preferences.client.admin;
 
+import java.util.Collections;
+import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -36,7 +39,7 @@ import org.uberfire.workbench.model.impl.PerspectiveDefinitionImpl;
 import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.Menus;
 
-@Dependent
+@ApplicationScoped
 @WorkbenchPerspective(identifier = AdminPagePerspective.IDENTIFIER)
 public class AdminPagePerspective {
 
@@ -55,7 +58,8 @@ public class AdminPagePerspective {
     @Perspective
     public PerspectiveDefinition getPerspective() {
         if (perspective == null) {
-            return createPerspectiveDefinition();
+            perspective = createPerspectiveDefinition();
+            configurePerspective(Collections.emptyMap());
         }
 
         return perspective;
@@ -66,7 +70,7 @@ public class AdminPagePerspective {
         perspectiveIdentifierToGoBackTo = placeRequest.getParameter("perspectiveIdentifierToGoBackTo",
                                                                     null);
         perspective = createPerspectiveDefinition();
-        configurePerspective(placeRequest);
+        configurePerspective(placeRequest.getParameters());
     }
 
     PerspectiveDefinition createPerspectiveDefinition() {
@@ -76,9 +80,9 @@ public class AdminPagePerspective {
         return perspective;
     }
 
-    void configurePerspective(final PlaceRequest placeRequest) {
+    void configurePerspective(final Map<String, String> parameters) {
         perspective.getRoot().addPart(new PartDefinitionImpl(new DefaultPlaceRequest(AdminPagePresenter.IDENTIFIER,
-                                                                                     placeRequest.getParameters())));
+                                                                                     parameters)));
     }
 
     @WorkbenchMenu

--- a/uberfire-extensions/uberfire-preferences-ui-client/src/test/java/org/uberfire/ext/preferences/client/admin/AdminPagePerspectiveTest.java
+++ b/uberfire-extensions/uberfire-preferences-ui-client/src/test/java/org/uberfire/ext/preferences/client/admin/AdminPagePerspectiveTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.ext.preferences.client.admin;
 
+import java.util.Collections;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.mvp.PlaceRequest;
@@ -32,7 +34,7 @@ public class AdminPagePerspectiveTest {
     @Before
     public void setup() {
         perspective = spy(new AdminPagePerspective());
-        doNothing().when(perspective).configurePerspective(any(PlaceRequest.class));
+        doNothing().when(perspective).configurePerspective(anyMap());
     }
 
     @Test
@@ -40,8 +42,7 @@ public class AdminPagePerspectiveTest {
         final PerspectiveDefinition perspectiveDefinition = perspective.getPerspective();
 
         verify(perspective).createPerspectiveDefinition();
-        verify(perspective,
-               never()).configurePerspective(any(PlaceRequest.class));
+        verify(perspective).configurePerspective(Collections.emptyMap());
 
         assertNotNull(perspectiveDefinition);
         assertNotNull(perspectiveDefinition.getName());
@@ -54,14 +55,14 @@ public class AdminPagePerspectiveTest {
         verify(perspective,
                times(1)).createPerspectiveDefinition();
         verify(perspective,
-               times(1)).configurePerspective(any(PlaceRequest.class));
+               times(1)).configurePerspective(anyMap());
 
         final PerspectiveDefinition perspectiveDefinition = perspective.getPerspective();
 
         verify(perspective,
                times(1)).createPerspectiveDefinition();
         verify(perspective,
-               times(1)).configurePerspective(any(PlaceRequest.class));
+               times(1)).configurePerspective(anyMap());
 
         assertNotNull(perspectiveDefinition);
         assertNotNull(perspectiveDefinition.getName());


### PR DESCRIPTION
Cherry-picked from https://github.com/kiegroup/appformer/pull/315