### PR TITLE
[7.7.x] RHPAM-994: Stunner - Error popup appears once importing some processes

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/BaseUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/BaseUploadServlet.java
@@ -67,11 +67,6 @@ public abstract class BaseUploadServlet extends BaseFilteredServlet {
                              final FileItem uploadedItem) throws IOException {
         try {
             ioService.startBatch(path.getFileSystem());
-
-            if (!ioService.exists(path)) {
-                ioService.createFile(path);
-            }
-
             ioService.write(path,
                             IOUtils.toByteArray(uploadedItem.getInputStream()));
         } finally {

--- a/uberfire-server/src/test/java/org/uberfire/server/FileUploadServletTest.java
+++ b/uberfire-server/src/test/java/org/uberfire/server/FileUploadServletTest.java
@@ -282,8 +282,6 @@ public class FileUploadServletTest {
         verify(ioService,
                times(1)).get(eq(expectedURI));
         verify(ioService,
-               times(1)).exists(any(Path.class));
-        verify(ioService,
                times(1)).write(any(Path.class),
                                eq(fileContent.getBytes()));
         verify(ioService,
@@ -334,8 +332,6 @@ public class FileUploadServletTest {
                times(1)).startBatch(eq(fileSystem));
         verify(ioService,
                times(1)).get(eq(expectedURI));
-        verify(ioService,
-               times(1)).exists(any(Path.class));
         verify(ioService,
                times(1)).write(any(Path.class),
                                eq(fileContent.getBytes()));


### PR DESCRIPTION
    - Removes unnecessary ioService.createFile(xxx) invocation for later writing the file content with ioService.write(xxx)