### PR TITLE
JBPM-7855 - Stunner cannot export diagrams (after any exception on client)

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjector.java
@@ -35,8 +35,8 @@ import org.uberfire.ext.editor.commons.client.file.exports.FileExportResources;
 @ApplicationScoped
 public class FileExportScriptInjector {
 
-    public static final String NS = "org.uberfire.ext.editor.commons.client.file.exports.jso.";
     public static final String NS_SEPARATOR = ".";
+    public static final String NS = "window" + NS_SEPARATOR;
     public static final String JS_OBJ_SUFFIX = " || {};";
 
     private final Consumer<String> scriptInjector;

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/JsFileSaver.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/JsFileSaver.java
@@ -17,6 +17,7 @@
 package org.uberfire.ext.editor.commons.client.file.exports.jso;
 
 import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import org.jboss.errai.common.client.dom.Blob;
 
@@ -25,7 +26,7 @@ import org.jboss.errai.common.client.dom.Blob;
  * Provided by the webjar <code>org.webjars.bower.filesaver</code>.
  * @see <a href="https://github.com/eligrey/FileSaver.js">FileSaver.js</a>
  */
-@JsType(isNative = true)
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public class JsFileSaver {
 
     /**

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/JsPdf.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/JsPdf.java
@@ -18,6 +18,7 @@ package org.uberfire.ext.editor.commons.client.file.exports.jso;
 
 import jsinterop.annotations.JsConstructor;
 import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
 /**
@@ -25,7 +26,7 @@ import jsinterop.annotations.JsType;
  * Provided by the webjar <code>org.webjars.bower.jspdf</code>.
  * @see <a href="https://github.com/MrRio/jsPDF">jsPDF.js</a>
  */
-@JsType(isNative = true)
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
 public class JsPdf {
 
     /**

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjectorTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/FileExportScriptInjectorTest.java
@@ -29,10 +29,12 @@ import org.uberfire.ext.editor.commons.client.file.exports.FileExportResources;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.uberfire.ext.editor.commons.client.file.exports.jso.FileExportScriptInjector.buildNamespaceObject;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class FileExportScriptInjectorTest {
 
+    public static final String NS = "window.";
     private FileExportScriptInjector tested;
 
     @Mock
@@ -50,8 +52,8 @@ public class FileExportScriptInjectorTest {
         verify(scriptInjector,
                times(1)).accept(scriptCaptor.capture());
         final String script = scriptCaptor.getValue();
-        final String fsNsObject = FileExportScriptInjector.buildNamespaceObject(JsFileSaver.class.getName() + ".saveAs");
-        final String jsPdfNsObject = FileExportScriptInjector.buildNamespaceObject(JsPdf.class.getName());
+        final String fsNsObject = buildNamespaceObject(NS + JsFileSaver.class.getSimpleName() + ".saveAs");
+        final String jsPdfNsObject = buildNamespaceObject(NS + JsPdf.class.getSimpleName());
         final String c2sNsObject = FileExportResources.INSTANCE.canvas2svg().getText();
         assertEquals("var " +
                              fsNsObject +
@@ -61,7 +63,7 @@ public class FileExportScriptInjectorTest {
                              jsPdfNsObject +
                              " = function(settings) {\n" +
                              "jsPdf\n" +
-                             "var saveAs = org.uberfire.ext.editor.commons.client.file.exports.jso.JsFileSaver.saveAs; " +
+                             "var saveAs = " + NS + "JsFileSaver.saveAs; " +
                              "return new jsPDF(settings);};" + "\n" +
                              c2sNsObject + "\n",
                      script);
@@ -69,33 +71,10 @@ public class FileExportScriptInjectorTest {
 
     @Test
     public void testNamespaces() {
-        assertEquals(
-                "org = org || {};\n" +
-                        "org.uberfire = org.uberfire || {};\n" +
-                        "org.uberfire.ext = org.uberfire.ext || {};\n" +
-                        "org.uberfire.ext.editor = org.uberfire.ext.editor || {};\n" +
-                        "org.uberfire.ext.editor.commons = org.uberfire.ext.editor.commons || {};\n" +
-                        "org.uberfire.ext.editor.commons.client = org.uberfire.ext.editor.commons.client || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file = org.uberfire.ext.editor.commons.client.file || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file.exports = org.uberfire.ext.editor.commons.client.file.exports || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file.exports.jso = org.uberfire.ext.editor.commons.client.file.exports.jso || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file.exports.jso.JsFileSaver",
-                FileExportScriptInjector.buildNamespaceObject(JsFileSaver.class.getName())
-        );
-        assertEquals(
-                "org = org || {};\n" +
-                        "org.uberfire = org.uberfire || {};\n" +
-                        "org.uberfire.ext = org.uberfire.ext || {};\n" +
-                        "org.uberfire.ext.editor = org.uberfire.ext.editor || {};\n" +
-                        "org.uberfire.ext.editor.commons = org.uberfire.ext.editor.commons || {};\n" +
-                        "org.uberfire.ext.editor.commons.client = org.uberfire.ext.editor.commons.client || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file = org.uberfire.ext.editor.commons.client.file || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file.exports = org.uberfire.ext.editor.commons.client.file.exports || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file.exports.jso = org.uberfire.ext.editor.commons.client.file.exports.jso || {};\n" +
-                        "org.uberfire.ext.editor.commons.client.file.exports.jso.JsPdf",
-                FileExportScriptInjector.buildNamespaceObject(JsPdf.class.getName())
-        );
-        assertEquals("nonamespace",
-                     FileExportScriptInjector.buildNamespaceObject("nonamespace"));
+        assertEquals("window = window || {};\n" + NS + "JsFileSaver",
+                     buildNamespaceObject(NS + JsFileSaver.class.getSimpleName()));
+        assertEquals("window = window || {};\n" + NS + "JsPdf",
+                     buildNamespaceObject(NS + JsPdf.class.getSimpleName()));
+        assertEquals("nonamespace", buildNamespaceObject("nonamespace"));
     }
 }


### PR DESCRIPTION
The problem was caused after any exception on client, the native libraries used on the export was not working anymore, seems that they were unloaded, getting NPE when trying to acess them on all the export formats.

**Solution:** 

Changed the native libs that use JsInterop setting the namespace **GLOBAL**:
 `@JsType(isNative = true, namespace = JsPackage.GLOBAL)`. 
Some adjustments were necessary on the `FileExportScriptInjector` to make these changes work.

Now if we get any exception on client, it is still possible to export Diagrams without any error, the native libraries are still loaded as expect.

@romartin @hasys 