### PR TITLE
[AF-1141] Distributed CDI Events on Cluster

### DIFF
--- a/uberfire-commons/pom.xml
+++ b/uberfire-commons/pom.xml
@@ -70,6 +70,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-marshalling</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.spec.javax.jms</groupId>
       <artifactId>jboss-jms-api_2.0_spec</artifactId>
     </dependency>

--- a/uberfire-commons/src/main/java/org/uberfire/commons/cluster/events/ClusterEventObserver.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/cluster/events/ClusterEventObserver.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.commons.cluster.events;
+
+import java.util.UUID;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.Reception;
+import javax.enterprise.inject.spi.EventMetadata;
+import javax.inject.Inject;
+
+import org.jboss.errai.marshalling.server.ServerMarshalling;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.cluster.ClusterJMSService;
+import org.uberfire.commons.cluster.ClusterService;
+import org.uberfire.commons.clusterapi.Clustered;
+import org.uberfire.commons.services.cdi.Startup;
+
+@Startup
+@ApplicationScoped
+public class ClusterEventObserver {
+
+    public static final String CHANNEL_NAME = "CLUSTER_CDI_EVENTS";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterEventObserver.class);
+
+    private String nodeId = UUID.randomUUID().toString();
+
+    private Event<Object> eventBus;
+    private ClusterService clusterService;
+
+    public ClusterEventObserver() {
+
+    }
+
+    @Inject
+    public ClusterEventObserver(Event<Object> eventBus) {
+        this.clusterService = new ClusterJMSService();
+        this.eventBus = eventBus;
+        if (this.clusterService.isAppFormerClustered()) {
+            this.clusterService.connect();
+            this.clusterService.createConsumer(ClusterJMSService.DestinationType.PubSub,
+                                               CHANNEL_NAME,
+                                               ClusterSerializedCDIMessageWrapper.class,
+                                               message -> consumeMessage(eventBus,
+                                                                         message));
+        }
+    }
+
+    @PreDestroy
+    public void shutdown(){
+        if(this.clusterService.isAppFormerClustered()){
+            this.clusterService.close();
+        }
+    }
+
+    ClusterService getClusterService() {
+        return clusterService;
+    }
+
+    void consumeMessage(Event<Object> eventBus,
+                        ClusterSerializedCDIMessageWrapper message) {
+        if (!message.getNodeId().equals(nodeId)) {
+            try {
+                Object event = fromJSON(message);
+                eventBus.fire(event);
+            } catch (Exception e) {
+                LOGGER.error("Error consuming cluster event:  " + e.getMessage());
+            }
+        }
+    }
+
+    Object fromJSON(ClusterSerializedCDIMessageWrapper message) {
+        return ServerMarshalling.fromJSON(message.getJson());
+    }
+
+    public void observeAllEvents(@Observes(notifyObserver = Reception.IF_EXISTS) Object event,
+                                 EventMetadata metaData) {
+        if (shouldObserveThisEvent(event,
+                                   metaData)) {
+            broadcast(event);
+        }
+    }
+
+    public void broadcast(Object event) {
+        if (!getClusterService().isAppFormerClustered()) {
+            return;
+        }
+
+        ClusterSerializedCDIMessageWrapper wrapper = new ClusterSerializedCDIMessageWrapper(nodeId,
+                                                                                            toJSON(event),
+                                                                                            event.getClass().getName());
+
+        getClusterService().broadcast(ClusterService.DestinationType.PubSub,
+                                      CHANNEL_NAME,
+                                      wrapper);
+    }
+
+    String toJSON(Object event) {
+        return ServerMarshalling.toJSON(event);
+    }
+
+    boolean shouldObserveThisEvent(Object event,
+                                   EventMetadata metaData) {
+        return event.getClass().isAnnotationPresent(Clustered.class) && !createdOnThisClass(metaData);
+    }
+
+    private boolean createdOnThisClass(EventMetadata metaData) {
+        if (metaData == null || metaData.getInjectionPoint() == null) {
+            return false;
+        } else {
+            return metaData.getInjectionPoint().getBean().getBeanClass().equals(this.getClass());
+        }
+    }
+
+    String getNodeId() {
+        return nodeId;
+    }
+}

