### PR TITLE
JBPM-7145 allow SVG persisted on backend (Stunner)

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
@@ -16,6 +16,12 @@
 
 package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.management.Attribute;
+
 import elemental2.core.Array;
 import elemental2.dom.CanvasGradient;
 import elemental2.dom.Element;
@@ -27,6 +33,7 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
+import org.jboss.errai.codegen.Parameter;
 
 /**
  * This is a JsInterop class responsible to make the interface to the <b>canvas2svg</b> library,
@@ -193,12 +200,17 @@ class C2S {
 
     // -----------------------------JS overlay save/restore group -----------------------------
     @JsOverlay
-    public final void saveGroup() {
+    public final void saveGroup(Map<String, String> attributes) {
         Element group = this.__createElement("g");
         Element parent = this.__closestGroupOrSvg(null);
         this.__groupStack.push(parent);
         parent.appendChild(group);
         this.__currentElement = group;
+        //setting the group attributes
+        Optional.ofNullable(attributes).ifPresent(attr -> attr.entrySet()
+                .stream()
+                .filter(entry -> Objects.nonNull(entry.getValue()))
+                .forEach(entry -> group.setAttribute(entry.getKey(), entry.getValue())));
     }
 
     @JsOverlay

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2D.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2D.java
@@ -16,6 +16,9 @@
 
 package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
 
+import java.util.Map;
+import java.util.Optional;
+
 import elemental2.dom.CanvasGradient;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLCanvasElement;
@@ -108,8 +111,8 @@ public class C2SContext2D implements IContext2D {
         delegate.setLineDashOffset(offset);
     }
 
-    public void saveGroup() {
-        delegate.saveGroup();
+    public void saveGroup(Map<String, String> attributes) {
+        delegate.saveGroup(attributes);
     }
 
     public void restoreGroup() {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/IContext2D.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/IContext2D.java
@@ -16,6 +16,9 @@
 
 package org.uberfire.ext.editor.commons.client.file.exports.svg;
 
+import java.util.Map;
+import java.util.Optional;
+
 import elemental2.dom.CanvasGradient;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLCanvasElement;
@@ -61,7 +64,7 @@ public interface IContext2D {
 
     void setLineDashOffset(double offset);
 
-    void saveGroup();
+    void saveGroup(Map<String, String> attributes);
 
     void saveStyle();
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2DTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2DTest.java
@@ -16,6 +16,10 @@
 
 package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
 import elemental2.core.Array;
@@ -28,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -166,8 +171,13 @@ public class C2SContext2DTest {
 
     @Test
     public void saveGroup() {
-        c2SContext2D.saveGroup();
-        verify(c2S).saveGroup();
+        final String key = "id";
+        final String value = "value";
+        final Map<String, String> id = new HashMap<String, String>(){{
+            put(key, value);
+        }};
+        c2SContext2D.saveGroup(id);
+        verify(c2S).saveGroup(id);
     }
 
     @Test


### PR DESCRIPTION
JBPM-7145 changes to support SVG backend export, allow adding attributes to SVG groups.
It is necessary to add the BPMN id to SVG groups, so it was inserted on the saveGroup method that is an JsOverlay to the **canvas2svg**  lib.
Stunner will use this feature to save the diagrams SVG on the VFS.

@romartin 
@LuboTerifaj 