### PR TITLE
[AF-1544]: Dot files are not indexed, so dot files condition added before queueing delete events

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
@@ -363,9 +363,9 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
                         }
 
                         private void queueDeleteEvent(WatchEvent object, final WatchContext context, final IndexerDispatcher dispatcher) throws DisposedException {
-                            Path path = context.getOldPath();
-                            if(!path.getFileName().toString().startsWith(".")){
-                                final Path oldPath = context.getOldPath();
+                            final Path oldPath = context.getOldPath();
+                            // ignore delete events for dot files, because dot files are not indexed
+                            if(!oldPath.getFileName().toString().startsWith(".")){
                                 dispatcher.offer(new DeletedFileEvent(oldPath));
                             }
                         }

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
@@ -46,7 +46,6 @@ import org.uberfire.java.nio.base.WatchContext;
 import org.uberfire.java.nio.base.dotfiles.DotFileUtils;
 import org.uberfire.java.nio.file.DeleteOption;
 import org.uberfire.java.nio.file.DirectoryNotEmptyException;
-import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
@@ -364,8 +363,11 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
                         }
 
                         private void queueDeleteEvent(WatchEvent object, final WatchContext context, final IndexerDispatcher dispatcher) throws DisposedException {
-                            final Path oldPath = context.getOldPath();
-                            dispatcher.offer(new DeletedFileEvent(oldPath));
+                            Path path = context.getOldPath();
+                            if(!path.getFileName().toString().startsWith(".")){
+                                final Path oldPath = context.getOldPath();
+                                dispatcher.offer(new DeletedFileEvent(oldPath));
+                            }
                         }
 
                         private void queueRenameEvent(final WatchContext context, final IndexerDispatcher dispatcher) throws DisposedException {


### PR DESCRIPTION
There was a NPE when trying to delete _src/main/.java_ from index, but those files are not directly indexed as they are. They are converted to _src/main/java_, so we can't delete a _.java_ that is not there. 
I added that check so now it will not try to delete dot files from index.