### PR TITLE
AF-1678: Fix illegal transitive dependencies errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
     <version.io.netty.old>3.10.6.Final</version.io.netty.old>
-    <version.elasticsearch.client>5.6.1</version.elasticsearch.client>
+    <version.org.elasticsearch>5.6.1</version.org.elasticsearch>
     <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
     <version.com.unboundid>3.2.0</version.com.unboundid>
     <version.org.infinispan>9.3.2.Final</version.org.infinispan>
@@ -1129,7 +1129,23 @@
       <dependency>
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>transport</artifactId>
-        <version>${version.elasticsearch.client}</version>
+        <version>${version.org.elasticsearch}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.elasticsearch</groupId>
+        <artifactId>elasticsearch</artifactId>
+        <version>${version.org.elasticsearch}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.elasticsearch.client</groupId>
+        <artifactId>elasticsearch-rest-client</artifactId>
+        <version>${version.org.elasticsearch}</version>
         <exclusions>
           <exclusion>
             <artifactId>commons-logging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <version.org.kie.soup>${version.org.kie}</version.org.kie.soup>
     <!-- Exception as it is needed for gwt-maven-plugin version-->
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
+    <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.google.guava>20.0</version.com.google.guava>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
@@ -977,6 +978,12 @@
             <artifactId>javax.annotation-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.elemental2</groupId>
+        <artifactId>elemental2-dom</artifactId>
+        <version>${version.com.google.elemental2}</version>
       </dependency>
 
       <!-- RHDM-588 freemarker -->

--- a/pom.xml
+++ b/pom.xml
@@ -986,6 +986,12 @@
         <version>${version.com.google.elemental2}</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.google.elemental2</groupId>
+        <artifactId>elemental2-promise</artifactId>
+        <version>${version.com.google.elemental2}</version>
+      </dependency>
+
       <!-- RHDM-588 freemarker -->
       <dependency>
         <groupId>org.freemarker</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.com.google.guava>20.0</version.com.google.guava>
+    <version.com.google.jsinterop.base>1.0.0-RC1</version.com.google.jsinterop.base>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
@@ -1007,6 +1008,12 @@
         <groupId>com.google.elemental2</groupId>
         <artifactId>elemental2-promise</artifactId>
         <version>${version.com.google.elemental2}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.jsinterop</groupId>
+        <artifactId>base</artifactId>
+        <version>${version.com.google.jsinterop.base}</version>
       </dependency>
 
       <!-- RHDM-588 freemarker -->

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,6 @@
     <version.bundle.plugin>3.3.0</version.bundle.plugin><!-- 3.2.0 sometimes fails with NPE during parallel build-->
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
-    <!-- TODO fix all the modules to have all direct dependencies specified, then remove this property -->
-    <illegaltransitivereportonly>true</illegaltransitivereportonly>
     <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,9 @@
     <version.org.kie.soup>${version.org.kie}</version.org.kie.soup>
     <!-- Exception as it is needed for gwt-maven-plugin version-->
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
-    <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
+    <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.com.google.guava>20.0</version.com.google.guava>
-    <version.com.jcraft>0.1.54</version.com.jcraft>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
@@ -83,6 +82,8 @@
     <version.org.gwtbootstrap3>0.9.3</version.org.gwtbootstrap3>
 
     <version.org.jboss.byteman>3.0.10</version.org.jboss.byteman>
+    <version.org.jboss.jboss-dmr>1.4.1.Final</version.org.jboss.jboss-dmr>
+    <version.org.jboss.jboss-msc>1.2.7.SP1</version.org.jboss.jboss-msc>
 
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
     <version.org.wildfly.security>1.1.3.Final</version.org.wildfly.security>
@@ -943,6 +944,17 @@
       </dependency>
 
       <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-core</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-common</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-catalina</artifactId>
         <version>${version.org.apache.tomcat}</version>
@@ -970,6 +982,10 @@
         <artifactId>gwt-dev</artifactId>
         <version>${version.com.google.gwt}</version>
         <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -1004,6 +1020,12 @@
         <groupId>com.allen-sauer.gwt.dnd</groupId>
         <artifactId>gwt-dnd</artifactId>
         <version>${version.com.allen-sauer.gwt.dnd}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1348,6 +1370,18 @@
         <groupId>com.googlecode.jtype</groupId>
         <artifactId>jtype</artifactId>
         <version>${version.com.googlecode.jtype}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-dmr</artifactId>
