### PR TITLE
[AF-1718] NullPointerException is thrown while creating multiple projects through curl command

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
@@ -156,7 +156,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         this.executorService = executorService;
         this.indexersFactory = indexersFactory;
         this.dispatcherFactory = dispatcherFactory;
-        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, views);
+        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, this::setupWatchService, views);
         ensureCoreIndexerExists();
     }
 
@@ -175,7 +175,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         this.executorService = executorService;
         this.indexersFactory = indexersFactory;
         this.dispatcherFactory = dispatcherFactory;
-        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, views);
+        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, this::setupWatchService, views);
         ensureCoreIndexerExists();
     }
 
@@ -195,7 +195,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         this.executorService = executorService;
         this.indexersFactory = indexersFactory;
         this.dispatcherFactory = dispatcherFactory;
-        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, views);
+        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, this::setupWatchService, views);
         ensureCoreIndexerExists();
     }
 
@@ -217,7 +217,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         this.executorService = executorService;
         this.indexersFactory = indexersFactory;
         this.dispatcherFactory = dispatcherFactory;
-        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, views);
+        this.batchIndex = new BatchIndex(indexEngine, observer, executorService, indexersFactory, dispatcherFactory, this::setupWatchService, views);
         ensureCoreIndexerExists();
     }
 
@@ -237,7 +237,6 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
             ProviderNotFoundException, SecurityException {
         final FileSystem fs = super.getFileSystem(uri);
         setupBatchIndex(fs);
-        setupWatchService(fs);
         return fs;
     }
 
@@ -249,7 +248,6 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         final FileSystem fs = super.newFileSystem(uri,
                                                   env);
         setupBatchIndex(fs);
-        setupWatchService(fs);
         return fs;
     }
 
@@ -281,6 +279,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         }
         final WatchService ws = fs.newWatchService();
         watchServicesByFS.put(fs.getName(), ws);
+        LOGGER.info("Indexing file system. { " + fs.getName() + " }");
 
         final ExecutorService defaultInstance = this.executorService;
 

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/elasticsearch/BatchIndexTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/elasticsearch/BatchIndexTest.java
@@ -41,7 +41,8 @@ import org.uberfire.java.nio.file.OpenOption;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.uberfire.ext.metadata.io.KObjectUtil.toKCluster;
 
 public class BatchIndexTest extends BaseIndexTest {
@@ -213,6 +214,8 @@ public class BatchIndexTest extends BaseIndexTest {
                        Executors.newCachedThreadPool(new DescriptiveThreadFactory()),
                        indexersFactory(),
                        indexerDispatcherFactory(config.getIndexEngine()),
+                       (e) -> {
+                       },
                        DublinCoreView.class).run(ioService().get("git://elastic-temp-repo-test/").getFileSystem(),
                                                  () -> {
                                                      try {

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/infinispan/BatchIndexTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/infinispan/BatchIndexTest.java
@@ -41,7 +41,8 @@ import org.uberfire.java.nio.file.OpenOption;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.uberfire.ext.metadata.io.KObjectUtil.toKCluster;
 
 public class BatchIndexTest extends BaseIndexTest {
@@ -213,6 +214,8 @@ public class BatchIndexTest extends BaseIndexTest {
                        Executors.newCachedThreadPool(new DescriptiveThreadFactory()),
                        indexersFactory(),
                        indexerDispatcherFactory(config.getIndexEngine()),
+                       (e) -> {
+                       },
                        DublinCoreView.class).run(ioService().get("git://elastic-temp-repo-test/").getFileSystem(),
                                                  () -> {
                                                      try {

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/lucene/BatchIndexTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/lucene/BatchIndexTest.java
@@ -37,7 +37,8 @@ import org.uberfire.java.nio.file.OpenOption;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.uberfire.ext.metadata.io.KObjectUtil.toKCluster;
 
 public class BatchIndexTest extends BaseIndexTest {
@@ -191,24 +192,27 @@ public class BatchIndexTest extends BaseIndexTest {
 
         new BatchIndex(config.getIndexEngine(),
                        new Observer() {
+
                            @Override
                            public void information(final String message) {
 
-                           }
+                       }
 
                            @Override
                            public void warning(final String message) {
 
-                           }
+                       }
 
                            @Override
                            public void error(final String message) {
 
-                           }
+                       }
                        },
                        Executors.newCachedThreadPool(new DescriptiveThreadFactory()),
                        indexersFactory(),
                        indexerDispatcherFactory(config.getIndexEngine()),
+                       (e) -> {
+                       },
                        DublinCoreView.class).run(ioService().get("git://temp-repo-test/").getFileSystem(),
                                                  () -> {
                                                      try {


### PR DESCRIPTION
Establishing order between workbench indexing and file system indexing