### PR TITLE
[7.7.x] AF-1227: Library content is not visible when Projects link is clicked

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -314,9 +314,12 @@ public class PlaceManagerImpl
         };
 
         final PerspectiveActivity currentPerspective = perspectiveManager.getCurrentPerspective();
+        final boolean thereIsAnOpenedPerspective = currentPerspective != null;
+        final boolean isDifferentPerspective = thereIsAnOpenedPerspective && !place.equals(currentPerspective.getPlace());
+        final boolean isForcedPlaceRequest = place instanceof ForcedPlaceRequest;
 
         // Before launching the perspective, checks if there is some close chain to be executed for the current perspective
-        if (currentPerspective != null) {
+        if (thereIsAnOpenedPerspective && (isDifferentPerspective || isForcedPlaceRequest)) {
             final BiParameterizedCommand<Command, PlaceRequest> closeChain = this.perspectiveCloseChain.get(currentPerspective.getIdentifier());
             if (closeChain != null) {
                 closeChain.execute(launchPerspectiveCommand,

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
@@ -70,6 +70,7 @@ import org.uberfire.client.workbench.events.ClosePlaceEvent;
 import org.uberfire.client.workbench.events.NewSplashScreenActiveEvent;
 import org.uberfire.client.workbench.events.PlaceLostFocusEvent;
 import org.uberfire.client.workbench.events.SelectPlaceEvent;
+import org.uberfire.mvp.BiParameterizedCommand;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
@@ -641,11 +642,20 @@ public class PlaceManagerTest {
                 .thenReturn(singleton((Activity) ozPerspectiveActivity));
         when(ozPerspectiveActivity.getDefaultPerspectiveLayout()).thenReturn(ozPerspectiveDef);
         when(ozPerspectiveActivity.getPlace()).thenReturn(ozPerspectivePlace);
+        when(ozPerspectiveActivity.isType(ActivityResourceType.PERSPECTIVE.name())).thenReturn(true);
+        when(ozPerspectiveActivity.getIdentifier()).thenReturn("oz_perspective");
 
         // we'll pretend we started in oz
         when(perspectiveManager.getCurrentPerspective()).thenReturn(ozPerspectiveActivity);
 
+        final BiParameterizedCommand<Command, PlaceRequest> closeChain = mock(BiParameterizedCommand.class);
+        placeManager.registerPerspectiveCloseChain("oz_perspective",
+                                                   closeChain);
+
         placeManager.goTo(ozPerspectivePlace);
+
+        verify(closeChain,
+               never()).execute(any(), any());
 
         // verify no side effects (should stay put)
         verify(ozPerspectiveActivity,


### PR DESCRIPTION
Cherry-picked from https://github.com/kiegroup/appformer/pull/389.