### PR TITLE
AF-1201: [CMS perspective] IE11 Adding tile navigation component for custom trees causes error

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavItemTileWidgetView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-navigation-client/src/main/java/org/dashbuilder/client/navigation/widget/NavItemTileWidgetView.java
@@ -55,7 +55,7 @@ public class NavItemTileWidgetView implements NavItemTileWidget.View, IsElement 
     @Override
     public void show(String name, String descr, ItemType type) {
         textSpan.setTextContent(name);
-        mainDiv.getStyle().setProperty("title", descr);
+        mainDiv.setTitle(descr);
 
         if (ItemType.GROUP == type) {
             mainDiv.setClassName("uf-navitem-tile-body uf-navitem-tile-group");


### PR DESCRIPTION
@kkufova I managed to reproduce/fix it on a Win7/IE11 machine. Notice no test case is provided as this is a view only fix. IMO proper coverage must be provided by means of UI integration tests.