### PR TITLE
Remove slf4j-ext which is not user anywhere

### DIFF
--- a/dashbuilder/dashbuilder-distros/pom.xml
+++ b/dashbuilder/dashbuilder-distros/pom.xml
@@ -120,11 +120,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging</artifactId>
     </dependency>

--- a/dashbuilder/dashbuilder-distros/src/main/assembly/assembly-tomcat-8.xml
+++ b/dashbuilder/dashbuilder-distros/src/main/assembly/assembly-tomcat-8.xml
@@ -28,7 +28,6 @@
         <include>org.jboss.logging:jboss-logging</include>
         <include>org.slf4j:slf4j-api:jar</include>
         <include>org.slf4j:jcl-over-slf4j</include>
-        <include>org.slf4j:slf4j-ext</include>
         <include>org.codehaus.woodstox:woodstox-core-asl</include>
         <include>org.codehaus.woodstox:stax2-api</include>
         <include>wsdl4j:wsdl4j</include>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -442,12 +442,6 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
 

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
@@ -183,12 +183,6 @@
 
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-ext</artifactId>
-        <version>\${version.org.slf4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
         <version>\${version.org.slf4j}</version>
       </dependency>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/pom.xml
@@ -94,11 +94,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-api</artifactId>
     </dependency>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
@@ -30,7 +30,6 @@
         <include>javax.activation:activation:jar</include>
 
         <include>org.slf4j:slf4j-api:jar</include>
-        <include>org.slf4j:slf4j-ext:jar</include>
         <include>ch.qos.cal10n:cal10n-api:jar</include>
 
         <include>org.hibernate.javax.persistence:hibernate-jpa-2.1-api:jar</include>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-webapp/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-webapp/pom.xml
@@ -184,12 +184,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -75,11 +75,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-    </dependency>
-
     <!-- This is a war file, so logback is not in scope test, but in scope compile -->
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
@@ -63,12 +63,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/uberfire-showcase/showcase-distribution-wars/pom.xml
+++ b/uberfire-showcase/showcase-distribution-wars/pom.xml
@@ -107,10 +107,6 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
 

--- a/uberfire-showcase/showcase-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
+++ b/uberfire-showcase/showcase-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
@@ -46,7 +46,6 @@
         <include>javax.activation:activation:jar</include>
 
         <include>org.slf4j:slf4j-api:jar</include>
-        <include>org.slf4j:slf4j-ext:jar</include>
         <!-- Use JUL as logging impl as that is used by Tomcat itself. -->
         <include>org.slf4j:slf4j-jdk14</include>
         <include>ch.qos.cal10n:cal10n-api:jar</include>

--- a/uberfire-showcase/uberfire-client-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-client-webapp/pom.xml
@@ -69,12 +69,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>provided</scope>

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -84,11 +84,6 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-ext</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
 


### PR DESCRIPTION
You can check for yourself by running this in the appformer repo:
`grep 'org.slf4j.*' -r --include=*.java -o -h | sort | uniq`

You'll see that we're only ever using from slf4j is Logger and LoggerFactory that come from slf4j-api
If you're curious which functionality slf4j-ext (which we don't use) provides, you can check its [website](https://www.slf4j.org/extensions.html).