### PR TITLE
AF-1186: Versions history is lost after asset rename

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitVersionAttributeView.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitVersionAttributeView.java
@@ -32,6 +32,7 @@ import org.uberfire.java.nio.base.version.VersionRecord;
 import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.FileTime;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitHistory;
 import org.uberfire.java.nio.fs.jgit.util.model.PathInfo;
 import org.uberfire.java.nio.fs.jgit.util.model.PathType;
 
@@ -76,8 +77,9 @@ public class JGitVersionAttributeView extends VersionAttributeView<JGitPathImpl>
 
         if (refId != null) {
             try {
-                for (final RevCommit commit : fs.getGit().listCommits(refId,
-                                                                      pathInfo.getPath())) {
+                final CommitHistory history = fs.getGit().listCommits(refId, pathInfo.getPath());
+                for (final RevCommit commit : history.getCommits()) {
+                    final String recordPath = history.trackedFileNameChangeFor(commit.getId());
                     records.add(new VersionRecord() {
                         @Override
                         public String id() {
@@ -107,7 +109,7 @@ public class JGitVersionAttributeView extends VersionAttributeView<JGitPathImpl>
                         @Override
                         public String uri() {
                             return fs.getPath(commit.name(),
-                                              path).toUri().toString();
+                                              recordPath).toUri().toString();
                         }
                     });
                 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/Git.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/Git.java
@@ -43,6 +43,7 @@ import org.uberfire.java.nio.fs.jgit.util.commands.CreateRepository;
 import org.uberfire.java.nio.fs.jgit.util.commands.Fork;
 import org.uberfire.java.nio.fs.jgit.util.commands.SubdirectoryClone;
 import org.uberfire.java.nio.fs.jgit.util.model.CommitContent;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitHistory;
 import org.uberfire.java.nio.fs.jgit.util.model.CommitInfo;
 import org.uberfire.java.nio.fs.jgit.util.model.PathInfo;
 
@@ -118,8 +119,8 @@ public interface Git {
 
     RevCommit getLastCommit(final Ref ref) throws IOException;
 
-    List<RevCommit> listCommits(final Ref ref,
-                                final String path) throws IOException, GitAPIException;
+    CommitHistory listCommits(final Ref ref,
+                              final String path) throws IOException, GitAPIException;
 
     List<RevCommit> listCommits(final ObjectId startRange,
                                 final ObjectId endRange);

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/GitImpl.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/GitImpl.java
@@ -82,6 +82,7 @@ import org.uberfire.java.nio.fs.jgit.util.commands.Squash;
 import org.uberfire.java.nio.fs.jgit.util.commands.SyncRemote;
 import org.uberfire.java.nio.fs.jgit.util.commands.UpdateRemoteConfig;
 import org.uberfire.java.nio.fs.jgit.util.model.CommitContent;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitHistory;
 import org.uberfire.java.nio.fs.jgit.util.model.CommitInfo;
 import org.uberfire.java.nio.fs.jgit.util.model.PathInfo;
 
@@ -187,8 +188,8 @@ public class GitImpl implements Git {
     }
 
     @Override
-    public List<RevCommit> listCommits(final Ref ref,
-                                       final String path) throws IOException, GitAPIException {
+    public CommitHistory listCommits(final Ref ref,
+                                     final String path) throws IOException, GitAPIException {
         return new ListCommits(this,
                                ref,
                                path).execute();
@@ -200,7 +201,8 @@ public class GitImpl implements Git {
         return retryIfNeeded(RuntimeException.class,
                              () -> new ListCommits(this,
                                                    startRange,
-                                                   endRange).execute());
+                                                   endRange).execute()
+                                                            .getCommits());
     }
 
     @Override

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ListCommits.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ListCommits.java
@@ -18,34 +18,53 @@ package org.uberfire.java.nio.fs.jgit.util.commands;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.eclipse.jgit.api.LogCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffConfig;
+import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.AnyObjectId;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.FollowFilter;
+import org.eclipse.jgit.revwalk.RenameCallback;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.TreeRevFilter;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
+import org.uberfire.java.nio.fs.jgit.util.Git;
 import org.uberfire.java.nio.fs.jgit.util.GitImpl;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitHistory;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 
 public class ListCommits {
 
-    private final GitImpl git;
+    private final Git git;
     private final ObjectId startRange;
     private final ObjectId endRange;
-    private final Ref ref;
     private final String path;
 
-    public ListCommits(final GitImpl git,
+    public ListCommits(final Git git,
                        final Ref ref,
                        final String path) {
         this.git = git;
-        this.ref = ref;
-        this.path = path;
+        this.path = makeRelative(path);
         this.startRange = null;
-        this.endRange = null;
+        this.endRange = ref.getObjectId();
+    }
+
+    private static String makeRelative(String path) {
+        return (path != null && path.startsWith("/")) ? path.substring(1) : path;
     }
 
     public ListCommits(final GitImpl git,
@@ -54,35 +73,97 @@ public class ListCommits {
         this.git = git;
         this.startRange = startRange;
         this.endRange = endRange;
-        this.ref = null;
         this.path = null;
     }
 
-    public List<RevCommit> execute() throws IOException, GitAPIException {
-        final List<RevCommit> list = new ArrayList<>();
+    public CommitHistory execute() throws IOException, GitAPIException {
         try (final RevWalk rw = buildWalk()) {
-            if (ref == null) {
-                rw.markStart(rw.parseCommit(endRange));
-                if (startRange != null) {
-                    rw.markUninteresting(rw.parseCommit(startRange));
-                }
+            if (path == null || path.isEmpty()) {
+                return fullCommitHistory(rw);
+            } else {
+                return pathCommitHistory(rw);
             }
-            for (RevCommit rev : rw) {
-                list.add(rev);
-            }
-            return list;
         }
     }
 
-    private RevWalk buildWalk() throws GitAPIException, IncorrectObjectTypeException, MissingObjectException {
-        if (ref != null) {
-            final LogCommand logCommand = git._log().add(ref.getObjectId());
-            if (path != null && !path.isEmpty()) {
-                logCommand.addPath(path);
+    private CommitHistory pathCommitHistory(final RevWalk rw) throws MissingObjectException, IncorrectObjectTypeException, IOException {
+        final Map<AnyObjectId, String> pathByCommit = new HashMap<>();
+        final List<RevCommit> commits = new ArrayList<>();
+        final RenameCaptor renameCaptor = new RenameCaptor();
+        /*
+         * We have to go through all commits and filter ourselves so that we can use the
+         * rename callback to map commits to path renames.
+         */
+        final TreeRevFilter revFilter = createTreeRevFilter(rw, path, renameCaptor);
+        String curPath = path;
+        for (final RevCommit commit : rw) {
+            if (revFilter.include(rw, commit)) {
+                @SuppressWarnings("resource")
+                final TreeWalk tw = new TreeWalk(rw.getObjectReader());
+                tw.setRecursive(true);
+                tw.setFilter(PathFilter.create(curPath));
+                tw.addTree(commit.getTree());
+                // Checks for special case that path wasn't deleted in this commit
+                if (tw.next()) {
+                    commits.add(commit);
+                    // There is a rename to track
+                    pathByCommit.put(commit.getId(), curPath);
+                    if (renameCaptor.hasCaptured()) {
+                        curPath = renameCaptor.getAndReset().getOldPath();
+                    }
+                }
             }
-            return (RevWalk) logCommand.call();
         }
 
-        return new RevWalk(git.getRepository());
+        return new CommitHistory(commits, pathByCommit, path);
+    }
+
+    private CommitHistory fullCommitHistory(final RevWalk rw) {
+        final List<RevCommit> commits = stream(rw.spliterator(), false).collect(toList());
+        return new CommitHistory(commits, Collections.emptyMap(), null);
+    }
+
+    private TreeRevFilter createTreeRevFilter(final RevWalk rw, String curPath, final RenameCallback renameCallback) {
+        final FollowFilter followFilter = FollowFilter.create(curPath, git.getRepository().getConfig().get(DiffConfig.KEY));
+        followFilter.setRenameCallback(renameCallback);
+        final TreeRevFilter revFilter = new TreeRevFilter(rw, followFilter);
+        return revFilter;
+    }
+
+    private RevWalk buildWalk() throws GitAPIException, IOException {
+        final RevWalk rw = new RevWalk(git.getRepository());
+        rw.setTreeFilter(TreeFilter.ANY_DIFF);
+        rw.markStart(rw.parseCommit(endRange));
+        rw.sort(RevSort.TOPO);
+        if (startRange != null) {
+            rw.markUninteresting(rw.parseCommit(startRange));
+        }
+
+        return rw;
+    }
+
+    private static class RenameCaptor extends RenameCallback {
+
+        private DiffEntry captured;
+
+        @Override
+        public void renamed(final DiffEntry entry) {
+            captured = entry;
+        }
+
+        public boolean hasCaptured() {
+            return captured != null;
+        }
+
+        public DiffEntry getAndReset() {
+            if (captured == null) {
+                throw new NullPointerException("Cannot get DiffEntry when none was captured.");
+            }
+
+            final DiffEntry retVal = captured;
+            captured = null;
+
+            return retVal;
+        }
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/model/CommitHistory.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/model/CommitHistory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.uberfire.java.nio.fs.jgit.util.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.revwalk.RevCommit;
+
+public class CommitHistory {
+
+    private final List<RevCommit> commits;
+    private final Map<AnyObjectId, String> pathsByCommit;
+    private final String trackedPath;
+
+    public CommitHistory(final List<RevCommit> commits,
+                         final Map<AnyObjectId, String> pathsByCommit,
+                         final String trackedPath) {
+        this.commits = commits;
+        this.pathsByCommit = pathsByCommit;
+        this.trackedPath = trackedPath;
+    }
+
+    public List<RevCommit> getCommits() {
+        return commits;
+    }
+
+    /**
+     * @return The initial file path that was followed, or else the root path (/) if none was given.
+     */
+    public String getTrackedFilePath() {
+        return (trackedPath == null) ? "/" : trackedPath;
+    }
+
+    public String trackedFileNameChangeFor(final AnyObjectId commitId) {
+        return Optional.ofNullable(pathsByCommit.get(commitId))
+                       .map(path -> "/" + path)
+                       .orElseGet(() -> getTrackedFilePath());
+    }
+
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitHistoryTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitHistoryTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.uberfire.java.nio.fs.jgit;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.java.nio.fs.jgit.util.Git;
+import org.uberfire.java.nio.fs.jgit.util.commands.CreateRepository;
+import org.uberfire.java.nio.fs.jgit.util.commands.ListCommits;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitHistory;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitInfo;
+import org.uberfire.java.nio.fs.jgit.util.model.MoveCommitContent;
+
+import static org.junit.Assert.assertEquals;
+
+public class JGitHistoryTest extends AbstractTestInfra {
+
+    private Git git;
+
+    @Before
+    public void setup() throws IOException {
+        final File tmpDir = createTempDirectory();
+        final File repoDir = new File(tmpDir, "test-repo.git");
+        git = new CreateRepository(repoDir).execute()
+                                           .orElseThrow(() -> new IllegalStateException("Unable to create git repo for tests."));
+
+        commit(git,
+               "master",
+               "create files",
+               content("non-moving.txt", multiline("a", "b", "c")),
+               content("moving.txt", multiline("1", "2", "3")));
+        moveCommit(singleMove("moving.txt", "moving1.txt"), "rename moving file");
+        commit(git,
+               "master",
+               "change content, no moves",
+               content("non-moving.txt", multiline("a", "b", "d")),
+               content("moving1.txt", multiline("1", "2", "4")));
+        moveCommit(singleMove("moving1.txt", "dir/moving2.txt"), "move moving file to new dir");
+        commit(git,
+               "master",
+               "simulate checkout old version",
+               content("moving1.txt", multiline("1", "2", "4")));
+    }
+
+    private Map<String, String> singleMove(String from, String to) {
+        Map<String, String> moves = new HashMap<>();
+        moves.put(from, to);
+        return moves;
+    }
+
+    private void moveCommit(Map<String, String> moves, String message) {
+        git.commit("master", new CommitInfo(null, "name", "name@example.com", message, null, null), false, null, new MoveCommitContent(moves));
+    }
+
+    private static String multiline(String... lines) {
+        return Arrays.stream(lines)
+                     .reduce((s1, s2) -> s1 + "\n" + s2)
+                     .orElse("");
+    }
+
+    @Test
+    public void listCommitsForUnmovedFile() throws Exception {
+        final CommitHistory history = new ListCommits(git, git.getRef("master"), "non-moving.txt").execute();
+        assertEquals("non-moving.txt", history.getTrackedFilePath());
+        assertEquals(2, history.getCommits().size());
+        assertEquals("/non-moving.txt", history.trackedFileNameChangeFor(history.getCommits().get(0).getId()));
+        assertEquals("/non-moving.txt", history.trackedFileNameChangeFor(history.getCommits().get(1).getId()));
+    }
+
+    @Test
+    public void listCommitsForMovedFile() throws Exception {
+        final CommitHistory history = new ListCommits(git, git.getRef("master"), "dir/moving2.txt").execute();
+        assertEquals("dir/moving2.txt", history.getTrackedFilePath());
+        assertEquals(4, history.getCommits().size());
+
+        final RevCommit commit0 = history.getCommits().get(0);
+        String oPath0 = history.trackedFileNameChangeFor(commit0.getId());
+        assertEquals("move moving file to new dir", commit0.getFullMessage());
+        assertEquals("/dir/moving2.txt", oPath0);
+
+        final RevCommit commit1 = history.getCommits().get(1);
+        String oPath1 = history.trackedFileNameChangeFor(commit1.getId());
+        assertEquals("change content, no moves", commit1.getFullMessage());
+        assertEquals("/moving1.txt", oPath1);
+
+        final RevCommit commit2 = history.getCommits().get(2);
+        String oPath2 = history.trackedFileNameChangeFor(commit2.getId());
+        assertEquals("rename moving file", commit2.getFullMessage());
+        assertEquals("/moving1.txt", oPath2);
+
+        final RevCommit commit3 = history.getCommits().get(3);
+        String oPath3 = history.trackedFileNameChangeFor(commit3.getId());
+        assertEquals("create files", commit3.getFullMessage());
+        assertEquals("/moving.txt", oPath3);
+    }
+
+    @Test
+    public void listCommitsForRestoredFile() throws Exception {
+        final CommitHistory history = new ListCommits(git, git.getRef("master"), "moving1.txt").execute();
+        assertEquals("moving1.txt", history.getTrackedFilePath());
+        assertEquals(4, history.getCommits().size());
+
+        final RevCommit commit0 = history.getCommits().get(0);
+        String oPath0 = history.trackedFileNameChangeFor(commit0.getId());
+        assertEquals("simulate checkout old version", commit0.getFullMessage());
+        assertEquals("/moving1.txt", oPath0);
+
+        final RevCommit commit1 = history.getCommits().get(1);
+        String oPath1 = history.trackedFileNameChangeFor(commit1.getId());
+        assertEquals("change content, no moves", commit1.getFullMessage());
+        assertEquals("/moving1.txt", oPath1);
+
+        final RevCommit commit2 = history.getCommits().get(2);
+        String oPath2 = history.trackedFileNameChangeFor(commit2.getId());
+        assertEquals("rename moving file", commit2.getFullMessage());
+        assertEquals("/moving1.txt", oPath2);
+
+        final RevCommit commit3 = history.getCommits().get(3);
+        String oPath3 = history.trackedFileNameChangeFor(commit3.getId());
+        assertEquals("create files", commit3.getFullMessage());
+        assertEquals("/moving.txt", oPath3);
+    }
+
+    @Test
+    public void listCommitsOnDirectory() throws Exception {
+        final CommitHistory history = new ListCommits(git, git.getRef("master"), "dir").execute();
+        assertEquals("dir", history.getTrackedFilePath());
+        assertEquals(1, history.getCommits().size());
+
+        final RevCommit commit0 = history.getCommits().get(0);
+        String oPath0 = history.trackedFileNameChangeFor(commit0.getId());
+        assertEquals("move moving file to new dir", commit0.getFullMessage());
+        assertEquals("/dir", oPath0);
+    }
+
+    @Test
+    public void listCommitsOnRootDirectoryViaAbsolute() throws Exception {
+        final CommitHistory history = new ListCommits(git, git.getRef("master"), "/").execute();
+        assertEquals("/", history.getTrackedFilePath());
+        assertEquals(5, history.getCommits().size());
+
+        final RevCommit commit0 = history.getCommits().get(0);
+        String oPath0 = history.trackedFileNameChangeFor(commit0.getId());
+        assertEquals("simulate checkout old version", commit0.getFullMessage());
+        assertEquals("/", oPath0);
+    }
+
+    @Test
+    public void listCommitsOnRootDirectoryViaNull() throws Exception {
+        final CommitHistory history = new ListCommits(git, git.getRef("master"), null).execute();
+        assertEquals("/", history.getTrackedFilePath());
+        assertEquals(5, history.getCommits().size());
+
+        final RevCommit commit0 = history.getCommits().get(0);
+        String oPath0 = history.trackedFileNameChangeFor(commit0.getId());
+        assertEquals("simulate checkout old version", commit0.getFullMessage());
+        assertEquals("/", oPath0);
+    }
+
+    @Test
+    public void listCommitsOnRootDirectoryViaEmpty() throws Exception {
+        final CommitHistory history = new ListCommits(git, git.getRef("master"), "").execute();
+        assertEquals("/", history.getTrackedFilePath());
+        assertEquals(5, history.getCommits().size());
+
+        final RevCommit commit0 = history.getCommits().get(0);
+        String oPath0 = history.trackedFileNameChangeFor(commit0.getId());
+        assertEquals("simulate checkout old version", commit0.getFullMessage());
+        assertEquals("/", oPath0);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSubdirectoryCloneTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSubdirectoryCloneTest.java
@@ -19,10 +19,8 @@ package org.uberfire.java.nio.fs.jgit;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
@@ -46,14 +44,12 @@ import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.junit.Test;
 import org.uberfire.java.nio.fs.jgit.util.Git;
-import org.uberfire.java.nio.fs.jgit.util.commands.Commit;
 import org.uberfire.java.nio.fs.jgit.util.commands.CreateRepository;
 import org.uberfire.java.nio.fs.jgit.util.commands.ListRefs;
 import org.uberfire.java.nio.fs.jgit.util.commands.SubdirectoryClone;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -306,20 +302,6 @@ public class JGitSubdirectoryCloneTest extends AbstractTestInfra {
         return new CreateRepository(gitSource).execute().get();
     }
 
-    private void commit(final Git origin, String branchName, String message, TestFile... testFiles) throws IOException {
-        final Map<String, File> data = Arrays.stream(testFiles)
-                                             .collect(toMap(f -> f.path, f -> tmpFile(f.content)));
-        new Commit(origin,
-                   branchName,
-                   "name",
-                   "name@example.com",
-                   message,
-                   null,
-                   null,
-                   false,
-                   data).execute();
-    }
-
     /*
      * Unfortunately there is no easier way to write a commit with multiple parents.
      */
@@ -386,28 +368,5 @@ public class JGitSubdirectoryCloneTest extends AbstractTestInfra {
                 ent.setObjectId(blobId);
             }
         });
-    }
-
-    private File tmpFile(final String content) {
-        try {
-            return tempFile(content);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static TestFile content(final String path, final String content) {
-        return new TestFile(path, content);
-    }
-
-    private static class TestFile {
-
-        final String path;
-        final String content;
-
-        TestFile(final String path, final String content) {
-            this.path = path;
-            this.content = content;
-        }
     }
 }


### PR DESCRIPTION
Fixes `ListCommits` command to follow path name changes, and maps version records to correct paths of renamed files.

Note that there are issues with some editors when trying to view previous versions of moved files. One that I encountered is with the data modeller. That editor produces two commits when moving a file. One renames the Java class and the other moves the file. If you try checking out the commit that renames the Java class, the data modeller cannot load the class, presumably because the class name and file name do not match. We might want to make a JIRA issue to ensure that rename operations are committed atomically. //cc @wmedvede 