### PR TITLE
Configs and hooks of the repository should be preserved

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/CreateRepository.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/CreateRepository.java
@@ -56,6 +56,7 @@ public class CreateRepository {
 
     public Optional<Git> execute() {
         try {
+            boolean newRepository = !repoDir.exists();
             final org.eclipse.jgit.api.Git _git = org.eclipse.jgit.api.Git.init().setBare(true).setDirectory(repoDir).call();
 
             if (leaders != null) {
@@ -78,7 +79,7 @@ public class CreateRepository {
 
             final org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repo);
 
-            if (hookDir != null) {
+            if (setupGitHooks(newRepository)) {
                 final File repoHookDir = new File(repoDir,
                                                   "hooks");
 
@@ -101,5 +102,9 @@ public class CreateRepository {
         } catch (final Exception ex) {
             throw new IOException(ex);
         }
+    }
+
+    private boolean setupGitHooks(boolean newRepository) {
+        return newRepository && hookDir != null;
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
@@ -239,7 +239,28 @@ public class JGitForkTest extends AbstractTestInfra {
         provider.newFileSystem(forkUri,
                                forkEnv);
     }
-    
+
+    @Test
+    public void testForkWithoutHookDirShouldNotBeUpdatedAfterGitHookDirAdded() throws IOException, GitAPIException {
+
+        final File hooksDir = createTempDirectory();
+
+        final File parentFolder = createTempDirectory();
+
+        final File gitSource = new File(parentFolder,
+                                        SOURCE_GIT + ".git");
+
+        writeMockHook(hooksDir, PostCommitHook.NAME);
+        writeMockHook(hooksDir, PreCommitHook.NAME);
+
+        final Git repo = new CreateRepository(gitSource, null).execute().get();
+        final Git existentRepoWithHookDirDefined = new CreateRepository(gitSource, hooksDir).execute().get();
+
+        File[] hooks = new File(existentRepoWithHookDirDefined.getRepository().getDirectory(), "hooks").listFiles();
+        assertThat(hooks).isEmpty();
+    }
+
+
     @Test
     public void testForkWithHookDir() throws IOException, GitAPIException {
     	final File hooksDir = createTempDirectory();


### PR DESCRIPTION
To test this:

Current behavior:

1-) Open BC and create some repos without git hook dir defined.

2-) Shutdown BC and setup git hooks template dir -Dorg.uberfire.nio.git.hooks=/tmp/hooks

3-) Run BC and see ALL repos with hooks:


![image](https://user-images.githubusercontent.com/531351/49484153-f98a9780-f803-11e8-983f-02838572acbc.png)


After this PR:

1-) Open BC and create some repos without git hook dir defined.

2-) Shutdown BC and setup git hooks template dir -Dorg.uberfire.nio.git.hooks=/tmp/hooks

3-) Run BC and only new repos has the template.

![image](https://user-images.githubusercontent.com/531351/49484165-0f985800-f804-11e8-8c29-57cb61ce2aee.png)