+        <version>${version.org.jboss.jboss-dmr}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.msc</groupId>
+        <artifactId>jboss-msc</artifactId>
+        <version>${version.org.jboss.jboss-msc}</version>
       </dependency>
 
       <!-- log4j-to-slf4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.google.guava>20.0</version.com.google.guava>
+    <version.com.jcraft>0.1.54</version.com.jcraft>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
@@ -1320,6 +1321,11 @@
         </exclusions>
       </dependency>
 
+      <dependency>
+        <groupId>com.jcraft</groupId>
+        <artifactId>jsch</artifactId>
+        <version>${version.com.jcraft}</version>
+      </dependency>
 
       <!-- Required to run the ElasticSearch server when performing the unit test executions.
           The ELS data provider requires groovy scripts enabled on the server.-->

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
     <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
     <version.com.unboundid>3.2.0</version.com.unboundid>
     <version.org.infinispan>9.3.2.Final</version.org.infinispan>
+    <version.org.infinispan.protostream>4.2.2.Final</version.org.infinispan.protostream>
 
     <!-- Newer version in ip-bom causes ServiceLoader error -->
     <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
@@ -1233,6 +1234,11 @@
             <artifactId>jboss-marshalling-osgi</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan.protostream</groupId>
+        <artifactId>protostream</artifactId>
+        <version>${version.org.infinispan.protostream}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
     <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
+    <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
     <version.com.google.guava>20.0</version.com.google.guava>
-    <version.com.google.jsinterop.base>1.0.0-RC1</version.com.google.jsinterop.base>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>

--- a/pom.xml
+++ b/pom.xml
@@ -1000,6 +1000,12 @@
 
       <dependency>
         <groupId>com.google.elemental2</groupId>
+        <artifactId>elemental2-core</artifactId>
+        <version>${version.com.google.elemental2}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.elemental2</groupId>
         <artifactId>elemental2-dom</artifactId>
         <version>${version.com.google.elemental2}</version>
       </dependency>

--- a/uberfire-api/pom.xml
+++ b/uberfire-api/pom.xml
@@ -45,6 +45,11 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
     </dependency>
 
@@ -62,6 +67,11 @@
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
     </dependency>
 
   </dependencies>

--- a/uberfire-backend/uberfire-backend-api/pom.xml
+++ b/uberfire-backend/uberfire-backend-api/pom.xml
@@ -67,6 +67,11 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/uberfire-backend/uberfire-backend-cdi/pom.xml
+++ b/uberfire-backend/uberfire-backend-cdi/pom.xml
@@ -52,7 +52,11 @@
       <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>

--- a/uberfire-backend/uberfire-backend-server/pom.xml
+++ b/uberfire-backend/uberfire-backend-server/pom.xml
@@ -49,6 +49,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.1_spec</artifactId>
       <scope>provided</scope>
@@ -120,6 +125,11 @@
       <artifactId>errai-marshalling</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
     <!-- Encryption\Decryption service-->
     <dependency>
       <groupId>org.jasypt</groupId>
@@ -136,6 +146,26 @@
       <groupId>org.jboss.spec.javax.ejb</groupId>
       <artifactId>jboss-ejb-api_3.2_spec</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-client-api/pom.xml
+++ b/uberfire-client-api/pom.xml
@@ -56,6 +56,36 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-promise</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
+    </dependency>
+    
+    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>

--- a/uberfire-experimental/uberfire-experimental-client/pom.xml
+++ b/uberfire-experimental/uberfire-experimental-client/pom.xml
@@ -46,6 +46,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>
@@ -53,6 +58,11 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-api</artifactId>
     </dependency>
 
     <dependency>
@@ -76,11 +86,9 @@
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
 
-    <!-- test -->
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
@@ -29,11 +29,15 @@
 
   <name>Uberfire Commons Editor Backend</name>
   <description>Uberfire Commons Editor Backend</description>
