### PR TITLE
AF-1585: avoid port failure if already in use, by automatically assigning a new available port

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/common/PortUtil.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/common/PortUtil.java
@@ -1,0 +1,36 @@
+package org.uberfire.java.nio.fs.jgit.daemon.common;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PortUtil {
+
+    private static final String ERROR_MESSAGE = "Error trying to find a free port.";
+    private static final Logger LOG = LoggerFactory.getLogger(PortUtil.class);
+
+    public static int validateOrGetNew(int preferredPort) {
+        if (preferredPort == 0 || isPortInUse(preferredPort)) {
+            if (preferredPort != 0) {
+                LOG.warn("Port {} already in use, system will automatically look for a new one.", preferredPort);
+            }
+            try (ServerSocket ss = new ServerSocket(0)) {
+                return ss.getLocalPort();
+            } catch (IOException e) {
+                LOG.error(ERROR_MESSAGE, e);
+                throw new RuntimeException(ERROR_MESSAGE);
+            }
+        }
+        return preferredPort;
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (final ServerSocket ss = new ServerSocket(port)) {
+            return false;
+        } catch (Exception e) {
+        }
+        return true;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/git/Daemon.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/git/Daemon.java
@@ -50,15 +50,20 @@ import org.eclipse.jgit.transport.resolver.RepositoryResolver;
 import org.eclipse.jgit.transport.resolver.ServiceNotAuthorizedException;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
 import org.eclipse.jgit.transport.resolver.UploadPackFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.uberfire.commons.async.DescriptiveRunnable;
 import org.uberfire.java.nio.fs.jgit.daemon.filters.HiddenBranchRefFilter;
 
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import static org.uberfire.java.nio.fs.jgit.daemon.common.PortUtil.validateOrGetNew;
 
 /**
  * Basic daemon for the anonymous <code>git://</code> transport protocol.
  */
 public class Daemon {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Daemon.class);
 
     private static final int BACKLOG = 5;
 
@@ -94,11 +99,10 @@ public class Daemon {
     /**
      * Configures a new daemon for the specified network address. The daemon will not attempt to bind to an address or
      * accept connections until a call to {@link #start()}.
-     *
-     * @param addr             address to listen for connections on. If null, any available port will be chosen on all network
-     *                         interfaces.
+     * @param addr address to listen for connections on. If null, any available port will be chosen on all network
+     * interfaces.
      * @param acceptThreadPool source of threads for waiting for inbound socket connections. Every time the daemon is started or
-     *                         restarted, a new task will be submitted to this pool. When the daemon is stopped, the task completes.
+     * restarted, a new task will be submitted to this pool. When the daemon is stopped, the task completes.
      */
     public Daemon(final InetSocketAddress addr,
                   final Executor acceptThreadPool,
@@ -217,9 +221,8 @@ public class Daemon {
 
     /**
      * Lookup a supported service so it can be reconfigured.
-     *
      * @param name name of the service; e.g. "receive-pack"/"git-receive-pack" or
-     *             "upload-pack"/"git-upload-pack".
+     * "upload-pack"/"git-upload-pack".
      * @return the service; null if this daemon implementation doesn't support
      * the requested service type.
      */
@@ -244,10 +247,9 @@ public class Daemon {
 
     /**
      * Set the timeout before willing to abort an IO call.
-     *
      * @param seconds number of seconds to wait (with no data transfer occurring)
-     *                before aborting an IO read or write operation with the
-     *                connected client.
+     * before aborting an IO read or write operation with the
+     * connected client.
      */
     public void setTimeout(final int seconds) {
         timeout = seconds;
@@ -255,7 +257,6 @@ public class Daemon {
 
     /**
      * Sets the resolver that locates repositories by name.
-     *
      * @param resolver the resolver instance.
      */
     public void setRepositoryResolver(RepositoryResolver<DaemonClient> resolver) {
@@ -264,7 +265,6 @@ public class Daemon {
 
     /**
      * Sets the factory that constructs and configures the per-request UploadPack.
-     *
      * @param factory the factory. If null upload-pack is disabled.
      */
     @SuppressWarnings("unchecked")
@@ -279,8 +279,7 @@ public class Daemon {
     /**
      * Starts this daemon listening for connections on a thread supplied by the executor service given to the
      * constructor. The daemon can be stopped by a call to {@link #stop()} or by shutting down the ExecutorService.
-     *
-     * @throws IOException           the server socket could not be opened.
+     * @throws IOException the server socket could not be opened.
      * @throws IllegalStateException the daemon is already running.
      */
     public synchronized void start() throws IOException {
@@ -292,12 +291,14 @@ public class Daemon {
         int listenPort = myAddress != null ? myAddress.getPort() : 0;
 
         try {
-            this.listenSock = new ServerSocket(listenPort,
+            this.listenSock = new ServerSocket(validateOrGetNew(listenPort),
                                                BACKLOG,
                                                listenAddress);
         } catch (IOException e) {
-            throw new IOException("Failed to open server socket for " + listenAddress + ":" + listenPort,
-                                  e);
+            throw new IOException("Failed to open server socket for " + listenAddress + ":" + listenPort, e);
+        }
+        if (listenSock.getLocalPort() != listenPort) {
+            LOG.error("Git original port {} not available, new free port {} assigned.", listenPort, listenSock.getLocalPort());
         }
         myAddress = (InetSocketAddress) listenSock.getLocalSocketAddress();
 
@@ -409,15 +410,7 @@ public class Daemon {
         try {
             return repositoryResolver.open(client,
                                            name.substring(1));
-        } catch (RepositoryNotFoundException e) {
-            // null signals it "wasn't found", which is all that is suitable
-            // for the remote client to know.
-            return null;
-        } catch (ServiceNotAuthorizedException e) {
-            // null signals it "wasn't found", which is all that is suitable
-            // for the remote client to know.
-            return null;
-        } catch (ServiceNotEnabledException e) {
+        } catch (RepositoryNotFoundException | ServiceNotAuthorizedException | ServiceNotEnabledException e) {
             // null signals it "wasn't found", which is all that is suitable
             // for the remote client to know.
             return null;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/AbstractTestInfra.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/AbstractTestInfra.java
@@ -209,8 +209,7 @@ public abstract class AbstractTestInfra {
     public static int findFreePort() {
         int port = 0;
         try {
-            ServerSocket server =
-                    new ServerSocket(0);
+            ServerSocket server = new ServerSocket(0);
             port = server.getLocalPort();
             server.close();
         } catch (IOException e) {
@@ -230,7 +229,7 @@ public abstract class AbstractTestInfra {
 
     static void commit(final Git origin, final String branchName, final String message, final TestFile... testFiles) throws IOException {
         final Map<String, File> data = Arrays.stream(testFiles)
-                                             .collect(toMap(f -> f.path, f -> tmpFile(f.content)));
+                .collect(toMap(f -> f.path, f -> tmpFile(f.content)));
         new Commit(origin,
                    branchName,
                    "name",
@@ -253,7 +252,6 @@ public abstract class AbstractTestInfra {
     static TestFile content(final String path, final String content) {
         return new TestFile(path, content);
     }
-    
 
     /**
      * Creates mock hook in defined hooks directory.
@@ -263,7 +261,7 @@ public abstract class AbstractTestInfra {
      * @throws UnsupportedEncodingException
      */
     void writeMockHook(final File hooksDirectory,
-                               final String hookName)
+                       final String hookName)
             throws FileNotFoundException, UnsupportedEncodingException {
         final PrintWriter writer = new PrintWriter(new File(hooksDirectory,
                                                             hookName),
@@ -271,7 +269,7 @@ public abstract class AbstractTestInfra {
         writer.println("# something");
         writer.close();
     }
-    
+
     /**
      * Tests if defined hook was executed or not.
      * @param gitRepoName Name of test git repository that is created for committing changes.
@@ -281,8 +279,8 @@ public abstract class AbstractTestInfra {
      * @throws IOException
      */
     void testHook(final String gitRepoName,
-                          final String testedHookName,
-                          final boolean wasExecuted) throws IOException {
+                  final String testedHookName,
+                  final boolean wasExecuted) throws IOException {
         final URI newRepo = URI.create("git://" + gitRepoName);
 
         final AtomicBoolean hookExecuted = new AtomicBoolean(false);

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHookTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHookTest.java
@@ -32,12 +32,6 @@ public class JGitFileSystemImplProviderHookTest extends AbstractTestInfra {
     @Override
     public Map<String, String> getGitPreferences() {
         Map<String, String> gitPrefs = super.getGitPreferences();
-        gitPrefs.put("org.uberfire.nio.git.daemon.enabled",
-                     "true");
-        int gitDaemonPort = findFreePort();
-        gitPrefs.put("org.uberfire.nio.git.daemon.port",
-                     String.valueOf(gitDaemonPort));
-
         try {
             final File hooksDir = createTempDirectory();
             gitPrefs.put("org.uberfire.nio.git.hooks",

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderSSHBadConfigTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderSSHBadConfigTest.java
@@ -32,8 +32,6 @@ public class JGitFileSystemImplProviderSSHBadConfigTest extends AbstractTestInfr
 
         gitPrefs.put("org.uberfire.nio.git.ssh.enabled",
                      "true");
-        gitPrefs.put("org.uberfire.nio.git.ssh.port",
-                     String.valueOf(findFreePort()));
         gitPrefs.put("org.uberfire.nio.git.ssh.idle.timeout",
                      "bz");
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/daemon/common/PortUtilTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/daemon/common/PortUtilTest.java
@@ -1,0 +1,39 @@
+package org.uberfire.java.nio.fs.jgit.daemon.common;
+
+import java.net.ServerSocket;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.fail;
+
+public class PortUtilTest {
+
+    @Test
+    public void testValidateOrGetNewWithPreferredNotAvailable() {
+        int result1 = PortUtil.validateOrGetNew(0);
+
+        try (ServerSocket ss = new ServerSocket(result1)) {
+            int result = PortUtil.validateOrGetNew(result1);
+            assertThat(result).isNotEqualTo(result1);
+        } catch (Exception x) {
+            fail("Port allocation should have work!");
+        }
+    }
+
+    @Test
+    public void testValidateOrGetNewWithZero() {
+        int result1 = PortUtil.validateOrGetNew(0);
+
+        assertThat(result1).isNotEqualTo(0);
+    }
+
+    @Test
+    public void testValidateOrGetNewWithAvailablePreferredPort() {
+        int result = PortUtil.validateOrGetNew(0);
+        int result2 = PortUtil.validateOrGetNew(result);
+
+        assertThat(result2).isEqualTo(result);
+    }
+
+}


### PR DESCRIPTION
Avoid port failure if already in use, by automatically assigning a new available port in case of preferred port isn't available.
This change should improve our testing infrastructre, avoiding what's called `randon` test failures.

Docs: https://github.com/kiegroup/kie-docs/pull/1157