### PR TITLE
AF-1758: Use Patternfly C3 CSS classes instead injecting C3 CSS

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
@@ -225,24 +225,6 @@
               </resources>
             </configuration>
           </execution>
-          <execution>
-            <id>copy-c3-resources-css</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}/org/dashbuilder/renderer/c3/client/exports/css</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.build.directory}/c3/META-INF/resources/webjars/c3/${version.org.webjars.bower.c3}</directory>
-                  <includes>
-                    <include>c3.min.css</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/exports/NativeLibraryResources.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/exports/NativeLibraryResources.java
@@ -14,6 +14,4 @@ public interface NativeLibraryResources extends ClientBundle {
     @Source("js/c3.js")
     TextResource c3js();
 
-    @Source("css/c3.min.css")
-    TextResource c3css();
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/exports/ResourcesInjector.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/exports/ResourcesInjector.java
@@ -1,7 +1,5 @@
 package org.dashbuilder.renderer.c3.client.exports;
 
-import com.google.gwt.dom.client.StyleInjector;
-
 public class ResourcesInjector {
 
     static boolean injected;
@@ -14,8 +12,6 @@ public class ResourcesInjector {
     }
 
     private static void injectAllResources() {
-        String c3css = NativeLibraryResources.INSTANCE.c3css().getText();
-        StyleInjector.inject(c3css + ".c3-tooltip td{color: #000}");
         JavaScriptInjector.inject(NativeLibraryResources.INSTANCE.d3js().getText());
         JavaScriptInjector.inject(NativeLibraryResources.INSTANCE.c3js().getText());
     }


### PR DESCRIPTION
Removed C3 default CSS and let patternfly C3 CSS take over.