- 
+
   <dependencies>
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -46,6 +50,10 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -74,7 +82,7 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
-     <scope>test</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -83,6 +91,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -44,11 +44,38 @@
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons-editor-api</artifactId>
@@ -80,6 +107,18 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-preferences-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-api/pom.xml
@@ -41,7 +41,15 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-runtime-plugins-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/pom.xml
@@ -29,14 +29,16 @@
 
   <name>Uberfire Layout Editor Backend</name>
   <description>Uberfire Layout Editor Backend</description>
- 
-  <dependencies>
 
+  <dependencies>
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-layout-editor-api</artifactId>
@@ -63,7 +65,19 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-runtime-plugins-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-runtime-plugins-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-backend</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -74,6 +88,5 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-
   </dependencies>
 </project>

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
@@ -54,6 +54,14 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/pom.xml
@@ -78,6 +78,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-api/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-api/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
       <scope>provided</scope>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/pom.xml
@@ -35,8 +35,24 @@
       <artifactId>uberfire-metadata-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>transport</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
     </dependency>
     <dependency>
       <groupId>com.unboundid</groupId>
@@ -78,17 +94,26 @@
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-misc</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-to-slf4j</artifactId>
     </dependency>
   </dependencies>
-
 
 </project>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/pom.xml
@@ -68,18 +68,36 @@
       <artifactId>infinispan-client-hotrod</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker-junit-rule</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.shrinkwrap</groupId>
-      <artifactId>shrinkwrap-impl-base</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan.protostream</groupId>
+      <artifactId>protostream</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
@@ -91,7 +109,16 @@
       <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-docker-junit-rule</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.shrinkwrap</groupId>
+      <artifactId>shrinkwrap-impl-base</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
 
 </project>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/pom.xml
@@ -77,5 +77,9 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
@@ -68,6 +68,10 @@
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-extensions/uberfire-preferences-ui-client/pom.xml
+++ b/uberfire-extensions/uberfire-preferences-ui-client/pom.xml
@@ -104,6 +104,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-properties-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-properties-editor-client</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/pom.xml
@@ -56,5 +56,10 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons-editor-client</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>errai-bus</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
     <!-- as javax.inject is excluded in parent pom's errai-bus dep. It had to be declared here -->
     <dependency>
       <groupId>javax.inject</groupId>
@@ -100,6 +105,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
@@ -112,6 +122,11 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
@@ -71,6 +71,10 @@
       <artifactId>gwtbootstrap3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
@@ -83,8 +87,32 @@
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-layout-editor-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
@@ -36,6 +36,11 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-server</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -61,7 +66,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
@@ -70,7 +75,7 @@
   </dependencies>
 
   <build>
-    
+
     <plugins>
 
       <!-- Build the test-jar artifact as tests for other service implementation modules depends on these ones. -->
@@ -85,9 +90,9 @@
           </execution>
         </executions>
       </plugin>
-      
+
     </plugins>
-    
+
   </build>
-  
+
 </project>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
@@ -56,6 +56,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -126,6 +131,11 @@
       <artifactId>errai-cdi-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+
     <!-- Others. -->
 
     <dependency>
@@ -146,7 +156,7 @@
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
-    </dependency>    
+    </dependency>
 
     <!-- Test scope. -->
 
@@ -155,7 +165,7 @@
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
@@ -164,5 +174,5 @@
 
   </dependencies>
 
-  
+
 </project>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
@@ -38,7 +38,22 @@
       <artifactId>uberfire-client-all</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-api</artifactId>
@@ -48,6 +63,11 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
     </dependency>
 
     <dependency>
@@ -69,7 +89,7 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-client</artifactId>
@@ -97,5 +117,5 @@
     </dependency>
 
   </dependencies>
-  
+
 </project>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
@@ -32,9 +32,9 @@
   <description>Uberfire Security Management - Provider Implementation for KeyCloak</description>
 
   <dependencies>
-    
+
     <!-- Uberfire related. -->
-    
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
@@ -81,7 +81,7 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
@@ -104,22 +104,32 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-common</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
 
     <!-- Test scope. -->
