### PR TITLE
AF-923: cache invalidation on session expire/logout for security related info

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/CleanupSecurityCacheSessionListener.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/CleanupSecurityCacheSessionListener.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.security.server;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebListener;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.security.authz.AuthorizationManager;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Releases locks on session end and clear authz related caches.
+ */
+@WebListener
+public class CleanupSecurityCacheSessionListener implements HttpSessionListener {
+
+    private final Collection<AuthorizationManager> authorizationManagers = new ArrayList<>();
+
+    public CleanupSecurityCacheSessionListener() {
+        //empty needed for weld
+    }
+
+    @Inject
+    public CleanupSecurityCacheSessionListener(final Instance<AuthorizationManager> authorizationManagers) {
+        for (AuthorizationManager authorizationManager : authorizationManagers) {
+            this.authorizationManagers.add(authorizationManager);
+        }
+    }
+
+    @Override
+    public void sessionCreated(HttpSessionEvent se) {
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se) {
+        if (authorizationManagers.isEmpty()) {
+            return;
+        }
+        final User currentUser = (User) se.getSession().getAttribute(ServletSecurityAuthenticationService.USER_SESSION_ATTR_NAME);
+        if (currentUser != null && !currentUser.equals(User.ANONYMOUS)) {
+            for (AuthorizationManager authorizationManager : authorizationManagers) {
+                authorizationManager.invalidate(currentUser);
+            }
+        }
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/CleanupSecurityCacheSessionListener.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/CleanupSecurityCacheSessionListener.java
@@ -17,19 +17,18 @@
 
 package org.uberfire.ext.security.server;
 
+import org.jboss.errai.security.shared.api.identity.User;
+import org.uberfire.security.authz.AuthorizationManager;
+
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.servlet.annotation.WebListener;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
-
-import org.jboss.errai.security.shared.api.identity.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.uberfire.security.authz.AuthorizationManager;
-
 import java.util.ArrayList;
 import java.util.Collection;
+
+import static org.jboss.errai.security.shared.api.identity.User.ANONYMOUS;
 
 /**
  * Releases locks on session end and clear authz related caches.
@@ -60,7 +59,7 @@ public class CleanupSecurityCacheSessionListener implements HttpSessionListener 
             return;
         }
         final User currentUser = (User) se.getSession().getAttribute(ServletSecurityAuthenticationService.USER_SESSION_ATTR_NAME);
-        if (currentUser != null && !currentUser.equals(User.ANONYMOUS)) {
+        if (!ANONYMOUS.equals(currentUser)) {
             for (AuthorizationManager authorizationManager : authorizationManagers) {
                 authorizationManager.invalidate(currentUser);
             }

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/CleanupSecurityCacheSessionListenerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/CleanupSecurityCacheSessionListenerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.security.server;
+
+import javax.enterprise.inject.Instance;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+
+import com.google.common.collect.ImmutableSet;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.security.authz.AuthorizationManager;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CleanupSecurityCacheSessionListenerTest {
+
+    @Mock
+    private HttpSessionEvent evt;
+
+    @Mock
+    private HttpSession session;
+
+    @Test
+    public void testSessionCleanup() {
+        final AuthorizationManager authorizationManager1 = mock(AuthorizationManager.class);
+        final AuthorizationManager authorizationManager2 = mock(AuthorizationManager.class);
+
+        final Instance<AuthorizationManager> instances = mock(Instance.class);
+        when(instances.iterator()).thenReturn(asList(authorizationManager1,
+                                                     authorizationManager2).iterator());
+
+        final CleanupSecurityCacheSessionListener listener = new CleanupSecurityCacheSessionListener(instances);
+
+        final User user = new UserImpl("user", ImmutableSet.of(new RoleImpl("author")));
+
+        when(evt.getSession()).thenReturn(session);
+        when(session.getAttribute(ServletSecurityAuthenticationService.USER_SESSION_ATTR_NAME)).thenReturn(user);
+
+        listener.sessionDestroyed(evt);
+
+        verify(authorizationManager1, times(1)).invalidate(user);
+        verify(authorizationManager2, times(1)).invalidate(user);
+    }
+
+    @Test
+    public void testSessionCleanupNPE() {
+        final CleanupSecurityCacheSessionListener listener = new CleanupSecurityCacheSessionListener();
+
+        final User user = new UserImpl("user", ImmutableSet.of(new RoleImpl("author")));
+
+        when(evt.getSession()).thenReturn(session);
+        when(session.getAttribute(ServletSecurityAuthenticationService.USER_SESSION_ATTR_NAME)).thenReturn(user);
+
+        listener.sessionDestroyed(evt);
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/io/IOServiceSecuritySetupTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/io/IOServiceSecuritySetupTest.java
@@ -198,6 +198,11 @@ public class IOServiceSecuritySetupTest {
                                      User user) {
             return null;
         }
+
+        @Override
+        public void invalidate(User user) {
+
+        }
     }
 
     ;

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationManager.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationManager.java
@@ -232,4 +232,10 @@ public interface AuthorizationManager {
      */
     PermissionCheck check(String permission,
                           User user);
+
+    /**
+     * Invalidate user related authorization data cached
+     * @param user user to invalidate cache
+     */
+    void invalidate(final User user);
 }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/PermissionManager.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/PermissionManager.java
@@ -175,4 +175,10 @@ public interface PermissionManager {
      */
     PermissionCollection resolvePermissions(User user,
                                             VotingStrategy votingStrategy);
+
+    /**
+     * Invalidate user related authorization data cached
+     * @param user user to invalidate cache
+     */
+    void invalidate(final User user);
 }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthorizationManager.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthorizationManager.java
@@ -231,4 +231,10 @@ public class DefaultAuthorizationManager implements AuthorizationManager {
                                        user,
                                        votingStrategy);
     }
