### PR TITLE
AF-799

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
@@ -43,6 +43,7 @@ import org.guvnor.m2repo.model.JarListPageRow;
 import org.guvnor.m2repo.service.M2RepoService;
 import org.jboss.errai.bus.server.annotations.Service;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.uberfire.paging.PageResponse;
 
 @Service
@@ -56,10 +57,13 @@ public class M2RepoServiceImpl implements M2RepoService,
 
     private GuvnorM2Repository repository;
 
-    public M2RepoServiceImpl() {
-    }
+    public M2RepoServiceImpl() {}
 
     @Inject
+    public M2RepoServiceImpl(GuvnorM2Repository repository) {
+        this(LoggerFactory.getLogger(M2RepoServiceImpl.class), repository);
+    }
+
     public M2RepoServiceImpl(final Logger logger,
                              GuvnorM2Repository repository) {
         this.logger = logger;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderConfiguration.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderConfiguration.java
@@ -75,7 +75,7 @@ public class JGitFileSystemProviderConfiguration {
     public static final String DEFAULT_SSH_ALGORITHM = "RSA";
     public static final String DEFAULT_SSH_CERT_PASSPHRASE = "";
     public static final String DEFAULT_COMMIT_LIMIT_TO_GC = "20";
-    public static final String DEFAULT_JGIT_FILE_SYSTEM_INSTANCES_CACHE = "20";
+    public static final String DEFAULT_JGIT_FILE_SYSTEM_INSTANCES_CACHE = "10000";
     public static final String DEFAULT_GIT_ENV_KEY_MIGRATE_FROM = "migrate-from";
     public static final String DEFAULT_ENABLE_GIT_KETCH = "false";
 

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.backend.server.utils.configuration;
+
+public enum ConfigurationKey {
+
+    COMPILER,
+    SOURCE_VERSION,
+    TARGET_VERSION,
+    FAIL_ON_ERROR,
+
+    MAVEN_COMPILER_PLUGIN_GROUP,
+    MAVEN_COMPILER_PLUGIN_ARTIFACT,
+    MAVEN_COMPILER_PLUGIN_VERSION,
+
+    TAKARI_COMPILER_PLUGIN_GROUP,
+    TAKARI_COMPILER_PLUGIN_ARTIFACT,
+    TAKARI_COMPILER_PLUGIN_VERSION,
+
+    KIE_MAVEN_PLUGINS,
+    KIE_MAVEN_PLUGIN,
+    KIE_TAKARI_PLUGIN,
+
+    KIE_VERSION;
+}

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
@@ -22,7 +22,7 @@ package org.guvnor.common.services.project.backend.server.utils.configuration;
  * <p>
  *  COMPILER (jdt) jdt or javac
  *  SOURCE_VERSION  (1.8) configured with jvm source code version
- *  TARGET_VERSION  (1.8)configured with jvm target version
+ *  TARGET_VERSION  (1.8) configured with jvm target version
  *  <p>
  *  FAIL_ON_ERROR (false) configured with false to continue the build on the correct classes and skip the build of classes with errors
  *  MAVEN_COMPILER_PLUGIN_GROUP (org.apache.maven.plugins) configured with default maven compiler group to disabled it

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
@@ -17,27 +17,27 @@
 package org.guvnor.common.services.project.backend.server.utils.configuration;
 
 /**
- * Keys use to configure the Maven compiler in the kie-wb-common
+ * Keys used to configure the Maven compiler in the kie-wb-common
  *
  * <p>
- *  COMPILER jdt or javac
- *  SOURCE_VERSION  configured with jvm source code version
- *  TARGET_VERSION  configured with jvm target version
+ *  COMPILER (jdt) jdt or javac
+ *  SOURCE_VERSION  (1.8) configured with jvm source code version
+ *  TARGET_VERSION  (1.8)configured with jvm target version
  *  <p>
- *  FAIL_ON_ERROR configured with false to continue the build on the correct classes and skip the build of classes with errors
- *  MAVEN_COMPILER_PLUGIN_GROUP  configured with default maven compiler group to disabled it
- *  MAVEN_COMPILER_PLUGIN_ARTIFACT configured with default maven compiler ArtifactID to disabled it
- *  MAVEN_COMPILER_PLUGIN_VERSION configured with default maven compiler version to disabled it
+ *  FAIL_ON_ERROR (false) configured with false to continue the build on the correct classes and skip the build of classes with errors
+ *  MAVEN_COMPILER_PLUGIN_GROUP (org.apache.maven.plugins) configured with default maven compiler group to disabled it
+ *  MAVEN_COMPILER_PLUGIN_ARTIFACT (maven-compiler-plugin) configured with default maven compiler ArtifactID to disabled it
+ *  MAVEN_COMPILER_PLUGIN_VERSION (3.7.0) configured with default maven compiler version to disabled it
  *  <p>
- *  TAKARI_COMPILER_PLUGIN_GROUP configured with takari GroupID
- *  TAKARI_COMPILER_PLUGIN_ARTIFACT configured with takari ArtifactID
- *  TAKARI_COMPILER_PLUGIN_VERSION configured with a placeholder and set with the correct value in the maven build with takari version
+ *  TAKARI_COMPILER_PLUGIN_GROUP (io.takari.maven.plugins) configured with takari GroupID
+ *  TAKARI_COMPILER_PLUGIN_ARTIFACT (takari-lifecycle-plugin) configured with takari ArtifactID
+ *  TAKARI_COMPILER_PLUGIN_VERSION (${version.io.takari.maven.plugins})configured with a placeholder and set with the correct value in the maven build with takari version
  *  <p>
- *  KIE_MAVEN_PLUGINS configured with the GroupID of kie plugin from the Integration prj
- *  KIE_MAVEN_PLUGIN  configured with the artifactID of the kie-maven-plugin
- *  KIE_TAKARI_PLUGIN configured with the artifactID of the kie-takari-plugin
+ *  KIE_PLUGIN_GROUP (org.kie) configured with the GroupID of kie plugin from the Integration prj
+ *  KIE_MAVEN_PLUGIN_ARTIFACT  (kie-maven-plugin) configured with the artifactID of the kie-maven-plugin
+ *  KIE_TAKARI_PLUGIN_ARTIFACT (kie-maven-plugin) configured with the artifactID of the kie-takari-plugin
  *  <p>
- *  KIE_VERSION configured with a placeholder and set with the correct value in the maven build
+ *  KIE_VERSION (${version.org.kie}) configured with a placeholder and set with the correct value in the maven build
  * */
 public enum ConfigurationKey {
 
@@ -54,9 +54,9 @@ public enum ConfigurationKey {
     TAKARI_COMPILER_PLUGIN_ARTIFACT,
     TAKARI_COMPILER_PLUGIN_VERSION,
 
-    KIE_MAVEN_PLUGINS,
-    KIE_MAVEN_PLUGIN,
-    KIE_TAKARI_PLUGIN,
+    KIE_PLUGIN_GROUP,
+    KIE_MAVEN_PLUGIN_ARTIFACT,
+    KIE_TAKARI_PLUGIN_ARTIFACT,
 
     KIE_VERSION;
 }

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationKey.java
@@ -16,6 +16,29 @@
 
 package org.guvnor.common.services.project.backend.server.utils.configuration;
 
+/**
+ * Keys use to configure the Maven compiler in the kie-wb-common
+ *
+ * <p>
+ *  COMPILER jdt or javac
+ *  SOURCE_VERSION  configured with jvm source code version
+ *  TARGET_VERSION  configured with jvm target version
+ *  <p>
+ *  FAIL_ON_ERROR configured with false to continue the build on the correct classes and skip the build of classes with errors
+ *  MAVEN_COMPILER_PLUGIN_GROUP  configured with default maven compiler group to disabled it
+ *  MAVEN_COMPILER_PLUGIN_ARTIFACT configured with default maven compiler ArtifactID to disabled it
+ *  MAVEN_COMPILER_PLUGIN_VERSION configured with default maven compiler version to disabled it
+ *  <p>
+ *  TAKARI_COMPILER_PLUGIN_GROUP configured with takari GroupID
+ *  TAKARI_COMPILER_PLUGIN_ARTIFACT configured with takari ArtifactID
+ *  TAKARI_COMPILER_PLUGIN_VERSION configured with a placeholder and set with the correct value in the maven build with takari version
+ *  <p>
+ *  KIE_MAVEN_PLUGINS configured with the GroupID of kie plugin from the Integration prj
+ *  KIE_MAVEN_PLUGIN  configured with the artifactID of the kie-maven-plugin
+ *  KIE_TAKARI_PLUGIN configured with the artifactID of the kie-takari-plugin
+ *  <p>
+ *  KIE_VERSION configured with a placeholder and set with the correct value in the maven build
+ * */
 public enum ConfigurationKey {
 
     COMPILER,

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationStrategy.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/ConfigurationStrategy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.common.services.project.backend.server.utils.configuration;
+
+import java.util.Map;
+
+/**
+ * Define the behaviour of a ConfigurationStrategy,
+ * load the configuration and check if it's valid
+ */
+public interface ConfigurationStrategy extends Valid,
+                                               Order {
+
+    Map<ConfigurationKey, String> loadConfiguration();
+}

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/Order.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/Order.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.backend.server.utils.configuration;
+
+/***
+ * Used to order execution of implementations of the same interface in
+ */
+public interface Order {
+
+    /**
+     * Used by the implementor to assign and order of execution when multiple implementations are present
+     * @return
+     */
+    Integer getOrder();
+}

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/Order.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/Order.java
@@ -18,7 +18,7 @@
 package org.guvnor.common.services.project.backend.server.utils.configuration;
 
 /***
- * Used to order execution of implementations of the same interface in
+ * Used to order execution of implementations of the same interface
  */
 public interface Order {
 

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/Valid.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/configuration/Valid.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.backend.server.utils.configuration;
+
+/***
+ * Used to validate a state of an object in different implementations
+ */
+public interface Valid {
+
+    /***
+     * Signals if is in a valid state using an internal algo to check a particular implementations
+     * @return
+     */
+    Boolean isValid();
+}


### PR DESCRIPTION
It contains configuration classes for the compiler and a constructor change in one class to be usable, the code is only on the maven compiler and not the integration of the workbench,
it depends on:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/781

@jhrcek @porcelli @jakubschwan 