-    
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-backend</artifactId>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
@@ -92,6 +92,16 @@
       <artifactId>wildfly-elytron</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-dmr</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.msc</groupId>
+      <artifactId>jboss-msc</artifactId>
+    </dependency>
+
     <!-- 
       NOTE:
       If deploying into a JBoss Wildfly or EAP, there is no need to include these dependencies, 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
@@ -33,10 +33,20 @@
   <dependencies>
 
     <!-- Uberfire. -->
-    
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
     </dependency>
 
     <dependency>
@@ -77,13 +87,13 @@
       <artifactId>uberfire-widgets-commons</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-api</artifactId>
@@ -132,8 +142,13 @@
       <artifactId>errai-cdi-client</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+
     <!-- Others. -->
-    
+
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
@@ -141,7 +156,7 @@
     </dependency>
 
     <!-- GWT and GWT Extensions -->
-    
+
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
@@ -167,13 +182,13 @@
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
   </dependencies>
-  
+
 </project>

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
@@ -47,11 +47,27 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -74,12 +90,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
@@ -31,29 +31,28 @@
   <description>Uberfire Simple Docks Client</description>
 
   <dependencies>
-    
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
@@ -80,6 +79,10 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
@@ -40,6 +40,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
     </dependency>
 
@@ -52,12 +57,17 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-service-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-table</artifactId>
@@ -67,9 +77,25 @@
       <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3-extras</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
     </dependency>
 
     <dependency>
@@ -130,5 +156,5 @@
       </resource>
     </resources>
   </build>
-  
+
 </project>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-client/pom.xml
@@ -65,12 +65,17 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-all</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
-      <scope>test</scope>      
-    </dependency>    
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
@@ -30,7 +30,11 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-     </dependency>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bayesian-network/uberfire-wires-bayesian-network-client/pom.xml
@@ -94,6 +94,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-wires-bayesian-parser-backend</artifactId>
     </dependency>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-api/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-api/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>uberfire-commons-editor-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
@@ -52,6 +52,21 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
     </dependency>
 
@@ -68,6 +83,31 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-config</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
   </dependencies>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-client/pom.xml
@@ -46,7 +46,32 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ioc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons-editor-api</artifactId>
     </dependency>
 
     <dependency>
@@ -67,6 +92,11 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons-editor-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
     </dependency>
 
   </dependencies>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-client/pom.xml
@@ -77,6 +77,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
+    </dependency>
+
     <!-- Property Editor - Uberfire Extensions -->
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -42,7 +42,6 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-service-backend</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-api</artifactId>
@@ -239,6 +238,16 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
     </dependency>
 
     <dependency>
@@ -463,6 +472,16 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
     </dependency>
 
   </dependencies>

--- a/uberfire-io/pom.xml
+++ b/uberfire-io/pom.xml
@@ -53,6 +53,10 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/uberfire-js/pom.xml
+++ b/uberfire-js/pom.xml
@@ -33,6 +33,12 @@
   <description>UberFire JS</description>
 
   <dependencies>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-api</artifactId>
@@ -51,6 +57,21 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-message-console/uberfire-message-console-client/pom.xml
+++ b/uberfire-message-console/uberfire-message-console-client/pom.xml
@@ -49,6 +49,11 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
     </dependency>
 
@@ -117,6 +122,11 @@
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>uberfire-nio2-fs</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/pom.xml
@@ -40,5 +40,10 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>commons-io</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch</artifactId>
+    </dependency>
+
     <!-- Core Library -->
     <dependency>
       <groupId>org.apache.sshd</groupId>

--- a/uberfire-preferences/uberfire-preferences-api/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-api/pom.xml
@@ -42,6 +42,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>

--- a/uberfire-preferences/uberfire-preferences-backend/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-backend/pom.xml
@@ -32,6 +32,10 @@
       <artifactId>xstream</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
@@ -43,6 +47,10 @@
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -59,6 +67,10 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-preferences/uberfire-preferences-client/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-client/pom.xml
@@ -61,6 +61,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-properties-editor-client</artifactId>
       <scope>provided</scope>
