### PR TITLE
[7.7.x] AF-1184: [Layout editor] Moving any component on canvas breaks Layouteditor

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -70,6 +70,7 @@ public class Container implements LayoutEditorElement {
     private LayoutTemplate.Style pageStyle = LayoutTemplate.Style.FLUID;
     private Event<LayoutEditorElementSelectEvent> containerSelectEvent;
     private Event<LayoutEditorElementUnselectEvent> containerUnselectEvent;
+    private DnDManager dndManager;
     private boolean selectable = false;
     private boolean selected = false;
 
@@ -80,7 +81,8 @@ public class Container implements LayoutEditorElement {
                      Instance<EmptyDropRow> emptyDropRowInstance,
                      Event<ComponentDropEvent> componentDropEvent,
                      Event<LayoutEditorElementSelectEvent> containerSelectEvent,
-                     Event<LayoutEditorElementUnselectEvent> containerUnselectEvent) {
+                     Event<LayoutEditorElementUnselectEvent> containerUnselectEvent,
+                     DnDManager dndManager) {
         this.layoutCssHelper = layoutCssHelper;
         this.rowInstance = rowInstance;
         this.emptyDropRowInstance = emptyDropRowInstance;
@@ -88,6 +90,7 @@ public class Container implements LayoutEditorElement {
         this.componentDropEvent = componentDropEvent;
         this.containerSelectEvent = containerSelectEvent;
         this.containerUnselectEvent = containerUnselectEvent;
+        this.dndManager = dndManager;
         this.id = idGenerator.createContainerID();
     }
 
@@ -343,6 +346,8 @@ public class Container implements LayoutEditorElement {
         addNewRow(row,
                   dropRow,
                   updatedRows);
+        // notifying dndManager that the move has finished!
+        dndManager.endComponentMove();
     }
 
     private void removeOldComponent(Column column) {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
@@ -288,6 +288,8 @@ public class Row implements LayoutEditorElement {
         return (drop) -> {
             if (dropFromMoveComponent(drop)) {
                 removeOldComponent(drop);
+                // notifying dndManager that the move has finished!
+                dndManager.endComponentMove();
             }
             notifyDrop(drop);
             Row.this.columns = updateColumns(drop,

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
@@ -109,7 +109,8 @@ public abstract class AbstractLayoutEditorTest {
                              emptyDropRowInstance,
                              componentDropEventMock,
                              layoutElementSelectEventMock,
-                             layoutElementUnselectEventMock) {
+                             layoutElementUnselectEventMock,
+                             dnDManager) {
             private UniqueIDGenerator idGenerator = new UniqueIDGenerator();
 
             @Override

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/rows/RowTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/rows/RowTest.java
@@ -301,8 +301,44 @@ public class RowTest extends AbstractLayoutEditorTest {
 
         verify(componentDropEventMock).fire(dropEventCaptor.capture());
         assertTrue(dropEventCaptor.getValue().getFromMove());
+        // after drop dnDManager is no longer on move state
+        assertFalse(dnDManager.isOnComponentMove());
+    }
+
+    @Test
+    public void testMoveElement() throws Exception {
+        loadLayout(SAMPLE_FULL_FLUID_LAYOUT);
+
+        Row row = getRowByIndex(FIRST_ROW);
+        assertThat(row.getColumns()).hasSize(4);
+
+        Column rowColumn = row.getColumns().get(0);
+        assertThat(rowColumn).isNotNull().isInstanceOf(ComponentColumn.class);
+
+        ComponentColumn column = (ComponentColumn) rowColumn;
+
+        dnDManager.dragComponent(column.getLayoutComponent(),
+                                 row.getId(),
+                                 column);
+        row.removeColumn(column);
+
+        assertThat(row.getColumns()).hasSize(3);
+
+        ArgumentCaptor<ComponentRemovedEvent> removeEventCaptor = ArgumentCaptor.forClass(ComponentRemovedEvent.class);
+        verify(componentRemoveEventMock,
+               times(1)).fire(removeEventCaptor.capture());
+
+        assertTrue(removeEventCaptor.getValue().getFromMove());
         assertTrue(dnDManager.isOnComponentMove());
 
+        // Dropping (we don't need any dropData for this test)
+        row.drop("", RowDrop.Orientation.BEFORE);
+        ArgumentCaptor<ComponentDropEvent> dropEventCaptor = ArgumentCaptor.forClass(ComponentDropEvent.class);
+
+        verify(componentDropEventMock).fire(dropEventCaptor.capture());
+        assertTrue(dropEventCaptor.getValue().getFromMove());
+        // after drop dnDManager is no longer on move state
+        assertFalse(dnDManager.isOnComponentMove());
     }
 
     @Test


### PR DESCRIPTION
Backport of https://github.com/kiegroup/appformer/pull/326

@dgutierr @kkufova could you please take a look?