### PR TITLE
Remove useles property overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,19 +52,13 @@
     <uberfire.version>${project.version}</uberfire.version>
     <version.org.kie>7.15.0-SNAPSHOT</version.org.kie>
     <version.org.kie.soup>${version.org.kie}</version.org.kie.soup>
-    <!-- Exception as it is needed for gwt-maven-plugin version-->
-    <version.com.google.gwt>2.8.2</version.com.google.gwt>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.google.elemental2>1.0.0-beta-1</version.com.google.elemental2>
     <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
-    <version.com.google.guava>20.0</version.com.google.guava>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
-    <!-- JGIT 4.4.1.201607150455-r override can be removed once we use IP BOM which includes https://github.com/jboss-integration/jboss-integration-platform-bom/pull/327 -->
-    <version.org.eclipse.jgit>4.8.0.201706111038-r</version.org.eclipse.jgit>
-    <version.org.apache.sshd>1.6.0</version.org.apache.sshd>
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
     <version.org.freemarker>2.3.26.jbossorg-1</version.org.freemarker>
     <version.org.jboss.errai>4.4.2-SNAPSHOT</version.org.jboss.errai>
@@ -80,7 +74,6 @@
         instance.-->
     <version.org.webjars.bower.jspdf>1.2.61</version.org.webjars.bower.jspdf>
     <version.org.webjars.bowergithub.gliffy.canvas2svg>0.1</version.org.webjars.bowergithub.gliffy.canvas2svg>
-    <version.org.gwtbootstrap3>0.9.3</version.org.gwtbootstrap3>
 
     <version.org.jboss.byteman>3.0.10</version.org.jboss.byteman>
     <version.org.jboss.jboss-dmr>1.4.1.Final</version.org.jboss.jboss-dmr>
@@ -106,7 +99,6 @@
     <version.com.ahome-it.lienzo-core.charts>2.0.241-RC1</version.com.ahome-it.lienzo-core.charts>
     <version.com.ahome-it.lienzo-tests.charts>2.0.241-RC1</version.com.ahome-it.lienzo-tests.charts>
 
-    <version.org.jboss.spec.javax.enterprise.concurrent>1.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent>
     <version.bundle.plugin>3.3.0</version.bundle.plugin><!-- 3.2.0 sometimes fails with NPE during parallel build-->
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
@@ -140,10 +132,6 @@
     <version.org.mariadb.jdbc>1.3.6</version.org.mariadb.jdbc>
     <version.org.mysql-driver>5.1.6</version.org.mysql-driver>
     <version.org.postgres-driver>9.1-901.jdbc4</version.org.postgres-driver>
-
-    <!-- Required since support for ELS 2.x. Keep in sync with kie-parent or remove when those
-          two versions are being updated on the IP BOM.-->
-    <version.commons-cli>1.3.1</version.commons-cli>
 
     <!-- required to fix RHDM-293 -->
     <version.org.apache.logging.log4j.log4j-to-slf4j>2.9.0</version.org.apache.logging.log4j.log4j-to-slf4j>


### PR DESCRIPTION
These overrides are no longer needed, because the versions in question have already been migrated to jboss-integration-platform-parent

```
uberfire-parent overrides 'version.com.google.guava' defined in jboss-integration-platform-parent from '20.0' to '20.0'
uberfire-parent overrides 'version.com.google.gwt' defined in jboss-integration-platform-parent from '2.8.2' to '2.8.2'
uberfire-parent overrides 'version.commons-cli' defined in jboss-integration-platform-parent from '1.3.1' to '1.3.1'
uberfire-parent overrides 'version.org.apache.sshd' defined in jboss-integration-platform-parent from '1.6.0' to '1.6.0'
uberfire-parent overrides 'version.org.eclipse.jgit' defined in jboss-integration-platform-parent from '4.8.0.201706111038-r' to '4.8.0.201706111038-r'
uberfire-parent overrides 'version.org.gwtbootstrap3' defined in jboss-integration-platform-parent from '0.9.3' to '0.9.3'
uberfire-parent overrides 'version.org.jboss.spec.javax.enterprise.concurrent' defined in jboss-integration-platform-parent from '1.0.0.Final' to '1.0.0.Final'
```