### PR TITLE
[AF-1662] Fix background error colour

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/themes/impl/KIEColours.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/themes/impl/KIEColours.java
@@ -39,5 +39,5 @@ public class KIEColours {
 
     public static final String CELL_ERROR_FOCUS = "#CC0000";
 
-    public static final String CELL_ERROR_BACKGROUND = "#CC0000";
+    public static final String CELL_ERROR_BACKGROUND = "#FFE6E6";
 }


### PR DESCRIPTION
There is a bug in the proposed colours
https://redhat.invisionapp.com/share/2MORFSO4VUX#/screens/327518515
Hex of background error colour is the same of the cell error outline but the RGB is different. I used a RGB to Hex converter to have the right value

@manstis 