### PR TITLE
[AF-1401] Some user actions don't fire post-commit hook: create data object, modify data object

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -2129,6 +2129,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
                 if (isOriginalStateBatch && !fileSystem.isOnBatch()) {
                     fileSystem.setBatchCommitInfo(null);
                     firePostponedBatchEvents(fileSystem);
+                    postCommitHook(fileSystem.getGit().getRepository());
                 }
                 fileSystem.setHadCommitOnBatchState(false);
             } finally {


### PR DESCRIPTION
Tomas and Porcelli.

The post-commit hook was not called in VFS batch mode. This is fixed by this PR.

This doesn't fix the 'create project hook' because there is no hook for 'creating project'. But we do some commits in the project creation, so probably user can track those on this case.

Tomas, in order to test it:

a1 is the project name.

➜  /tmp cd fs-drools-wb/.niogit/a1/a1.git
➜  a1.git git:(master) ls
HEAD     branches config   db.lock  hooks    logs     objects  refs
➜  a1.git git:(master) cd hooks
➜  hooks git:(master) ls
post-commit
➜  hooks git:(master) cat post-commit
date >> /tmp/hookCalledg



To place the hooks automatically on new repos:

-Dorg.uberfire.nio.git.hooks=/tmp/hooks

But only do this with all the system repos already created. You don't want to have hooks on those. :-)


