### PR TITLE
JBPM-7245  Diagram SVG is not highlighted on the WB

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
@@ -207,18 +207,15 @@ class C2S {
         parent.appendChild(group);
         this.__currentElement = group;
         //setting the group attributes
-        Optional.ofNullable(attributes).ifPresent(attr -> attr.entrySet()
-                .stream()
-                .filter(entry -> Objects.nonNull(entry.getValue()))
-                .forEach(entry -> group.setAttribute(entry.getKey(), entry.getValue())));
+        addAttributes(attributes);
     }
 
     @JsOverlay
     public final void restoreGroup() {
-        this.__currentElement = (Node) this.__groupStack.pop();
+        this.__currentElement = (Element) this.__groupStack.pop();
         //Clearing canvas will make the poped group invalid, currentElement is set to the root group node.
         if (this.__currentElement == null) {
-            this.__currentElement = this.__root.childNodes.item(1);
+            this.__currentElement = (Element) this.__root.childNodes.item(1);
         }
     }
 
@@ -232,6 +229,14 @@ class C2S {
         this.__currentElementsToStyle = null;
         Object state = this.__stack.pop();
         this.__applyStyleState(state);
+    }
+
+    @JsOverlay
+    public final void addAttributes(Map<String, String> attributes) {
+        Optional.ofNullable(attributes).ifPresent(attr -> attr.entrySet()
+                .stream()
+                .filter(entry -> Objects.nonNull(entry.getValue()))
+                .forEach(entry -> this.__currentElement.setAttribute(entry.getKey(), entry.getValue())));
     }
 
     public final native Element __createElement(String elementName);
@@ -249,7 +254,7 @@ class C2S {
     public Array __stack;
 
     @JsProperty
-    public Node __currentElement;
+    public Element __currentElement;
 
     @JsProperty
     public Node __root;

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2D.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2D.java
@@ -111,6 +111,10 @@ public class C2SContext2D implements IContext2D {
         delegate.setLineDashOffset(offset);
     }
 
+    public void addAttributes(Map<String, String> attributes) {
+        delegate.addAttributes(attributes);
+    }
+
     public void saveGroup(Map<String, String> attributes) {
         delegate.saveGroup(attributes);
     }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/IContext2D.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/svg/IContext2D.java
@@ -64,6 +64,8 @@ public interface IContext2D {
 
     void setLineDashOffset(double offset);
 
+    void addAttributes(Map<String, String> attributes);
+
     void saveGroup(Map<String, String> attributes);
 
     void saveStyle();


### PR DESCRIPTION
Changes to support Diagram SVG is not highlighted on the WB (jbpm-process-svg widget).
Insert the node id in the same way it was done for the containers.

PS: unit tests will be updated later, the PR is to be tested ASAP since this is a blocker.

@romartin 
@LuboTerifaj 