### PR TITLE
[AF-1432] Remove AF dependencies from Uberfire Core Grids component

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -17,36 +17,6 @@
   <dependencies>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-all</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-client-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-workbench-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3</artifactId>
     </dependency>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/GridColumn.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/GridColumn.java
@@ -16,8 +16,8 @@
 package org.uberfire.ext.wires.core.grids.client.model;
 
 import java.util.List;
+import java.util.function.Consumer;
 
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
@@ -48,7 +48,7 @@ public interface GridColumn<T> {
      */
     default void edit(final GridCell<T> cell,
                       final GridBodyCellRenderContext context,
-                      final Callback<GridCellValue<T>> callback) {
+                      final Consumer<GridCellValue<T>> callback) {
     }
 
     /**
@@ -59,7 +59,7 @@ public interface GridColumn<T> {
      */
     default void edit(final GridCell<T> cell,
                       final GridBodyCellEditContext context,
-                      final Callback<GridCellValue<T>> callback) {
+                      final Consumer<GridCellValue<T>> callback) {
         edit(cell,
              (GridBodyCellRenderContext) context,
              callback);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseBounds.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseBounds.java
@@ -66,7 +66,7 @@ public class BaseBounds implements Bounds {
     @Override
     public void setWidth(double width) {
         if (!(width >= 0)) {
-            throw new IllegalArgumentException("Width must be positive");
+            throw new IllegalStateException("Width must be positive");
         }
         this.width = width;
     }
@@ -79,7 +79,7 @@ public class BaseBounds implements Bounds {
     @Override
     public void setHeight(double height) {
         if (!(height >= 0)) {
-            throw new IllegalArgumentException("Height must be positive");
+            throw new IllegalStateException("Height must be positive");
         }
         this.height = height;
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseBounds.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseBounds.java
@@ -16,7 +16,6 @@
 
 package org.uberfire.ext.wires.core.grids.client.model.impl;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 
 /**
@@ -66,8 +65,9 @@ public class BaseBounds implements Bounds {
 
     @Override
     public void setWidth(double width) {
-        PortablePreconditions.checkCondition("Width must be positive",
-                                             width >= 0);
+        if (!(width >= 0)) {
+            throw new IllegalArgumentException("Width must be positive");
+        }
         this.width = width;
     }
 
@@ -78,8 +78,9 @@ public class BaseBounds implements Bounds {
 
     @Override
     public void setHeight(double height) {
-        PortablePreconditions.checkCondition("Height must be positive",
-                                             height >= 0);
+        if (!(height >= 0)) {
+            throw new IllegalArgumentException("Height must be positive");
+        }
         this.height = height;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridColumn.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridColumn.java
@@ -57,7 +57,7 @@ public class BaseGridColumn<T> implements GridColumn<T> {
                           final double width) {
         Objects.requireNonNull(headerMetaData, "headerMetaData");
         if (!(headerMetaData.size() > 0)) {
-            throw new IllegalArgumentException("headerMetaData has at least one entry");
+            throw new IllegalStateException("headerMetaData has at least one entry");
         }
         Objects.requireNonNull(columnRenderer, "columnRenderer");
         this.headerMetaData.addAll(headerMetaData);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridColumn.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridColumn.java
@@ -17,8 +17,8 @@ package org.uberfire.ext.wires.core.grids.client.model.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
 
@@ -45,10 +45,8 @@ public class BaseGridColumn<T> implements GridColumn<T> {
     public BaseGridColumn(final HeaderMetaData headerMetaData,
                           final GridColumnRenderer<T> columnRenderer,
                           final double width) {
-        PortablePreconditions.checkNotNull("headerMetaData",
-                                           headerMetaData);
-        PortablePreconditions.checkNotNull("columnRenderer",
-                                           columnRenderer);
+        Objects.requireNonNull(headerMetaData, "headerMetaData");
+        Objects.requireNonNull(columnRenderer, "columnRenderer");
         this.headerMetaData.add(headerMetaData);
         this.columnRenderer = columnRenderer;
         this.width = width;
@@ -57,12 +55,11 @@ public class BaseGridColumn<T> implements GridColumn<T> {
     public BaseGridColumn(final List<HeaderMetaData> headerMetaData,
                           final GridColumnRenderer<T> columnRenderer,
                           final double width) {
-        PortablePreconditions.checkNotNull("headerMetaData",
-                                           headerMetaData);
-        PortablePreconditions.checkCondition("headerMetaData has at least one entry",
-                                             headerMetaData.size() > 0);
-        PortablePreconditions.checkNotNull("columnRenderer",
-                                           columnRenderer);
+        Objects.requireNonNull(headerMetaData, "headerMetaData");
+        if (!(headerMetaData.size() > 0)) {
+            throw new IllegalArgumentException("headerMetaData has at least one entry");
+        }
+        Objects.requireNonNull(columnRenderer, "columnRenderer");
         this.headerMetaData.addAll(headerMetaData);
         this.columnRenderer = columnRenderer;
         this.width = width;

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
@@ -15,6 +15,7 @@
  */
 package org.uberfire.ext.wires.core.grids.client.model.impl;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,8 +27,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
-import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -273,8 +272,9 @@ public class BaseGridData implements GridData {
 
     @Override
     public void setHeaderRowCount(final int headerRowCount) {
-        PortablePreconditions.checkCondition("headerRowCount",
-                                             headerRowCount > 0);
+        if (!(headerRowCount > 0)) {
+            throw new IllegalArgumentException("headerRowCount");
+        }
         this.headerRowCount = headerRowCount;
     }
 
@@ -375,7 +375,7 @@ public class BaseGridData implements GridData {
         return doSetCell(rowIndex,
                          columnIndex,
                          (pair) -> {
-                             final Optional<BaseGridCell> cell = Optional.ofNullable((BaseGridCell) getCell(pair.getK1(), pair.getK2()));
+                             final Optional<BaseGridCell> cell = Optional.ofNullable((BaseGridCell) getCell(pair.getKey(), pair.getValue()));
                              final BaseGridCell c = cell.orElse(new BaseGridCell<>(value));
                              c.setValue(value);
                              return c;
@@ -384,7 +384,7 @@ public class BaseGridData implements GridData {
 
     protected Range doSetCell(final int rowIndex,
                               final int columnIndex,
-                              final Function<Pair<Integer, Integer>, GridCell<?>> cellSupplier) {
+                              final Function<Map.Entry<Integer, Integer>, GridCell<?>> cellSupplier) {
         if (rowIndex < 0 || rowIndex > rows.size() - 1) {
             return new Range(rowIndex);
         }
@@ -397,7 +397,7 @@ public class BaseGridData implements GridData {
         //If we're not merged just set the value of a single cell
         if (!isMerged) {
             ((BaseGridRow) rows.get(rowIndex)).setCell(_columnIndex,
-                                                       cellSupplier.apply(Pair.newPair(rowIndex, columnIndex)));
+                                                       cellSupplier.apply(new AbstractMap.SimpleEntry<>(rowIndex, columnIndex)));
             return new Range(rowIndex);
         }
 
@@ -413,7 +413,7 @@ public class BaseGridData implements GridData {
         for (int i = minRowIndex; i <= maxRowIndex; i++) {
             final GridRow row = rows.get(i);
             ((BaseGridRow) row).setCell(_columnIndex,
-                                        cellSupplier.apply(Pair.newPair(i, columnIndex)));
+                                        cellSupplier.apply(new AbstractMap.SimpleEntry<>(i, columnIndex)));
         }
 
         indexManager.onSetCell(range,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
@@ -273,7 +273,7 @@ public class BaseGridData implements GridData {
     @Override
     public void setHeaderRowCount(final int headerRowCount) {
         if (!(headerRowCount > 0)) {
-            throw new IllegalArgumentException("headerRowCount");
+            throw new IllegalStateException("headerRowCount");
         }
         this.headerRowCount = headerRowCount;
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseHeaderMetaData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseHeaderMetaData.java
@@ -15,7 +15,8 @@
  */
 package org.uberfire.ext.wires.core.grids.client.model.impl;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
+import java.util.Objects;
+
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 
 public class BaseHeaderMetaData implements GridColumn.HeaderMetaData {
@@ -32,10 +33,8 @@ public class BaseHeaderMetaData implements GridColumn.HeaderMetaData {
 
     public BaseHeaderMetaData(final String columnTitle,
                               final String columnGroup) {
-        this.columnTitle = PortablePreconditions.checkNotNull("columnTitle",
-                                                              columnTitle);
-        this.columnGroup = PortablePreconditions.checkNotNull("columnGroup",
-                                                              columnGroup);
+        this.columnTitle = Objects.requireNonNull(columnTitle, "columnTitle");
+        this.columnGroup = Objects.requireNonNull(columnGroup, "columnGroup");
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/DOMElementFactory.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/DOMElementFactory.java
@@ -15,7 +15,8 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.dom;
 
-import org.uberfire.client.callbacks.Callback;
+import java.util.function.Consumer;
+
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
@@ -53,6 +54,6 @@ public interface DOMElementFactory<W, E> extends HasDOMElementResources {
      * @param onDisplay A callback that is invoked after the cell has been attached to the DOM and displayed.
      */
     void attachDomElement(final GridBodyCellRenderContext context,
-                          final Callback<E> onCreation,
-                          final Callback<E> onDisplay);
+                          final Consumer<E> onCreation,
+                          final Consumer<E> onDisplay);
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/multiple/impl/BaseDOMElementFactory.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/multiple/impl/BaseDOMElementFactory.java
@@ -17,9 +17,9 @@ package org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import com.google.gwt.user.client.ui.Widget;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.MultipleDOMElementFactory;
@@ -52,8 +52,8 @@ public abstract class BaseDOMElementFactory<T, W extends Widget, E extends BaseD
 
     @Override
     public void attachDomElement(final GridBodyCellRenderContext context,
-                                 final Callback<E> onCreation,
-                                 final Callback<E> onDisplay) {
+                                 final Consumer<E> onCreation,
+                                 final Consumer<E> onDisplay) {
         E domElement;
         if (consumed + 1 > domElements.size()) {
             domElement = createDomElement(gridLayer,
@@ -67,10 +67,10 @@ public abstract class BaseDOMElementFactory<T, W extends Widget, E extends BaseD
 
         domElement.setContext(context);
         domElement.initialise(context);
-        onCreation.callback(domElement);
+        onCreation.accept(domElement);
 
         domElement.attach();
-        onDisplay.callback(domElement);
+        onDisplay.accept(domElement);
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/single/impl/BaseSingletonDOMElementFactory.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/single/impl/BaseSingletonDOMElementFactory.java
@@ -15,8 +15,9 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.dom.single.impl;
 
+import java.util.function.Consumer;
+
 import com.google.gwt.user.client.ui.Widget;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.SingletonDOMElementFactory;
@@ -53,8 +54,8 @@ public abstract class BaseSingletonDOMElementFactory<T, W extends Widget, E exte
 
     @Override
     public void attachDomElement(final GridBodyCellRenderContext context,
-                                 final Callback<E> onCreation,
-                                 final Callback<E> onDisplay) {
+                                 final Consumer<E> onCreation,
+                                 final Consumer<E> onDisplay) {
         gridLayer.batch(new GridLayerRedrawManager.PrioritizedCommand(Integer.MAX_VALUE) {
             @Override
             public void execute() {
@@ -63,10 +64,10 @@ public abstract class BaseSingletonDOMElementFactory<T, W extends Widget, E exte
                                                       context);
                 domElement.setContext(context);
                 domElement.initialise(context);
-                onCreation.callback(domElement);
+                onCreation.accept(domElement);
 
                 domElement.attach();
-                onDisplay.callback(domElement);
+                onDisplay.accept(domElement);
             }
         });
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/edit/EditorPopup.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/edit/EditorPopup.java
@@ -15,6 +15,8 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.edit;
 
+import java.util.function.Consumer;
+
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
@@ -27,7 +29,6 @@ import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.gwtbootstrap3.client.ui.constants.IconType;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 
@@ -40,7 +41,7 @@ public class EditorPopup extends Modal {
     private final ModalBody modalBody = new ModalBody();
 
     private GridCellValue<String> value;
-    private Callback<GridCellValue<String>> callback = null;
+    private Consumer<GridCellValue<String>> callback = null;
 
     public EditorPopup() {
         setTitle("Edit");
@@ -89,7 +90,7 @@ public class EditorPopup extends Modal {
      * @param callback Callback to invoke when the popup is "OK'ed".
      */
     public void edit(final GridCellValue<String> value,
-                     final Callback<GridCellValue<String>> callback) {
+                     final Consumer<GridCellValue<String>> callback) {
         this.value = value;
         this.callback = callback;
         textBox.setText(value == null ? "" : value.getValue());
@@ -102,7 +103,7 @@ public class EditorPopup extends Modal {
 
     private void commit() {
         if (callback != null) {
-            callback.callback(new BaseGridCellValue<String>(textBox.getText()));
+            callback.accept(new BaseGridCellValue<String>(textBox.getText()));
         }
         hide();
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/BooleanDOMElementColumn.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/BooleanDOMElementColumn.java
@@ -17,8 +17,8 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.columns;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -70,7 +70,7 @@ public class BooleanDOMElementColumn extends BaseGridColumn<Boolean> implements 
     @Override
     public void edit(final GridCell<Boolean> cell,
                      final GridBodyCellRenderContext context,
-                     final Callback<GridCellValue<Boolean>> callback) {
-        callback.callback(new BaseGridCellValue<>(!cell.getValue().getValue()));
+                     final Consumer<GridCellValue<Boolean>> callback) {
+        callback.accept(new BaseGridCellValue<>(!cell.getValue().getValue()));
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/ListBoxDOMElementSingletonColumn.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/ListBoxDOMElementSingletonColumn.java
@@ -17,15 +17,14 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.columns;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import com.google.gwt.user.client.ui.ListBox;
-import org.kie.soup.commons.validation.PortablePreconditions;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
-import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.ListBoxDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDOMElementResource;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.impl.ListBoxSingletonDOMElementFactory;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.single.impl.ListBoxColumnDOMElementSingletonRenderer;
@@ -50,37 +49,28 @@ public class ListBoxDOMElementSingletonColumn extends BaseGridColumn<String> imp
         super(headerMetaData,
               new ListBoxColumnDOMElementSingletonRenderer(factory),
               width);
-        this.factory = PortablePreconditions.checkNotNull("factory",
-                                                          factory);
+        this.factory = Objects.requireNonNull(factory, "factory");
     }
 
     @Override
     public void edit(final GridCell<String> cell,
                      final GridBodyCellRenderContext context,
-                     final Callback<GridCellValue<String>> callback) {
+                     final Consumer<GridCellValue<String>> callback) {
         factory.attachDomElement(context,
-                                 new Callback<ListBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final ListBoxDOMElement e) {
-                                         final ListBox widget = e.getWidget();
-                                         widget.addItem("one");
-                                         widget.addItem("two");
-                                         if (cell != null && cell.getValue() != null) {
-                                             for (int i = 0; i < widget.getItemCount(); i++) {
-                                                 if (widget.getItemText(i).equals(cell.getValue().getValue())) {
-                                                     widget.setSelectedIndex(i);
-                                                     break;
-                                                 }
+                                 e -> {
+                                     final ListBox widget = e.getWidget();
+                                     widget.addItem("one");
+                                     widget.addItem("two");
+                                     if (cell != null && cell.getValue() != null) {
+                                         for (int i = 0; i < widget.getItemCount(); i++) {
+                                             if (widget.getItemText(i).equals(cell.getValue().getValue())) {
+                                                 widget.setSelectedIndex(i);
+                                                 break;
                                              }
                                          }
                                      }
                                  },
-                                 new Callback<ListBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final ListBoxDOMElement e) {
-                                         e.getWidget().setFocus(true);
-                                     }
-                                 });
+                                 e -> e.getWidget().setFocus(true));
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/StringDOMElementSingletonColumn.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/StringDOMElementSingletonColumn.java
@@ -17,9 +17,9 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.columns;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -27,7 +27,6 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
-import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.TextBoxDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDOMElementResource;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.impl.TextBoxSingletonDOMElementFactory;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.single.impl.StringColumnDOMElementSingletonRenderer;
@@ -52,27 +51,16 @@ public class StringDOMElementSingletonColumn extends BaseGridColumn<String> impl
         super(headerMetaData,
               new StringColumnDOMElementSingletonRenderer(factory),
               width);
-        this.factory = PortablePreconditions.checkNotNull("factory",
-                                                          factory);
+        this.factory = Objects.requireNonNull(factory, "factory");
     }
 
     @Override
     public void edit(final GridCell<String> cell,
                      final GridBodyCellRenderContext context,
-                     final Callback<GridCellValue<String>> callback) {
+                     final Consumer<GridCellValue<String>> callback) {
         factory.attachDomElement(context,
-                                 new Callback<TextBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final TextBoxDOMElement e) {
-                                         e.getWidget().setValue(assertCell(cell).getValue().getValue());
-                                     }
-                                 },
-                                 new Callback<TextBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final TextBoxDOMElement e) {
-                                         e.getWidget().setFocus(true);
-                                     }
-                                 });
+                                 e -> e.getWidget().setValue(assertCell(cell).getValue().getValue()),
+                                 e -> e.getWidget().setFocus(true));
     }
 
     private GridCell<String> assertCell(final GridCell<String> cell) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/StringPopupColumn.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/StringPopupColumn.java
@@ -16,8 +16,8 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.columns;
 
 import java.util.List;
+import java.util.function.Consumer;
 
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -51,7 +51,7 @@ public class StringPopupColumn extends BaseGridColumn<String> {
     @Override
     public void edit(final GridCell<String> cell,
                      final GridBodyCellRenderContext context,
-                     final Callback<GridCellValue<String>> callback) {
+                     final Consumer<GridCellValue<String>> callback) {
         editor.edit(assertCell(cell).getValue(),
                     callback);
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
@@ -15,10 +15,12 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.grid.impl;
 
+import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.stream.Stream;
 
@@ -32,7 +34,6 @@ import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.Node;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Point2D;
-import org.uberfire.commons.data.Pair;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyRenderContext;
@@ -62,7 +63,7 @@ public class BaseGridWidget extends Group implements GridWidget {
     protected final SelectionsTransformer bodyTransformer;
     protected final SelectionsTransformer floatingColumnsTransformer;
     protected final BaseGridRendererHelper rendererHelper;
-    protected final Queue<Pair<Group, List<GridRenderer.RendererCommand>>> renderQueue = new ArrayDeque<>();
+    protected final Queue<Map.Entry<Group, List<GridRenderer.RendererCommand>>> renderQueue = new ArrayDeque<>();
 
     //These are final as a reference is held by the ISelectionsTransformers
     protected final List<GridColumn<?>> allColumns = new ArrayList<>();
@@ -530,16 +531,16 @@ public class BaseGridWidget extends Group implements GridWidget {
 
     protected void addCommandsToRenderQueue(final Group parent,
                                             final List<GridRenderer.RendererCommand> commands) {
-        renderQueue.add(new Pair<>(parent, commands));
+        renderQueue.add(new AbstractMap.SimpleEntry<>(parent, commands));
     }
 
     protected void executeRenderQueueCommands(final boolean isSelectionLayer) {
         renderQueue.stream()
-                .forEach(p -> p.getK2()
+                .forEach(p -> p.getValue()
                         .forEach(c -> c.execute(new GridRenderer.GridRendererContext() {
                             @Override
                             public Group getGroup() {
-                                return p.getK1();
+                                return p.getKey();
                             }
 
                             @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandler.java
@@ -16,11 +16,11 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.impl;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDOMElementResource;
@@ -47,14 +47,12 @@ public class BaseGridWidgetKeyboardHandler implements KeyDownHandler {
     private Set<KeyboardOperation> operations = new HashSet<>();
 
     public BaseGridWidgetKeyboardHandler(final GridLayer gridLayer) {
-        this.gridLayer = PortablePreconditions.checkNotNull("gridLayer",
-                                                            gridLayer);
+        this.gridLayer = Objects.requireNonNull(gridLayer, "gridLayer");
     }
 
     public void addOperation(final KeyboardOperation... operations) {
         for (KeyboardOperation operation : operations) {
-            this.operations.add(PortablePreconditions.checkNotNull("operation",
-                                                                   operation));
+            this.operations.add(Objects.requireNonNull(operation, "operation"));
         }
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
@@ -17,11 +17,11 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.impl;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.client.core.types.Transform;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
@@ -35,8 +35,7 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
     protected GridLayer gridLayer;
 
     public BaseKeyboardOperation(final GridLayer gridLayer) {
-        this.gridLayer = PortablePreconditions.checkNotNull("gridLayer",
-                                                            gridLayer);
+        this.gridLayer = Objects.requireNonNull(gridLayer, "gridLayer");
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/multiple/impl/BaseGridColumnMultipleDOMElementRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/multiple/impl/BaseGridColumnMultipleDOMElementRenderer.java
@@ -15,8 +15,9 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.multiple.impl;
 
+import java.util.Objects;
+
 import com.google.gwt.user.client.ui.Widget;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.multiple.MultipleDOMElementFactory;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.BaseGridColumnRenderer;
@@ -27,8 +28,7 @@ public abstract class BaseGridColumnMultipleDOMElementRenderer<T, W extends Widg
     protected final MultipleDOMElementFactory<W, E> factory;
 
     public BaseGridColumnMultipleDOMElementRenderer(final MultipleDOMElementFactory<W, E> factory) {
-        this.factory = PortablePreconditions.checkNotNull("factory",
-                                                          factory);
+        this.factory = Objects.requireNonNull(factory, "factory");
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/multiple/impl/BooleanColumnDOMElementRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/multiple/impl/BooleanColumnDOMElementRenderer.java
@@ -17,7 +17,6 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.m
 
 import com.ait.lienzo.client.core.shape.Group;
 import org.gwtbootstrap3.client.ui.CheckBox;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.CheckBoxDOMElement;
@@ -37,18 +36,8 @@ public class BooleanColumnDOMElementRenderer extends BaseGridColumnMultipleDOMEl
         }
         final Group g = new Group();
         factory.attachDomElement(context,
-                                 new Callback<CheckBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final CheckBoxDOMElement e) {
-                                         e.getWidget().setValue(cell.getValue().getValue());
-                                     }
-                                 },
-                                 new Callback<CheckBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final CheckBoxDOMElement result) {
-                                         //Do nothing
-                                     }
-                                 });
+                                 e -> e.getWidget().setValue(cell.getValue().getValue()),
+                                 result -> {});
         return g;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/multiple/impl/StringColumnDOMElementRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/multiple/impl/StringColumnDOMElementRenderer.java
@@ -17,7 +17,6 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.m
 
 import com.ait.lienzo.client.core.shape.Group;
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.TextBoxDOMElement;
@@ -37,18 +36,8 @@ public class StringColumnDOMElementRenderer extends BaseGridColumnMultipleDOMEle
         }
         final Group g = new Group();
         factory.attachDomElement(context,
-                                 new Callback<TextBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final TextBoxDOMElement e) {
-                                         e.getWidget().setValue(cell.getValue().getValue());
-                                     }
-                                 },
-                                 new Callback<TextBoxDOMElement>() {
-                                     @Override
-                                     public void callback(final TextBoxDOMElement e) {
-                                         //Do nothing
-                                     }
-                                 });
+                                 e -> e.getWidget().setValue(cell.getValue().getValue()),
+                                 e -> { });
         return g;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/single/impl/BaseGridColumnSingletonDOMElementRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/single/impl/BaseGridColumnSingletonDOMElementRenderer.java
@@ -15,8 +15,9 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.single.impl;
 
+import java.util.Objects;
+
 import com.google.gwt.user.client.ui.Widget;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.impl.BaseDOMElement;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.SingletonDOMElementFactory;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl.BaseGridColumnRenderer;
@@ -27,8 +28,7 @@ public abstract class BaseGridColumnSingletonDOMElementRenderer<T, W extends Wid
     protected final SingletonDOMElementFactory<W, E> factory;
 
     public BaseGridColumnSingletonDOMElementRenderer(final SingletonDOMElementFactory<W, E> factory) {
-        this.factory = PortablePreconditions.checkNotNull("factory",
-                                                          factory);
+        this.factory = Objects.requireNonNull(factory, "factory");
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/GridRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/GridRenderer.java
@@ -26,7 +26,6 @@ import org.uberfire.ext.wires.core.grids.client.widget.context.GridBoundaryRende
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridHeaderRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.GridRendererTheme;
-import org.uberfire.mvp.ParameterizedCommand;
 
 /**
  * Definition of a render for the pluggable rendering mechanism.
@@ -43,7 +42,8 @@ public interface GridRenderer {
     /**
      * Generic command to render a component of the grid
      */
-    interface RendererCommand extends ParameterizedCommand<GridRendererContext> {
+    interface RendererCommand {
+        void execute(GridRendererContext parameter);
 
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
@@ -17,6 +17,7 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.imp
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 import com.ait.lienzo.client.core.shape.Group;
@@ -27,7 +28,6 @@ import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.client.core.types.Transform;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyColumnRenderContext;
@@ -80,8 +80,7 @@ public class BaseGridRenderer implements GridRenderer {
 
     @Override
     public void setTheme(final GridRendererTheme theme) {
-        this.theme = PortablePreconditions.checkNotNull("theme",
-                                                        theme);
+        this.theme = Objects.requireNonNull(theme, "theme");
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
@@ -18,8 +18,8 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.imp
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
@@ -36,8 +36,7 @@ public class BaseGridRendererHelper {
     private final GridWidget view;
 
     public BaseGridRendererHelper(final GridWidget view) {
-        this.view = PortablePreconditions.checkNotNull("view",
-                                                       view);
+        this.view = Objects.requireNonNull(view, "view");
     }
 
     /**

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/DefaultSelectionsTransformer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/DefaultSelectionsTransformer.java
@@ -21,9 +21,9 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.util.ColumnIndexUtilities;
@@ -39,10 +39,8 @@ public class DefaultSelectionsTransformer implements SelectionsTransformer {
 
     public DefaultSelectionsTransformer(final GridData model,
                                         final List<GridColumn<?>> columns) {
-        this.model = PortablePreconditions.checkNotNull("model",
-                                                        model);
-        this.columns = PortablePreconditions.checkNotNull("columns",
-                                                          columns);
+        this.model = Objects.requireNonNull(model, "model");
+        this.columns = Objects.requireNonNull(columns, "columns");
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManager.java
@@ -17,12 +17,11 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.types.Point2D;
-import org.kie.soup.commons.validation.PortablePreconditions;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -46,10 +45,8 @@ public class BaseCellSelectionManager implements CellSelectionManager {
     private final GridData gridModel;
 
     public BaseCellSelectionManager(final GridWidget gridWidget) {
-        this.gridWidget = PortablePreconditions.checkNotNull("gridWidget",
-                                                             gridWidget);
-        this.gridModel = PortablePreconditions.checkNotNull("gridModel",
-                                                            gridWidget.getModel());
+        this.gridWidget = Objects.requireNonNull(gridWidget, "gridWidget");
+        this.gridModel = Objects.requireNonNull(gridWidget.getModel(), "gridModel");
     }
 
     @Override
@@ -435,15 +432,11 @@ public class BaseCellSelectionManager implements CellSelectionManager {
 
         column.edit(cell,
                     context,
-                    new Callback<GridCellValue<?>>() {
-
-                        @Override
-                        public void callback(final GridCellValue<?> value) {
+                    value-> {
                             gridModel.setCellValue(uiRowIndex,
                                                    uiColumnIndex,
-                                                   value);
+                                                   (GridCellValue<?>) value);
                             gridWidget.getLayer().batch();
-                        }
                     });
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManager.java
@@ -17,12 +17,12 @@ package org.uberfire.ext.wires.core.grids.client.widget.layer.impl;
 
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
 import com.google.gwt.animation.client.AnimationScheduler;
 import com.google.gwt.user.client.Command;
-import org.kie.soup.commons.validation.PortablePreconditions;
 
 public class GridLayerRedrawManager {
 
@@ -64,8 +64,7 @@ public class GridLayerRedrawManager {
     }
 
     public void schedule(final PrioritizedCommand command) {
-        PortablePreconditions.checkNotNull("command",
-                                           command);
+        Objects.requireNonNull(command, "command");
         if (!commands.contains(command)) {
             commands.add(command);
             kick();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/DefaultPinnedModeManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/DefaultPinnedModeManager.java
@@ -18,6 +18,7 @@ package org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import com.ait.lienzo.client.core.mediator.IMediator;
@@ -26,7 +27,6 @@ import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Transform;
 import com.google.gwt.user.client.Command;
-import org.kie.soup.commons.validation.PortablePreconditions;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.animation.GridWidgetEnterPinnedModeAnimation;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.animation.GridWidgetExitPinnedModeAnimation;
@@ -50,8 +50,7 @@ public class DefaultPinnedModeManager implements GridPinnedModeManager {
     public DefaultPinnedModeManager(final GridLayer gridLayer) {
         this.onEnterPinnedModeCommands = new ArrayList<>();
         this.onExitPinnedModeCommands = new ArrayList<>();
-        this.gridLayer = PortablePreconditions.checkNotNull("gridLayer",
-                                                            gridLayer);
+        this.gridLayer = Objects.requireNonNull(gridLayer, "gridLayer");
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridTest.java
@@ -15,8 +15,9 @@
  */
 package org.uberfire.ext.wires.core.grids.client.model.impl;
 
+import java.util.function.Consumer;
+
 import com.ait.lienzo.client.core.shape.Group;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -151,7 +152,7 @@ public abstract class BaseGridTest {
         @Override
         public void edit(final GridCell<T> cell,
                          final GridBodyCellRenderContext context,
-                         final Callback<GridCellValue<T>> callback) {
+                         final Consumer<GridCellValue<T>> callback) {
             //Do nothing
         }
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.ait.lienzo.client.core.event.INodeXYEvent;
 import com.ait.lienzo.client.core.event.NodeMouseMoveEvent;
@@ -48,7 +50,6 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.Gr
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
-import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -293,7 +294,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     @Test
     public void findMovableGridWhenOverDragHandleWhenIsPinned() {
         doFindMovableGridWhenOverDragHandle(true,
-                                            () -> {
+                                            (nothing) -> {
                                                 verify(state,
                                                        never()).setActiveGridWidget(any(GridWidget.class));
                                                 verify(state,
@@ -307,7 +308,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     @Test
     public void findMovableGridWhenOverDragHandleWhenNotPinned() {
         doFindMovableGridWhenOverDragHandle(false,
-                                            () -> {
+                                            (nothing) -> {
                                                 verify(state).setActiveGridWidget(eq(gridWidget));
                                                 verify(state).setOperation(eq(GridWidgetHandlersOperation.GRID_MOVE_PENDING));
                                                 assertEquals(gridWidget,
@@ -318,7 +319,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     }
 
     private void doFindMovableGridWhenOverDragHandle(final boolean isPinned,
-                                                     final Command assertion) {
+                                                     final Consumer<Object> assertion) {
         state.setOperation(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
         when(gridWidget.onDragHandle(any(INodeXYEvent.class))).thenReturn(true);
@@ -336,7 +337,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
         verify(handler,
                times(1)).findGridColumn(eq(event));
 
-        assertion.execute();
+        assertion.accept(null);
     }
 
     @Test

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 import com.ait.lienzo.client.core.event.INodeXYEvent;
 import com.ait.lienzo.client.core.event.NodeMouseMoveEvent;
@@ -294,7 +292,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     @Test
     public void findMovableGridWhenOverDragHandleWhenIsPinned() {
         doFindMovableGridWhenOverDragHandle(true,
-                                            (nothing) -> {
+                                            () -> {
                                                 verify(state,
                                                        never()).setActiveGridWidget(any(GridWidget.class));
                                                 verify(state,
@@ -308,7 +306,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     @Test
     public void findMovableGridWhenOverDragHandleWhenNotPinned() {
         doFindMovableGridWhenOverDragHandle(false,
-                                            (nothing) -> {
+                                            () -> {
                                                 verify(state).setActiveGridWidget(eq(gridWidget));
                                                 verify(state).setOperation(eq(GridWidgetHandlersOperation.GRID_MOVE_PENDING));
                                                 assertEquals(gridWidget,
@@ -319,7 +317,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     }
 
     private void doFindMovableGridWhenOverDragHandle(final boolean isPinned,
-                                                     final Consumer<Object> assertion) {
+                                                     final Runnable assertion) {
         state.setOperation(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
         when(gridWidget.onDragHandle(any(INodeXYEvent.class))).thenReturn(true);
@@ -337,7 +335,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
         verify(handler,
                times(1)).findGridColumn(eq(event));
 
-        assertion.accept(null);
+        assertion.run();
     }
 
     @Test

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/BooleanDOMElementColumnTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/columns/BooleanDOMElementColumnTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.ext.wires.core.grids.client.widget.grid.columns;
 
+import java.util.function.Consumer;
+
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +25,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridCellValue;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -50,7 +51,7 @@ public class BooleanDOMElementColumnTest {
     private GridBodyCellRenderContext context;
 
     @Mock
-    private Callback<GridCellValue<Boolean>> callback;
+    private Consumer<GridCellValue<Boolean>> callback;
 
     @Captor
     private ArgumentCaptor<BaseGridCellValue<Boolean>> callbackArgumentCaptor;
@@ -73,7 +74,7 @@ public class BooleanDOMElementColumnTest {
                     callback);
 
         verify(callback,
-               times(1)).callback(callbackArgumentCaptor.capture());
+               times(1)).accept(callbackArgumentCaptor.capture());
 
         final BaseGridCellValue<Boolean> callbackArgument = callbackArgumentCaptor.getValue();
         assertFalse(callbackArgument.getValue());
@@ -88,7 +89,7 @@ public class BooleanDOMElementColumnTest {
                     callback);
 
         verify(callback,
-               times(1)).callback(callbackArgumentCaptor.capture());
+               times(1)).accept(callbackArgumentCaptor.capture());
 
         final BaseGridCellValue<Boolean> callbackArgument = callbackArgumentCaptor.getValue();
         assertTrue(callbackArgument.getValue());

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManagerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManagerTest.java
@@ -17,6 +17,7 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.Viewport;
@@ -28,7 +29,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
@@ -505,20 +505,20 @@ public class BaseCellSelectionManagerTest {
         verify(col1,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellRenderContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
         verify(col2,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellRenderContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
 
         verify(col1,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellEditContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
         verify(col2,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellEditContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
     }
 
     @Test
@@ -533,11 +533,11 @@ public class BaseCellSelectionManagerTest {
         verify(col2,
                times(1)).edit(any(GridCell.class),
                               contextArgumentCaptor.capture(),
-                              any(Callback.class));
+                              any(Consumer.class));
         verify(col2,
                times(1)).edit(any(GridCell.class),
                               editContextArgumentCaptor.capture(),
-                              any(Callback.class));
+                              any(Consumer.class));
 
         final GridBodyCellRenderContext context = contextArgumentCaptor.getValue();
         assertEquals(0,
@@ -559,20 +559,20 @@ public class BaseCellSelectionManagerTest {
         verify(col1,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellRenderContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
         verify(col2,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellRenderContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
 
         verify(col1,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellEditContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
         verify(col2,
                never()).edit(any(GridCell.class),
                              any(GridBodyCellEditContext.class),
-                             any(Callback.class));
+                             any(Consumer.class));
     }
 
     @Test
@@ -598,11 +598,11 @@ public class BaseCellSelectionManagerTest {
         verify(col2,
                times(1)).edit(any(GridCell.class),
                               contextArgumentCaptor.capture(),
-                              any(Callback.class));
+                              any(Consumer.class));
         verify(col2,
                times(1)).edit(any(GridCell.class),
                               editContextArgumentCaptor.capture(),
-                              any(Callback.class));
+                              any(Consumer.class));
 
         final GridBodyCellRenderContext context = contextArgumentCaptor.getValue();
         assertEquals(0,


### PR DESCRIPTION
Removed all UF/WB related dependencies to Uberfire Core Grids component to become a pure Lienzo/Gwt component and maybe moved to an independent Lienzo-Grid component in the future.

- Removed `PortablePreconditions` usages
- Changed `Callback` to `Consumer`
- Changed `Command` to `Runnable`
- Changed `Pair` to `Map.Entry`

**NOTE:** I used `Objects` methods to replace `PortablePreconditions`. This changes the type of exception fired in case of null-check error: before was an `IllegalStateException` and now a `NullPointerException`. If needed I can implement an alternative to restore the same behaviour but I would like to use a built-in mechanism instead of a custom one.

@manstis @mdproctor @romartin @jsoltes 

PRs related:
https://github.com/kiegroup/appformer/pull/425
https://github.com/kiegroup/drools-wb/pull/902
https://github.com/kiegroup/kie-wb-common/pull/2009