### PR TITLE
Prevent NPE in WildflyGroupPropertiesManager

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/src/main/java/org/uberfire/ext/security/management/wildfly/properties/WildflyGroupPropertiesManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/src/main/java/org/uberfire/ext/security/management/wildfly/properties/WildflyGroupPropertiesManager.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ package org.uberfire.ext.security.management.wildfly.properties;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -108,7 +109,9 @@ public class WildflyGroupPropertiesManager extends BaseWildflyPropertiesManager 
 
     @Override
     public void destroy() throws Exception {
-        this.groupsPropertiesFileLoader.stop();
+        if (groupsPropertiesFileLoader != null) {
+            this.groupsPropertiesFileLoader.stop();
+        }
     }
 
     @Override
@@ -230,7 +233,7 @@ public class WildflyGroupPropertiesManager extends BaseWildflyPropertiesManager 
                 }
             });
         } catch (Exception e) {
-            LOG.error("Error removing the folowing group names: " + identifiers,
+            LOG.error("Error removing the folowing group names: " + Arrays.toString(identifiers),
                       e);
             throw new SecurityManagementException(e);
         }


### PR DESCRIPTION
@ederign please check. When WildflyGroupPropertiesManager fails to initialize (when groups.properties files is not found) `groupsPropertiesFileLoader` is null. This leads to unnecessary NPE thrown from the `destroy()` method on container shutdown. This is happening quite often when running tests using cargo which doesn't have the group file in the correct location (And it's OK because it doesn't need it) and it's spamming the console.

Also fixed exception message that wasn't showing the contents of the varargs argument - as it was it was only showing argument as `[Ljava.lang.String;@25154f`

<details>
  <summary>Exception</summary>
  <pre>
[talledLocalContainer] 13:40:00,761 ERROR [org.uberfire.ext.security.management.BackendUserSystemManager] (MSC service thread 1-5) UserManagementService destroy failure: java.lang.RuntimeException: Properties file for users not found at './standalone/configuration/application-users.properties'.
[talledLocalContainer] 	at org.uberfire.ext.security.management.wildfly.properties.WildflyUserPropertiesManager.buildFileLoader(WildflyUserPropertiesManager.java:273)
[talledLocalContainer] 	at org.uberfire.ext.security.management.wildfly.properties.WildflyUserPropertiesManager.getUsersFileLoader(WildflyUserPropertiesManager.java:321)
[talledLocalContainer] 	at org.uberfire.ext.security.management.wildfly.properties.WildflyUserPropertiesManager.destroy(WildflyUserPropertiesManager.java:106)
[talledLocalContainer] 	at org.uberfire.ext.security.management.wildfly.cli.WildflyUserPropertiesCLIManager.destroy(WildflyUserPropertiesCLIManager.java:94)
[talledLocalContainer] 	at org.uberfire.ext.security.management.BackendUserSystemManager.onDestroy(BackendUserSystemManager.java:182)
[talledLocalContainer] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[talledLocalContainer] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[talledLocalContainer] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[talledLocalContainer] 	at java.lang.reflect.Method.invoke(Method.java:498)
[talledLocalContainer] 	at org.jboss.weld.injection.producer.DefaultLifecycleCallbackInvoker.invokeMethods(DefaultLifecycleCallbackInvoker.java:97)
[talledLocalContainer] 	at org.jboss.weld.injection.producer.DefaultLifecycleCallbackInvoker.preDestroy(DefaultLifecycleCallbackInvoker.java:90)
[talledLocalContainer] 	at org.jboss.weld.injection.producer.BasicInjectionTarget.preDestroy(BasicInjectionTarget.java:127)
[talledLocalContainer] 	at org.jboss.weld.bean.ManagedBean.destroy(ManagedBean.java:189)
[talledLocalContainer] 	at org.jboss.weld.util.bean.IsolatedForwardingBean.destroy(IsolatedForwardingBean.java:50)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractContext.destroyContextualInstance(AbstractContext.java:139)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractContext.destroy(AbstractContext.java:153)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractSharedContext.destroy(AbstractSharedContext.java:61)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractSharedContext.invalidate(AbstractSharedContext.java:56)
[talledLocalContainer] 	at org.jboss.weld.bootstrap.WeldRuntime.shutdown(WeldRuntime.java:56)
[talledLocalContainer] 	at org.jboss.weld.bootstrap.WeldBootstrap.shutdown(WeldBootstrap.java:113)
[talledLocalContainer] 	at org.jboss.as.weld.WeldStartService.stop(WeldStartService.java:128)
[talledLocalContainer] 	at org.jboss.msc.service.ServiceControllerImpl$StopTask.stopService(ServiceControllerImpl.java:2150)
[talledLocalContainer] 	at org.jboss.msc.service.ServiceControllerImpl$StopTask.run(ServiceControllerImpl.java:2101)
[talledLocalContainer] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[talledLocalContainer] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[talledLocalContainer] 	at java.lang.Thread.run(Thread.java:748)
[talledLocalContainer] 
[talledLocalContainer] 13:40:00,762 ERROR [org.uberfire.ext.security.management.BackendUserSystemManager] (MSC service thread 1-5) GroupManagementService destroy failure: java.lang.NullPointerException
[talledLocalContainer] 	at org.uberfire.ext.security.management.wildfly.properties.WildflyGroupPropertiesManager.destroy(WildflyGroupPropertiesManager.java:111)
[talledLocalContainer] 	at org.uberfire.ext.security.management.wildfly.cli.WildflyGroupPropertiesCLIManager.destroy(WildflyGroupPropertiesCLIManager.java:84)
[talledLocalContainer] 	at org.uberfire.ext.security.management.BackendUserSystemManager.onDestroy(BackendUserSystemManager.java:194)
[talledLocalContainer] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[talledLocalContainer] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[talledLocalContainer] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[talledLocalContainer] 	at java.lang.reflect.Method.invoke(Method.java:498)
[talledLocalContainer] 	at org.jboss.weld.injection.producer.DefaultLifecycleCallbackInvoker.invokeMethods(DefaultLifecycleCallbackInvoker.java:97)
[talledLocalContainer] 	at org.jboss.weld.injection.producer.DefaultLifecycleCallbackInvoker.preDestroy(DefaultLifecycleCallbackInvoker.java:90)
[talledLocalContainer] 	at org.jboss.weld.injection.producer.BasicInjectionTarget.preDestroy(BasicInjectionTarget.java:127)
[talledLocalContainer] 	at org.jboss.weld.bean.ManagedBean.destroy(ManagedBean.java:189)
[talledLocalContainer] 	at org.jboss.weld.util.bean.IsolatedForwardingBean.destroy(IsolatedForwardingBean.java:50)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractContext.destroyContextualInstance(AbstractContext.java:139)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractContext.destroy(AbstractContext.java:153)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractSharedContext.destroy(AbstractSharedContext.java:61)
[talledLocalContainer] 	at org.jboss.weld.context.AbstractSharedContext.invalidate(AbstractSharedContext.java:56)
[talledLocalContainer] 	at org.jboss.weld.bootstrap.WeldRuntime.shutdown(WeldRuntime.java:56)
[talledLocalContainer] 	at org.jboss.weld.bootstrap.WeldBootstrap.shutdown(WeldBootstrap.java:113)
[talledLocalContainer] 	at org.jboss.as.weld.WeldStartService.stop(WeldStartService.java:128)
[talledLocalContainer] 	at org.jboss.msc.service.ServiceControllerImpl$StopTask.stopService(ServiceControllerImpl.java:2150)
[talledLocalContainer] 	at org.jboss.msc.service.ServiceControllerImpl$StopTask.run(ServiceControllerImpl.java:2101)
[talledLocalContainer] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[talledLocalContainer] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[talledLocalContainer] 	at java.lang.Thread.run(Thread.java:748)
  </pre>
</details>