### PR TITLE
[AF-1238] FileSystem Watch Events should reproduce all the history on BatchMode

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
@@ -78,13 +78,11 @@ public interface JGitFileSystem extends FileSystem,
 
     int getNumberOfCommitsSinceLastGC();
 
-    void addOldHeadsOfPendingDiffs(String branchName,
-                                   NotificationModel notificationModel);
+    void addPostponedWatchEvents(List<WatchEvent<?>> postponedWatchEvents);
 
-    Map<String, NotificationModel> getOldHeadsOfPendingDiffs();
+    List<WatchEvent<?>> getPostponedWatchEvents();
 
-    boolean hasOldHeadsOfPendingDiffs();
+    void clearPostponedWatchEvents();
 
-    void clearOldHeadsOfPendingDiffs();
-
+    boolean hasPostponedEvents();
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxy.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxy.java
@@ -153,25 +153,23 @@ public class JGitFileSystemProxy implements JGitFileSystem {
     }
 
     @Override
-    public void addOldHeadsOfPendingDiffs(String branchName,
-                                          NotificationModel notificationModel) {
-        cachedSupplier.get().addOldHeadsOfPendingDiffs(branchName,
-                                                       notificationModel);
+    public void addPostponedWatchEvents(List<WatchEvent<?>> postponedWatchEvents) {
+        cachedSupplier.get().addPostponedWatchEvents(postponedWatchEvents);
     }
 
     @Override
-    public Map<String, NotificationModel> getOldHeadsOfPendingDiffs() {
-        return cachedSupplier.get().getOldHeadsOfPendingDiffs();
+    public List<WatchEvent<?>> getPostponedWatchEvents() {
+        return cachedSupplier.get().getPostponedWatchEvents();
     }
 
     @Override
-    public boolean hasOldHeadsOfPendingDiffs() {
-        return cachedSupplier.get().hasOldHeadsOfPendingDiffs();
+    public void clearPostponedWatchEvents() {
+        cachedSupplier.get().clearPostponedWatchEvents();
     }
 
     @Override
-    public void clearOldHeadsOfPendingDiffs() {
-        cachedSupplier.get().clearOldHeadsOfPendingDiffs();
+    public boolean hasPostponedEvents() {
+        return cachedSupplier.get().hasPostponedEvents();
     }
 
     @Override


### PR DESCRIPTION
### **Problem**


The story begins [here](https://issues.jboss.org/browse/RHPAM-559
). 
Data modeler code does the following: 

1. create a file with content (A.java);
2. Rename this file;
	2.1 Start a batch();
    2.2 Rename this file A.java -> B.java (one git commit)
    2.3 Change the content of this file in the refactoring process; (one git commit)
    2.4 Close batch 

The issue is that instead of a renaming(a->b) + modify event(b) they are receiving a delete on a and created in b.

@wmedvede did a great job helping me isolating this issue and what happening is that our VFS in batch mode does a amend of each commit and in the end batch process compare the three in 2.1 with the tree in 2.2 and get the 'wrong' events (or at least a compressed vision of the timeline).

The problem is that on git, when I do the same in the CLI:

- git diff HEAD HEAD~1 After 2.2
```
diff --git a/B.java b/A.java
similarity index 100%
rename from B.java
rename to A.java
(END)
```

- git diff HEAD HEAD~1 After 2.3
```
diff --git a/B.java b/B.java
index 47caeb6..cbfee01 100644
--- a/B.java
+++ b/B.java
@@ -1 +1 @@
- fsdljdssklfsjdfsdfjsdl
+ fsdfjsdl
```
When I do a git rebase -i HEAD~2 (like our batch does)
- git diff HEAD HEAD~1
```
diff --git a/A.java b/A.java

new file mode 100644
index 0000000..cbfee01
--- /dev/null
+++ b/A.java
@@ -0,0 +1 @@
+ fsdfjsdl

diff --git a/B.java b/B.java
deleted file mode 100644
index 47caeb6..0000000
--- a/B.java
+++ /dev/null
@@ -1 +0,0 @@
- fsdljdssklfsjdfsdfjsdl
```

See the history? Where is the rename/move? 🔪 😭 

Git does some magic or lost himself when comparing small/new files amended.


### **Proposed Solution**

Instead of comparing the start/end tree in the end of batch process I compared the tree in each commit and stored all the events associated. In our case we will have a rename event + a modify event. Easy isn't? 🤔 

### **Drawbacks**
That is where I'll need help from @manstis, @porcelli and @adrielparedes.

With the current/compressed behaviour, If I do something like:

1. Start a batch();
2. create b
3. modify b
4. modify b
5. modify b
6. modify b
2. End  batch

I would get only one B created event (remember that the commits are amended). Triggered the index/build just once.

With this new reality I would get 5 events. 😭 

This could be even worse:

1. Start a batch();
2. create b
3. modify b
4. modify b
5. modify b
6. modify b
7. delete b
2. End  batch

No event triggered. With the new solution we will have 6 events! 👍 

### ***Conclusion(?)***
I'm almost sure that our VFS should create all the events for all the changes, even if those changes are amended, but we will  need for sure to consolidate the events on [IOServiceIndexedImpl.](https://github.com/kiegroup/appformer/blob/69a58e6f5d699f0b6a4e957c89f7b6f28311ccb4/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java#L324) in short future (or event before merging this PR).

What do you guys think?


