### PR TITLE
upgraded jboss-ip-bom to 8.1.0.Final (#447)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-bom</artifactId>
     <!-- Keep in sync with the parent version of uberfire-bom/pom.xml -->
-    <version>8.1.0.CR2</version>
+    <version>8.1.0.Final</version>
   </parent>
 
   <groupId>org.uberfire</groupId>

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with the parent version of ../pom.xml -->
-    <version>8.1.0.CR2</version>
+    <version>8.1.0.Final</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
(cherry picked from commit 80e630a17404ab008ccec9453a2a88f7f373f6b0)
jboss-ip-bom 8.1.0.Final is identical to 8.1.0.CR2 - we had to do this as prod will work only with Final versions. In future there won't be anymore CRs for jboss-ip-bom - only Final versions.