### PR TITLE
Update the extra-enforcer-rules version to 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>extra-enforcer-rules</artifactId>
-              <version>1.0-beta-4-jbossorg-1</version>
+              <version>1.0</version>
             </dependency>
           </dependencies>
           <executions>


### PR DESCRIPTION
Same case as https://github.com/kiegroup/kie-soup/pull/78

Move the extra-enforcer-rules version to 1.0 so that the dependency is available from maven central