+
+    @Override
+    public void invalidate(final User user) {
+        permissionManager.invalidate(user);
+    }
+
 }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthzResultCache.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthzResultCache.java
@@ -32,8 +32,7 @@ public class DefaultAuthzResultCache {
         if (result == null) {
             return null;
         }
-        AuthorizationResult decision = result.get(user.getIdentifier());
-        return decision == null ? null : decision;
+        return result.get(user.getIdentifier());
     }
 
     public void put(final User user,
@@ -63,5 +62,14 @@ public class DefaultAuthzResultCache {
 
     public void clear() {
         internal.clear();
+    }
+
+    public void invalidate(final User user) {
+        if (user == null || user.getIdentifier() == null || user.getIdentifier().isEmpty()) {
+            return;
+        }
+        for (Map<String, AuthorizationResult> entry : internal.values()) {
+            entry.remove(user.getIdentifier());
+        }
     }
 }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultPermissionManager.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultPermissionManager.java
@@ -257,6 +257,11 @@ public class DefaultPermissionManager implements PermissionManager {
         }
     }
 
+    @Override
+    public void invalidate(final User user) {
+        cache.invalidate(user);
+    }
+
     private PermissionCollection resolvePermissionsAffirmative(User user) {
         // TODO
         PermissionCollection result = new DefaultPermissionCollection();

--- a/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/AuthorizationManagerTest.java
+++ b/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/AuthorizationManagerTest.java
@@ -515,4 +515,24 @@ public class AuthorizationManagerTest {
                never()).execute();
         verify(onGranted).execute();
     }
+
+    @Test
+    public void testInvalidateCache() throws Exception {
+        User user1 = createUserMock("admin",
+                "manager");
+        permissionManager.setDefaultVotingStrategy(VotingStrategy.AFFIRMATIVE);
+        assertTrue(authorizationManager.authorize(perspective1,
+                user1));
+
+        authorizationManager.check(perspective1,
+                user1)
+                .granted(onGranted)
+                .denied(onDenied);
+        verify(onDenied,
+                never()).execute();
+        verify(onGranted).execute();
+
+        authorizationManager.invalidate(user1);
+        verify(permissionManager, times(1)).invalidate(user1);
+    }
 }

--- a/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/DefaultAuthzResultCacheTest.java
+++ b/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/DefaultAuthzResultCacheTest.java
@@ -1,0 +1,41 @@
+package org.uberfire.security.impl.authz;
+
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
+import org.junit.Test;
+import org.uberfire.security.authz.AuthorizationResult;
+import org.uberfire.security.authz.Permission;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DefaultAuthzResultCacheTest {
+
+    protected User createUserMock(String... roles) {
+        return new UserImpl("username",
+                             Stream.of(roles).map(RoleImpl::new).collect(Collectors.toSet()),
+                             Collections.emptyList());
+    }
+
+    @Test
+    public void testInvalidate() {
+        final User user = createUserMock("admin");
+
+        final Permission viewAll = new DotNamedPermission("resource.read", true);
+
+        DefaultAuthzResultCache cache = new DefaultAuthzResultCache();
+        cache.put(user, viewAll, AuthorizationResult.ACCESS_GRANTED);
+
+        assertEquals(AuthorizationResult.ACCESS_GRANTED, cache.get(user, viewAll));
+
+        cache.invalidate(user);
+
+        assertNull(cache.get(user, viewAll));
+    }
+
+}

--- a/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/PermissionManagerTest.java
+++ b/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/PermissionManagerTest.java
@@ -372,6 +372,28 @@ public class PermissionManagerTest {
                      1);
         assertEquals(authzResultCache.size(createUserMock()),
                      0);
+
+        permissionManager.invalidate(user);
+
+        assertEquals(authzResultCache.size(user),
+                0);
+
+        permissionManager.checkPermission(viewAll,
+                user);
+        verify(permissionManager,
+                times(2)).resolvePermissions(user,
+                VotingStrategy.PRIORITY);
+        verify(authzResultCache,
+                times(2)).put(user,
+                viewAll,
+                AuthorizationResult.ACCESS_GRANTED);
+        verify(authzResultCache,
+                times(5)).get(user,
+                viewAll);
+        assertEquals(authzResultCache.size(user),
+                1);
+        assertEquals(authzResultCache.size(createUserMock()),
+                0);
     }
 
     @Test


### PR DESCRIPTION
@domhanak @ederign bringing feature to master 

looks like due the changes that @dgutierr was executing on security, this feature was postponed and never revisited.