### PR TITLE
DROOLS-2932: Extend KeyboardOperations to support header cells navigation

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilities.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilities.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 /**
  * Utilities class
@@ -93,5 +94,9 @@ public class ColumnIndexUtilities {
         }
 
         return candidateHeaderColumnIndex;
+    }
+
+    public static int getMaxUiHeaderRowIndexOfColumn(final GridData model, final int uiColumnIndex) {
+        return model.getColumns().get(uiColumnIndex).getHeaderMetaData().size() - 1;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandler.java
@@ -23,6 +23,7 @@ import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.HasDOMElementResources;
 import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDOMElementResource;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.KeyboardOperation.TriStateBoolean;
@@ -114,7 +115,9 @@ public class BaseGridWidgetKeyboardHandler implements KeyDownHandler {
         for (GridColumn<?> column : gridModel.getColumns()) {
             if (column instanceof HasSingletonDOMElementResource) {
                 ((HasSingletonDOMElementResource) column).flush();
-                ((HasSingletonDOMElementResource) column).destroyResources();
+            }
+            if (column instanceof HasDOMElementResources) {
+                ((HasDOMElementResources) column).destroyResources();
             }
         }
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilitiesTest.java
@@ -22,7 +22,9 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridTest;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 
 import static org.junit.Assert.assertEquals;
 
@@ -99,5 +101,17 @@ public class ColumnIndexUtilitiesTest {
                                                                        columns.get(0).getHeaderMetaData().get(0),
                                                                        0,
                                                                        0));
+    }
+
+    @Test
+    public void testGetUiHeaderRowIndex() {
+        final BaseGridData model = new BaseGridData();
+        columns.forEach(col -> model.appendColumn(col));
+
+        assertEquals(0, ColumnIndexUtilities.getMaxUiHeaderRowIndexOfColumn(model, 0));
+
+        columns.get(1).getHeaderMetaData().add(new BaseHeaderMetaData("col1", "second-row"));
+
+        assertEquals(1, ColumnIndexUtilities.getMaxUiHeaderRowIndexOfColumn(model, 1));
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetKeyboardHandlerTest.java
@@ -36,6 +36,8 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridTest;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.StringDOMElementColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.StringDOMElementSingletonColumn;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.SelectionExtension;
@@ -46,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -130,6 +133,35 @@ public class BaseGridWidgetKeyboardHandlerTest {
         final BaseGridWidgetKeyboardHandler wrapped = new BaseGridWidgetKeyboardHandler(layer);
         handler = spy(wrapped);
         setupKeyboardOperations();
+    }
+
+    @Test
+    public void testDestroyResourcesOnKeyDown() {
+        when(layer.getGridWidgets()).thenReturn(gridWidgets);
+        when(gridWidget1.isSelected()).thenReturn(true);
+        when(event.getNativeKeyCode()).thenReturn(KeyCodes.KEY_RIGHT);
+
+        final StringDOMElementColumn columnWithAdditionalDomElements = mock(StringDOMElementColumn.class);
+        gridWidget1Data.appendColumn(columnWithAdditionalDomElements);
+
+        handler.onKeyDown(event);
+
+        verify(columnWithAdditionalDomElements).destroyResources();
+    }
+
+    @Test
+    public void testDestroyResourcesAndFlushOnKeyDown() {
+        when(layer.getGridWidgets()).thenReturn(gridWidgets);
+        when(gridWidget1.isSelected()).thenReturn(true);
+        when(event.getNativeKeyCode()).thenReturn(KeyCodes.KEY_RIGHT);
+
+        final StringDOMElementSingletonColumn columnWithAdditionalDomElements = mock(StringDOMElementSingletonColumn.class);
+        gridWidget1Data.appendColumn(columnWithAdditionalDomElements);
+
+        handler.onKeyDown(event);
+
+        verify(columnWithAdditionalDomElements).flush();
+        verify(columnWithAdditionalDomElements).destroyResources();
     }
 
     @Test

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManagerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManagerTest.java
@@ -24,6 +24,7 @@ import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.client.core.types.Transform;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +39,7 @@ import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridTest;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
@@ -542,6 +544,118 @@ public class BaseCellSelectionManagerTest {
         assertEquals(new GridData.SelectedCell(0,
                                                0),
                      gridWidgetData.getSelectedCellsOrigin());
+    }
+
+    @Test
+    public void testAdjustSelectionUpFromDataToHeader() {
+        cellSelectionManager.selectCell(0,
+                                        1,
+                                        false,
+                                        false);
+
+        cellSelectionManager.adjustSelection(SelectionExtension.UP, false);
+
+        final List<GridData.SelectedCell> selectedCells = gridWidgetData.getSelectedCells();
+        Assertions.assertThat(selectedCells).isEmpty();
+
+        final List<GridData.SelectedCell> selectedHeaderCells = gridWidgetData.getSelectedHeaderCells();
+        Assertions.assertThat(selectedHeaderCells).hasSize(1);
+
+        final GridData.SelectedCell selectedHeaderCell = selectedHeaderCells.get(0);
+        Assertions.assertThat(selectedHeaderCell.getColumnIndex()).isEqualTo(1);
+        Assertions.assertThat(selectedHeaderCell.getRowIndex()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAdjustSelectionDownFromHeaderToData() {
+        cellSelectionManager.selectHeaderCell(0,
+                                              1,
+                                              false,
+                                              false);
+
+        cellSelectionManager.adjustSelection(SelectionExtension.DOWN, false);
+
+        final List<GridData.SelectedCell> selectedHeaderCells = gridWidgetData.getSelectedHeaderCells();
+        Assertions.assertThat(selectedHeaderCells).isEmpty();
+
+        final List<GridData.SelectedCell> selectedCells = gridWidgetData.getSelectedCells();
+        Assertions.assertThat(selectedCells).hasSize(1);
+
+        final GridData.SelectedCell selectedCell = selectedCells.get(0);
+        Assertions.assertThat(selectedCell.getColumnIndex()).isEqualTo(1);
+        Assertions.assertThat(selectedCell.getRowIndex()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAdjustSelectionUpInHeader() {
+        col2.getHeaderMetaData().add(new BaseHeaderMetaData("col1", "second-row"));
+
+        cellSelectionManager.selectHeaderCell(1,
+                                              1,
+                                              false,
+                                              false);
+
+        cellSelectionManager.adjustSelection(SelectionExtension.UP, false);
+
+        final List<GridData.SelectedCell> selectedHeaderCells = gridWidgetData.getSelectedHeaderCells();
+        Assertions.assertThat(selectedHeaderCells).hasSize(1);
+
+        final GridData.SelectedCell selectedHeaderCell = selectedHeaderCells.get(0);
+        Assertions.assertThat(selectedHeaderCell.getColumnIndex()).isEqualTo(1);
+        Assertions.assertThat(selectedHeaderCell.getRowIndex()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAdjustSelectionDownInHeader() {
+        col2.getHeaderMetaData().add(new BaseHeaderMetaData("col1", "second-row"));
+
+        cellSelectionManager.selectHeaderCell(0,
+                                              1,
+                                              false,
+                                              false);
+
+        cellSelectionManager.adjustSelection(SelectionExtension.DOWN, false);
+
+        final List<GridData.SelectedCell> selectedHeaderCells = gridWidgetData.getSelectedHeaderCells();
+        Assertions.assertThat(selectedHeaderCells).hasSize(1);
+
+        final GridData.SelectedCell selectedHeaderCell = selectedHeaderCells.get(0);
+        Assertions.assertThat(selectedHeaderCell.getColumnIndex()).isEqualTo(1);
+        Assertions.assertThat(selectedHeaderCell.getRowIndex()).isEqualTo(1);
+    }
+
+    @Test
+    public void testAdjustSelectionRightInHeader() {
+        cellSelectionManager.selectHeaderCell(0,
+                                              0,
+                                              false,
+                                              false);
+
+        cellSelectionManager.adjustSelection(SelectionExtension.RIGHT, false);
+
+        final List<GridData.SelectedCell> selectedHeaderCells = gridWidgetData.getSelectedHeaderCells();
+        Assertions.assertThat(selectedHeaderCells).hasSize(1);
+
+        final GridData.SelectedCell selectedHeaderCell = selectedHeaderCells.get(0);
+        Assertions.assertThat(selectedHeaderCell.getColumnIndex()).isEqualTo(1);
+        Assertions.assertThat(selectedHeaderCell.getRowIndex()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAdjustSelectionLeftInHeader() {
+        cellSelectionManager.selectHeaderCell(0,
+                                              1,
+                                              false,
+                                              false);
+
+        cellSelectionManager.adjustSelection(SelectionExtension.LEFT, false);
+
+        final List<GridData.SelectedCell> selectedHeaderCells = gridWidgetData.getSelectedHeaderCells();
+        Assertions.assertThat(selectedHeaderCells).hasSize(1);
+
+        final GridData.SelectedCell selectedHeaderCell = selectedHeaderCells.get(0);
+        Assertions.assertThat(selectedHeaderCell.getColumnIndex()).isEqualTo(0);
+        Assertions.assertThat(selectedHeaderCell.getRowIndex()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
Dependent on #558 

Ensemble with:
- kiegroup/kie-wb-common#2200
- kiegroup/drools-wb#968