@@ -69,6 +74,11 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-preferences-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-project/uberfire-project-backend/pom.xml
+++ b/uberfire-project/uberfire-project-backend/pom.xml
@@ -205,6 +205,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+    </dependency>
 
     <!-- Weld Modules. For tests only -->
 

--- a/uberfire-rest/uberfire-rest-backend/pom.xml
+++ b/uberfire-rest/uberfire-rest-backend/pom.xml
@@ -96,13 +96,6 @@
       </exclusions>
     </dependency>
 
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <!-- TEST: reflection -->
     <dependency>
       <groupId>org.reflections</groupId>

--- a/uberfire-security/uberfire-security-client/pom.xml
+++ b/uberfire-security/uberfire-security-client/pom.xml
@@ -32,6 +32,12 @@
   <description>UberFire Security Client</description>
 
   <dependencies>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-api</artifactId>
@@ -56,6 +62,16 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-cdi-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-server/pom.xml
+++ b/uberfire-server/pom.xml
@@ -66,6 +66,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
     </dependency>

--- a/uberfire-showcase/uberfire-client-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-client-webapp/pom.xml
@@ -110,9 +110,65 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-js</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -41,11 +41,6 @@
 
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>
-      <artifactId>gwtbootstrap3</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3-extras</artifactId>
     </dependency>
 
@@ -174,6 +169,11 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -414,6 +414,36 @@
       <artifactId>uberfire-experimental-client</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/uberfire-ssh/uberfire-ssh-backend/pom.xml
+++ b/uberfire-ssh/uberfire-ssh-backend/pom.xml
@@ -15,6 +15,21 @@
   <dependencies>
 
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/uberfire-ssh/uberfire-ssh-client/pom.xml
+++ b/uberfire-ssh/uberfire-ssh-client/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>

--- a/uberfire-structure/uberfire-structure-api/pom.xml
+++ b/uberfire-structure/uberfire-structure-api/pom.xml
@@ -19,6 +19,7 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-model</artifactId>
@@ -44,14 +45,19 @@
       <artifactId>uberfire-social-activities-api</artifactId>
     </dependency>
 
-    <!-- Errai Core -->
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
     </dependency>
   </dependencies>
 

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -124,9 +124,14 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-
-
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
 
     <!-- The version of commons-io in droolsjbpm-build-bootstrap pom is way too old-->
     <dependency>

--- a/uberfire-testing-utils/pom.xml
+++ b/uberfire-testing-utils/pom.xml
@@ -50,6 +50,11 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
     </dependency>
 
@@ -90,8 +95,33 @@
     </dependency>
 
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-promise</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-workbench/uberfire-workbench-client-backend/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-backend/pom.xml
@@ -33,6 +33,10 @@
   <dependencies>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
     </dependency>
     <dependency>
@@ -42,6 +46,22 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -95,6 +95,10 @@
       <groupId>com.google.jsinterop</groupId>
       <artifactId>jsinterop-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>base</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.errai</groupId>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -33,11 +33,27 @@
   <dependencies>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-experimental-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-client-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-security-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.gwtbootstrap3</groupId>
@@ -46,6 +62,38 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.allen-sauer.gwt.dnd</groupId>
+      <artifactId>gwt-dnd</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-workbench/uberfire-workbench-client/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client/pom.xml
@@ -52,6 +52,38 @@
       <artifactId>errai-cdi-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-bus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ioc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.allen-sauer.gwt.dnd</groupId>
       <artifactId>gwt-dnd</artifactId>
     </dependency>
@@ -59,19 +91,24 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>
     </dependency>
-    
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>


### PR DESCRIPTION
@ederign please check. There are tons of enforcer errors about illegal transitive dependencies.
Apart from spamming build console, the real issue with these missing dependencies is, that you can't really reliably build individual modules in separation (unless you did so before, which may not be the case when you checkout a different branch).

EDIT: I consider this ready for review. See individual commit messages (click the `...` after the commit message in the list below) for details about warnings being fixed. The PR build and full downstream are passing (with couple of unrelated kie-server integration test failures). I'm willing to rebase this (after Adriels wildfly and infinispan PRs are merged). The only thing I'm not sure about are dependency scopes (I'm sure I should have used `provided` scope at certain points, but not sure when - please point it out in the review).