### PR TITLE
AF-1248: Add profile to enable skipping of gwt compilation of showcases

### DIFF
--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -857,6 +857,21 @@
         </plugins>
       </build>
     </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -651,6 +651,21 @@
         </plugins>
       </build>
     </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/uberfire-showcase/uberfire-client-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-client-webapp/pom.xml
@@ -169,6 +169,21 @@
         </plugins>
       </build>
     </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -389,7 +389,7 @@
           <disableCastChecking>true</disableCastChecking>
           <runTarget>index.html</runTarget>
           <hostedWebapp>src/main/webapp</hostedWebapp>
-          <module>org.uberfire.FastCompiledUberfireShowcase</module>   
+          <module>org.uberfire.FastCompiledUberfireShowcase</module>
           <generateJsInteropExports>true</generateJsInteropExports>
           <compileSourcesArtifacts>
             <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
@@ -492,7 +492,7 @@
                 <include>src/main/webapp/org.uberfire.UberfireShowcase/</include>
                 <include>src/main/webapp/WEB-INF/deploy/</include>
                 <include>src/main/webapp/WEB-INF/classes/</include>
-                <include>src/main/webapp/WEB-INF/lib/</include>                
+                <include>src/main/webapp/WEB-INF/lib/</include>
                 <include>repositories/</include>
                 <include>.errai/</include>
                 <include>.niogit/**</include>
@@ -524,6 +524,21 @@
               <!-- Build all GWT permutations and optimize them -->
               <module>org.uberfire.UberfireShowcase</module>
               <draftCompile>false</draftCompile>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Hello @ederign,

I'm introducing a new profile that will enable to skip gwt compilation of showcases in downstream-pullrequests jobs. In normal build, nothing is skipped. Only when you add -Pno-showcase to mvn command line, the showcases won't be gwt-compiled.

Part of an ensemble:
https://github.com/kiegroup/jbpm-wb/pull/1160
https://github.com/kiegroup/kie-wb-common/pull/1917
https://github.com/kiegroup/drools-wb/pull/877
https://github.com/kiegroup/appformer/pull/401