--- a/uberfire-commons/src/main/java/org/uberfire/commons/cluster/events/ClusterSerializedCDIMessageWrapper.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/cluster/events/ClusterSerializedCDIMessageWrapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.commons.cluster.events;
+
+import java.io.Serializable;
+
+public class ClusterSerializedCDIMessageWrapper implements Serializable {
+
+    private String fqcn;
+    private String json;
+    private String nodeId;
+
+    public ClusterSerializedCDIMessageWrapper() {
+
+    }
+
+    public ClusterSerializedCDIMessageWrapper(String nodeId,
+                                              String json,
+                                              String fqcn) {
+
+        this.nodeId = nodeId;
+        this.json = json;
+        this.fqcn = fqcn;
+    }
+
+    public String getFqcn() {
+        return fqcn;
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public String getJson() {
+        return json;
+    }
+
+}

--- a/uberfire-commons/src/main/java/org/uberfire/commons/clusterapi/Clustered.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/clusterapi/Clustered.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.commons.clusterapi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * On cluster runtime enviroments, Errai @Portable POJOS annotated
+ * with this are propagated in the Cluster and retriggered (cdi fire)
+ * on each cluster node.
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE})
+public @interface Clustered {
+
+}

--- a/uberfire-commons/src/main/resources/org/uberfire/commons/UberfireCommons.gwt.xml
+++ b/uberfire-commons/src/main/resources/org/uberfire/commons/UberfireCommons.gwt.xml
@@ -24,5 +24,6 @@
   <source path='data'/>
   <source path='lifecycle'/>
   <source path='uuid'/>
+  <source path='clusterapi'/>
 
 </module>

