### PR TITLE
[AF-1713]: Added clustered event when deleting project

### DIFF
--- a/uberfire-structure/uberfire-structure-api/src/main/java/org/guvnor/structure/repositories/RepositoryRemovedEvent.java
+++ b/uberfire-structure/uberfire-structure-api/src/main/java/org/guvnor/structure/repositories/RepositoryRemovedEvent.java
@@ -16,8 +16,10 @@
 package org.guvnor.structure.repositories;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
+import org.uberfire.commons.clusterapi.Clustered;
 
 @Portable
+@Clustered
 public class RepositoryRemovedEvent {
 
     private Repository repository;


### PR DESCRIPTION
@jhrcek Added Clustered to DeleteProjectEvent. Now, when a project is deleted all nodes of the cluster are informed. If they are in the same View and any node deletes the project, view is closed and all return to LibraryView.