### PR TITLE
JBPM-5813: Stunner - Open XML editor instead of sorry screen when process can't be opened

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/BaseUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/BaseUploadServlet.java
@@ -18,6 +18,7 @@ package org.uberfire.server;
 
 import java.io.IOException;
 import java.util.Iterator;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -64,14 +65,19 @@ public abstract class BaseUploadServlet extends BaseFilteredServlet {
     protected void writeFile(final IOService ioService,
                              final Path path,
                              final FileItem uploadedItem) throws IOException {
-        if (!ioService.exists(path)) {
-            ioService.createFile(path);
+        try {
+            ioService.startBatch(path.getFileSystem());
+
+            if (!ioService.exists(path)) {
+                ioService.createFile(path);
+            }
+
+            ioService.write(path,
+                            IOUtils.toByteArray(uploadedItem.getInputStream()));
+        } finally {
+            uploadedItem.getInputStream().close();
+            ioService.endBatch();
         }
-
-        ioService.write(path,
-                        IOUtils.toByteArray(uploadedItem.getInputStream()));
-
-        uploadedItem.getInputStream().close();
     }
 
     protected void logError(Throwable e) {


### PR DESCRIPTION
Ensure BaseFileUploadServlet creates the file in a batch.

See https://issues.jboss.org/browse/JBPM-5813 (more specifically the reported issue on the Product [JIRA](https://issues.jboss.org/browse/RHPAM-447?focusedCommentId=13576647&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13576647)).