--- a/uberfire-commons/src/test/java/org/uberfire/commons/cluster/events/ClusterEventObserverTest.java
+++ b/uberfire-commons/src/test/java/org/uberfire/commons/cluster/events/ClusterEventObserverTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.commons.cluster.events;
+
+import java.lang.annotation.Annotation;
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.EventMetadata;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.util.TypeLiteral;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.commons.cluster.ClusterJMSService;
+import org.uberfire.commons.clusterapi.Clustered;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterEventObserverTest {
+
+    ClusterJMSService clusterService;
+    ClusterEventObserver observer;
+
+    @Before
+    public void setup() {
+        clusterService = mock(ClusterJMSService.class);
+        observer = setupMock();
+    }
+
+    @Mock
+    private EventSourceMock<Object> eventBus;
+
+    @Test
+    public void consumeTestOtherSenderNode() {
+        observer.consumeMessage(eventBus,
+                                new ClusterSerializedCDIMessageWrapper("wrongNode",
+                                                                       "json",
+                                                                       "fqcn"));
+        verify(eventBus).fire(any());
+    }
+
+    @Test
+    public void consumeTestMyMessages() {
+        observer.consumeMessage(eventBus,
+                                new ClusterSerializedCDIMessageWrapper(observer.getNodeId(),
+                                                                       "json",
+                                                                       "fqcn"));
+        verify(eventBus,
+               never()).fire(any());
+    }
+
+    @Test
+    public void shouldBroadCastMessagesOnlyOnCluster() {
+        when(clusterService.isAppFormerClustered()).thenReturn(false);
+
+        observer.broadcast(new Object());
+
+        verify(clusterService,
+               never()).broadcast(any(),
+                                  any(),
+                                  any());
+    }
+
+    @Test
+    public void shouldBroadCastMessages() {
+        when(clusterService.isAppFormerClustered()).thenReturn(true);
+
+        observer.broadcast(new EventTest());
+
+        verify(clusterService).broadcast(any(),
+                                         any(),
+                                         any());
+    }
+
+    @Test
+    public void shouldObserveThisEventTest() {
+        EventMetadata eventMetadataMock = mock(EventMetadata.class);
+        InjectionPoint injectionPointMock = mock(InjectionPoint.class);
+        Bean beanMock = mock(Bean.class);
+        when(eventMetadataMock.getInjectionPoint()).thenReturn(injectionPointMock);
+        when(injectionPointMock.getBean()).thenReturn(beanMock);
+
+        assertFalse(observer.shouldObserveThisEvent(new Object(),
+                                                    null));
+        assertTrue(observer.shouldObserveThisEvent(new EventTest(),
+                                                   null));
+
+        when(beanMock.getBeanClass()).thenReturn(Object.class);
+        assertTrue(observer.shouldObserveThisEvent(new EventTest(),
+                                                   eventMetadataMock));
+
+        when(beanMock.getBeanClass()).thenReturn(observer.getClass());
+        assertFalse(observer.shouldObserveThisEvent(new EventTest(),
+                                                    eventMetadataMock));
+
+        when(eventMetadataMock.getInjectionPoint()).thenReturn(null);
+        assertTrue(observer.shouldObserveThisEvent(new EventTest(),
+                                                   eventMetadataMock));
+    }
+
+    @Portable
+    @Clustered
+    public static class EventTest {
+
+    }
+
+    private ClusterEventObserver setupMock() {
+        return new ClusterEventObserver() {
+            @Override
+            ClusterJMSService getClusterService() {
+                return clusterService;
+            }
+
+            @Override
+            Object fromJSON(ClusterSerializedCDIMessageWrapper message) {
+                return new Object();
+            }
+
+            @Override
+            String toJSON(Object event) {
+                return "Dora";
+            }
+        };
+    }
+
+    // duplicated from uberfire test utils in order to avoid cyclic reference
+    public class EventSourceMock<T> implements Event<T> {
+
+        @Override
+        public void fire(T event) {
+            throw new UnsupportedOperationException("mocking testing class");
+        }
+
+        @Override
+        public Event<T> select(Annotation... qualifiers) {
+            throw new UnsupportedOperationException("mocking testing class");
+        }
+
+        @Override
+        public <U extends T> Event<U> select(Class<U> subtype,
+                                             Annotation... qualifiers) {
+            throw new UnsupportedOperationException("mocking testing class");
+        }
+
+        @Override
+        public <U extends T> Event<U> select(TypeLiteral<U> subtype,
+                                             Annotation... qualifiers) {
+            return null;
+        }
+    }
+}
+

--- a/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-backend/src/main/java/org/ext/uberfire/social/activities/persistence/SocialClusterMessaging.java
+++ b/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-backend/src/main/java/org/ext/uberfire/social/activities/persistence/SocialClusterMessaging.java
@@ -17,6 +17,7 @@ package org.ext.uberfire.social.activities.persistence;
 
 import java.util.List;
 import java.util.UUID;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -75,6 +76,13 @@ public class SocialClusterMessaging {
                                                        }
                                                    }
                                                });
+        }
+    }
+
+    @PreDestroy
+    public void shutdown(){
+        if(this.clusterService.isAppFormerClustered()){
+            this.clusterService.close();
         }
     }
 

--- a/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/events/NewProjectEvent.java
+++ b/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/events/NewProjectEvent.java
@@ -17,8 +17,10 @@ package org.guvnor.common.services.project.events;
 
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.uberfire.commons.clusterapi.Clustered;
 
 @Portable
+@Clustered
 public class NewProjectEvent {
 
     private WorkspaceProject workspaceProject;


### PR DESCRIPTION
Now CDI Events are also distributed in the cluster.

Just annotate your @Portable events with @Clustered and Appformer will replicate them on each node.

@tomasdavidorg to test this, on cluster env. open the library on each node and add some projects and spaces. If they appear on other nodes this mechanism is working.

The CDI event that is being distributed in this POC is the NewProjectEvent. (later PRs will propagate other  important events)

ps: This PR doesn't yet cover the sync of deleted spaces/projects/files. This will be addressed in later work.