### PR TITLE
[7.7.x] RHPAM-447 (JBPM-5813): Stunner - Open XML editor instead of sorry screen when process can't be opened

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/BaseUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/BaseUploadServlet.java
@@ -18,6 +18,7 @@ package org.uberfire.server;
 
 import java.io.IOException;
 import java.util.Iterator;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -64,14 +65,19 @@ public abstract class BaseUploadServlet extends BaseFilteredServlet {
     protected void writeFile(final IOService ioService,
                              final Path path,
                              final FileItem uploadedItem) throws IOException {
-        if (!ioService.exists(path)) {
-            ioService.createFile(path);
+        try {
+            ioService.startBatch(path.getFileSystem());
+
+            if (!ioService.exists(path)) {
+                ioService.createFile(path);
+            }
+
+            ioService.write(path,
+                            IOUtils.toByteArray(uploadedItem.getInputStream()));
+        } finally {
+            uploadedItem.getInputStream().close();
+            ioService.endBatch();
         }
-
-        ioService.write(path,
-                        IOUtils.toByteArray(uploadedItem.getInputStream()));
-
-        uploadedItem.getInputStream().close();
     }
 
     protected void logError(Throwable e) {


### PR DESCRIPTION
Ensure BaseFileUploadServlet creates the file in a batch.

See https://issues.jboss.org/browse/RHPAM-447 (more specifically [this](https://issues.jboss.org/browse/RHPAM-447?focusedCommentId=13577472&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13577472)).

This is the corollary of https://github.com/kiegroup/appformer/pull/359 for 7.7.x

(cherry picked from commit 95dbbd17e67330efebc4f1f911bb206ae39a53fe)