### PR TITLE
[7.7.x] Settings fixes

### DIFF
--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/WorkspaceProjectServiceImpl.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/WorkspaceProjectServiceImpl.java
@@ -184,7 +184,7 @@ public class WorkspaceProjectServiceImpl
         String suffix = "";
         while (!this.getAllWorkspaceProjectsByName(organizationalUnit,
                                                    name + suffix).isEmpty()) {
-            suffix = " [" + ++index + "]";
+            suffix = "-" + ++index;
         }
 
         return name + suffix;

--- a/uberfire-project/uberfire-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/WorkspaceProjectServiceImplTest.java
+++ b/uberfire-project/uberfire-project-backend/src/test/java/org/guvnor/common/services/project/backend/server/WorkspaceProjectServiceImplTest.java
@@ -247,14 +247,14 @@ public class WorkspaceProjectServiceImplTest {
             String newName = impl.createFreshProjectName(this.ou1,
                                                          pom.getName());
 
-            assertEquals("repository1 [1]",
+            assertEquals("repository1-1",
                          newName);
         }
 
         {
 
             doReturn(Optional.of(mock(Branch.class))).when(repository2).getDefaultBranch();
-            doReturn("repository1 [1]").when(repository2).getAlias();
+            doReturn("repository1-1").when(repository2).getAlias();
 
             POM pom = new POM("repository1",
                               "description",
@@ -265,7 +265,7 @@ public class WorkspaceProjectServiceImplTest {
             String newName = impl.createFreshProjectName(this.ou1,
                                                          pom.getName());
 
-            assertEquals("repository1 [2]",
+            assertEquals("repository1-2",
                          newName);
         }
     }


### PR DESCRIPTION
AF-1233: Manually added dependencies do not show up in Dependencies
AF-1236: Newly created persistable data objects are not automatically added to the list of Project Persistable Data Objects
AF-1237: Project duplication should use the suffix "-2" instead of " [2]"

Part of an ensemble:
* https://github.com/kiegroup/appformer/pull/393
* https://github.com/kiegroup/kie-wb-common/pull/1862