### PR TITLE
BXMSPROD-38: moved com.fasterxml.jackson to jboss-ip-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,6 @@
     <version.elasticsearch.client>5.6.1</version.elasticsearch.client>
     <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
     <version.com.unboundid>3.2.0</version.com.unboundid>
-    <com.fasterxml.jackson>2.8.10</com.fasterxml.jackson>
     <!-- Newer version in ip-bom causes ServiceLoader error -->
     <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
     <version.jnuit.docker.rule>0.3</version.jnuit.docker.rule>
@@ -136,11 +135,6 @@
     <version.org.mariadb.jdbc>1.3.6</version.org.mariadb.jdbc>
     <version.org.mysql-driver>5.1.6</version.org.mysql-driver>
     <version.org.postgres-driver>9.1-901.jdbc4</version.org.postgres-driver>
-
-    <!-- Required since support for ELS 2.x. Keep in sync with kie-parent or remove when those
-          two versions are being updated on the IP BOM.-->
-    <version.com.fasterxml.jackson>2.6.2</version.com.fasterxml.jackson>
-    <version.commons-cli>1.3.1</version.commons-cli>
 
     <!-- required to fix RHDM-293 -->
     <version.org.apache.logging.log4j.log4j-to-slf4j>2.9.0</version.org.apache.logging.log4j.log4j-to-slf4j>
@@ -1119,26 +1113,6 @@
         <artifactId>lucene-backward-codecs</artifactId>
         <version>${version.org.apache.lucene}</version>
       </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${com.fasterxml.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${com.fasterxml.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>${com.fasterxml.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${com.fasterxml.jackson}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.wildfly.security</groupId>
@@ -1276,29 +1250,6 @@
         </exclusions>
       </dependency>
 
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-smile</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-cbor</artifactId>
-        <version>${version.com.fasterxml.jackson}</version>
-      </dependency>
 
       <!-- Required to run the ElasticSearch server when performing the unit test executions.
           The ELS data provider requires groovy scripts enabled on the server.-->


### PR DESCRIPTION
DON'T MERGE before https://github.com/jboss-integration/jboss-integration-platform-bom/pull/424 was merged and jboss-ip-bpm 8.2.0.Final was released and kie-reps updated