### PR TITLE
[AF-1396] Asset editors don't resize with window size change

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -23,6 +23,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.Window;
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.common.client.dom.Document;
 import org.jboss.errai.common.client.dom.HTMLElement;
@@ -147,7 +148,9 @@ public class ComponentColumnView
     }
 
     void setupOnResize() {
-        document.getBody().setOnresize(event -> calculateWidth());
+        Window.addResizeHandler(event -> {
+            calculateWidth();
+        });
     }
 
     public void dockSelectEvent(@Observes UberfireDocksInteractionEvent event) {
@@ -360,7 +363,7 @@ public class ComponentColumnView
         });
         content.setOnmouseout(e -> {
             removeCSSClass(content,
-                    "componentMovePreview");
+                           "componentMovePreview");
         });
         content.setOnmouseover(e -> {
             e.preventDefault();


### PR DESCRIPTION
The old method was overriding af default resize handler : https://github.com/kiegroup/appformer/blob/2b157a2ca6f8e4f2c2a9b02fc5cb731b1ddc64a4/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java#L244