### PR TITLE
[AF-1744] File System Cache is not updated when project is deleted

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -409,7 +409,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider, Dispos
         fsManager.getOpenFileSystems().forEach(JGitFileSystem::close);
         shutdownSSH();
         forceStopDaemon();
-        fsManager.clear();
+        fsManager.shutdown();
     }
 
     /**

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemManagerMessageWrapper.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemManagerMessageWrapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.manager;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class JGitFileSystemManagerMessageWrapper implements Serializable {
+
+    private final String nodeId;
+    private final JGitFileSystemManagerMessage type;
+    private final String message;
+
+    public JGitFileSystemManagerMessageWrapper(String nodeId, JGitFileSystemManagerMessage type, String message) {
+        this.nodeId = nodeId;
+        this.type = type;
+        this.message = message;
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public JGitFileSystemManagerMessage getType() {
+        return type;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public enum JGitFileSystemManagerMessage {
+        FS_REMOVED
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JGitFileSystemManagerMessageWrapper that = (JGitFileSystemManagerMessageWrapper) o;
+        return Objects.equals(nodeId, that.nodeId) &&
+                type == that.type &&
+                Objects.equals(message, that.message);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(nodeId, type, message);
+    }
+}


### PR DESCRIPTION
<img width="1836" alt="screenshot 2018-12-11 15 10 28" src="https://user-images.githubusercontent.com/531351/49831658-71a41080-fd62-11e8-9960-013830d7543f.png">

This clears the FS cache after a project deletion on another node.

Drools wb War to test it: https://www.dropbox.com/s/j6pd27uzfke1rjt/drools-wb-webapp.war?dl=0

@jhrcek and @adrielparedes it's important to keep the library state like the video (on space screen) to avoid other nonrelated issues (that will be addressed later).

This PR was built over https://github.com/kiegroup/appformer/pull/554

@jhrcek @adrielparedes what do you think of after approval merging this small chunks?

Like this one and https://github.com/kiegroup/appformer/pull/554 ?