### PR TITLE
[DO NOT MERGE] Prevent NPE in LuceneIndexProvider

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/provider/LuceneIndexProvider.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/provider/LuceneIndexProvider.java
@@ -18,6 +18,7 @@ package org.uberfire.ext.metadata.backend.lucene.provider;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -105,14 +106,16 @@ public class LuceneIndexProvider implements IndexProvider {
     public void delete(String index,
                        String id) {
         final LuceneIndex luceneIndex = (LuceneIndex) indexManager.get(new KClusterImpl(index));
-        luceneIndex.deleteIfExists(id);
-        luceneIndex.commit();
+        if (luceneIndex != null) {
+            luceneIndex.deleteIfExists(id);
+            luceneIndex.commit();
+        }
     }
 
     @Override
     public List<KObject> findById(String index,
                                   String id) {
-        List<String> indices = Arrays.asList(index);
+        List<String> indices = Collections.singletonList(index);
         ScoreDoc[] docs = this.findRawByQuery(indices,
                                               new TermQuery(new Term("id",
                                                                      id)),


### PR DESCRIPTION
@adrielparedes could you check when you have a minute?

This is companion PR for https://github.com/kiegroup/kie-wb-distributions/pull/778

This is easy to reproduce NPE that occurs in kie-wb rest test very often as commented https://github.com/kiegroup/kie-wb-distributions/pull/778#issuecomment-408360618 - see simple steps to reproduce in that comment.
```
[id=org.kie.workbench.common.screens.datamodeller.backend.server.indexing.JavaFileIndexer]: java.lang.NullPointerException
at org.uberfire.ext.metadata.backend.lucene.provider.LuceneIndexProvider.delete(LuceneIndexProvider.java:108)
at org.uberfire.ext.metadata.io.index.MetadataIndexEngine.doDelete(MetadataIndexEngine.java:195)
at org.uberfire.ext.metadata.io.index.MetadataIndexEngine.doAction(MetadataIndexEngine.java:134)
at java.util.ArrayList.forEach(ArrayList.java:1257)
at org.uberfire.ext.metadata.io.index.MetadataIndexEngine.doCommit(MetadataIndexEngine.java:231)
at org.uberfire.ext.metadata.io.index.MetadataIndexEngine.commit(MetadataIndexEngine.java:220)
at org.uberfire.ext.metadata.io.IndexerDispatcher$IndexerJob.get(IndexerDispatcher.java:189)
at org.uberfire.ext.metadata.io.IndexerDispatcher$IndexerJob.get(IndexerDispatcher.java:159)
at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```