### PR TITLE
AF-1636 - Imported projects have wrong config on Git repository config

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/Clone.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/Clone.java
@@ -17,13 +17,11 @@
 package org.uberfire.java.nio.fs.jgit.util.commands;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
 
 import org.eclipse.jgit.internal.ketch.KetchLeaderCache;
 import org.eclipse.jgit.internal.storage.file.WindowCache;
-import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.storage.file.WindowCacheConfig;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.RefSpec;
@@ -40,6 +38,7 @@ import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull
 
 public class Clone {
 
+    public static final String REFS_MIRRORED = "+refs/heads/*:refs/remotes/origin/*";
     private final File repoDir;
     private final String origin;
     private final CredentialsProvider credentialsProvider;
@@ -82,7 +81,7 @@ public class Clone {
 
                 final Collection<RefSpec> refSpecList;
                 if (isMirror) {
-                    refSpecList = singletonList(new RefSpec("+refs/*:refs/*"));
+                    refSpecList = singletonList(new RefSpec(REFS_MIRRORED));
                 } else {
                     refSpecList = emptyList();
                 }
@@ -91,19 +90,6 @@ public class Clone {
                 git.fetch(credentialsProvider,
                           remote,
                           refSpecList);
-
-                if (isMirror) {
-                    final StoredConfig config = git.getRepository().getConfig();
-                    config.setBoolean("remote",
-                                      "origin",
-                                      "mirror",
-                                      true);
-                    try {
-                        config.save();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
 
                 git.syncRemote(remote);
 


### PR DESCRIPTION
Wrong config:
[remote "origin"]
url = https://github.com/porcelli/SampleTest.git
fetch = +refs/:refs/
mirror = true

Config updated:
![image](https://user-images.githubusercontent.com/531351/48587132-0bada000-e900-11e8-9bfa-b021d7b24317.png)

Config via a git clone uri

<img width="644" alt="screenshot 2018-11-15 17 58 33" src="https://user-images.githubusercontent.com/531351/48587143-16683500-e900-11e8-93d6-5960d8ed9eed.png">


Config of a sample repo cloned (not mirrored)


<img width="647" alt="screenshot 2018-11-15 17 59 28" src="https://user-images.githubusercontent.com/531351/48587179-34359a00-e900-11e8-835d-3e74f93ca29c.png">


To test the use case:
Import a repo (i.e. https://github.com/ederign/KieDora.git ) 
Add a hook like this one:
![image](https://user-images.githubusercontent.com/531351/48587248-6f37cd80-e900-11e8-968a-baae670860c4.png)

Do a commit in the repo, see the remote repo updated (but your user should have ssh keys configured and write access to this repo.



