### PR TITLE
Fix enforcer error about commons-logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -944,6 +944,18 @@
       </dependency>
 
       <dependency>
+        <groupId>org.eclipse.jgit</groupId>
+        <artifactId>org.eclipse.jgit</artifactId>
+        <version>${version.org.eclipse.jgit}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-core</artifactId>
         <version>${version.org.keycloak}</version>


### PR DESCRIPTION
My previous PR caused some errors in kie-wb-common and drools-wb like:
```
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (ban-blacklisted-dependencies) @ drools-wb-guided-dtable-editor-api ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: commons-logging:commons-logging:jar:1.1.1
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
```