### PR TITLE
[AF-1725] Make it possible to identify currently enabled business-central profile (for selenium testing)

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayoutImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayoutImpl.java
@@ -23,11 +23,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.animation.client.Animation;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Position;
@@ -49,6 +52,7 @@ import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.util.Layouts;
 import org.uberfire.client.workbench.docks.UberfireDocksContainer;
+import org.uberfire.client.workbench.events.WorkbenchProfileCssClass;
 import org.uberfire.client.workbench.widgets.dnd.WorkbenchDragAndDropManager;
 import org.uberfire.client.workbench.widgets.dnd.WorkbenchPickupDragController;
 import org.uberfire.mvp.Command;
@@ -64,11 +68,13 @@ public class WorkbenchLayoutImpl implements WorkbenchLayout {
 
     public static final String UF_MAXIMIZED_PANEL = "uf-maximized-panel";
 
+    public static final String UF_ROOT_CSS_CLASS = "uf-workbench-layout";
     /**
      * Holder for style information that was modified in order to maximize a panel.
      */
 
     private static final int MAXIMIZED_PANEL_Z_INDEX = 100;
+
     /**
      * Dock Layout panel: in center root perspective and also (if available) with east west south docks
      */
@@ -138,7 +144,7 @@ public class WorkbenchLayoutImpl implements WorkbenchLayout {
         headerPanel.setId("workbenchHeaderPanel");
         footerPanel.setId("workbenchFooterPanel");
         dragController.getBoundaryPanel().ensureDebugId("workbenchDragBoundary");
-        root.addStyleName("uf-workbench-layout");
+        root.addStyleName(UF_ROOT_CSS_CLASS);
     }
 
     @Override
@@ -322,6 +328,12 @@ public class WorkbenchLayoutImpl implements WorkbenchLayout {
              });
 
         return instances;
+    }
+
+    public void addWorkbenchProfileCssClass(@Observes WorkbenchProfileCssClass workbenchProfileCssClass) {
+        root.removeStyleName(root.getStyleName());
+        root.addStyleName(UF_ROOT_CSS_CLASS);
+        root.addStyleName(workbenchProfileCssClass.getClassName());
     }
 
     protected Div getHeaderPanel() {

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/WorkbenchProfileCssClass.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/WorkbenchProfileCssClass.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.workbench.events;
+
+import org.uberfire.mvp.PlaceRequest;
+
+/**
+ * An event to programmatically add a css class to Workbench root div
+ * This is used to differentiate business central profiles
+ */
+public class WorkbenchProfileCssClass  {
+
+    private String className;
+
+    public WorkbenchProfileCssClass(final String className) {
+        this.className = className;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/WorkbenchLayoutImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/WorkbenchLayoutImplTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.client.workbench.docks.UberfireDocksContainer;
+import org.uberfire.client.workbench.events.WorkbenchProfileCssClass;
 import org.uberfire.client.workbench.widgets.dnd.WorkbenchDragAndDropManager;
 import org.uberfire.client.workbench.widgets.dnd.WorkbenchPickupDragController;
 import org.uberfire.mvp.Command;
@@ -237,5 +238,18 @@ public class WorkbenchLayoutImplTest {
         verify(footerPanel,
                times(2)).appendChild(any());
         verify(root).setFooterWidget(any());
+    }
+
+    @Test
+    public void addWorkbenchProfileCssClass() {
+
+        when(root.getStyleName()).thenReturn("current stylename");
+
+        workbenchLayout.addWorkbenchProfileCssClass(new WorkbenchProfileCssClass("dora"));
+
+        verify(root).removeStyleName("current stylename");
+        verify(root).addStyleName(WorkbenchLayoutImpl.UF_ROOT_CSS_CLASS);
+        verify(root).addStyleName("dora");
+
     }
 }


### PR DESCRIPTION
@jesuino @jhrcek does that works for you?

https://cl.ly/90d703c9cfea/%255B6fa93efe9abf842e880d3dfec28d4e8e%255D_Image%2525202018-11-27%252520at%2525207.22.09%252520PM.png

@jesuino please fire the event when the profile is selected/changed (also on startup)

@jhrcek $('.uf-workbench-layout') is a selector that will containg the css class.