### PR TITLE
upgraded to errai Final version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <version.org.apache.sshd>1.6.0</version.org.apache.sshd>
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
     <version.org.freemarker>2.3.26.jbossorg-1</version.org.freemarker>
-    <version.org.jboss.errai>4.2.2-SNAPSHOT</version.org.jboss.errai>
+    <version.org.jboss.errai>4.2.2.Final</version.org.jboss.errai>
     <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.bower.google-code-prettify>1.0.4</version.org.webjars.bower.google-code-prettify>
     <version.org.webjars.bower.bootstrap-select>1.10.0</version.org.webjars.bower.bootstrap-select>


### PR DESCRIPTION
The requirement now is to use only Final versions of dependencies for community or product.