### PR TITLE
AF-1749: C3 Bubble Chart does not filter data correctly and display an error

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
@@ -104,7 +104,11 @@
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.gwtbootstrap3</groupId>
+      <artifactId>gwtbootstrap3</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
 

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/C3Displayer.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/C3Displayer.java
@@ -68,6 +68,10 @@ public abstract class C3Displayer<V extends C3Displayer.View> extends AbstractGw
         void setFilterLabelSet(FilterLabelSet filterLabelSet);
         
         void setBackgroundColor(String color);
+        
+        void noData();
+        
+        void setSize(int width, int height);
 
     }
     
@@ -114,10 +118,16 @@ public abstract class C3Displayer<V extends C3Displayer.View> extends AbstractGw
 
     @Override
     protected void updateVisualization() {
-        C3ChartConf conf = buildConfiguration();
-        getView().updateChart(conf);
-        updateFilterStatus();
-        applyPropertiesToView();
+        if(dataSet.getRowCount() == 0) {
+            getView().setSize(displayerSettings.getChartWidth(), 
+                              displayerSettings.getChartHeight());
+            getView().noData();
+        } else {
+            C3ChartConf conf = buildConfiguration();
+            getView().updateChart(conf);
+            updateFilterStatus();
+            applyPropertiesToView();
+        }
     }
 
     protected C3ChartConf buildConfiguration() {

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/C3DisplayerView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/C3DisplayerView.java
@@ -10,6 +10,7 @@ import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.gwtbootstrap3.client.ui.Label;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Panel;
@@ -78,10 +79,11 @@ public abstract class C3DisplayerView<P extends C3Displayer>
     
     @Override
     public void noData() {
-        FlowPanel noDataPanel = new FlowPanel();
+        FlowPanel noDataPanel = GWT.create(FlowPanel.class);
         noDataPanel.setWidth(width + "px");
         noDataPanel.setHeight(height + "px");
-        Label lblNoData = new Label(C3DisplayerConstants.INSTANCE.common_noData());
+        Label lblNoData = GWT.create(Label.class);
+        lblNoData.setText(C3DisplayerConstants.INSTANCE.common_noData());
         noDataPanel.add(lblNoData);
         displayerPanel.clear();
         displayerPanel.add(noDataPanel);
@@ -91,7 +93,6 @@ public abstract class C3DisplayerView<P extends C3Displayer>
     public void setSize(int width, int height) {
         this.width = width;
         this.height = height;
-        
     }
     
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/C3DisplayerView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/java/org/dashbuilder/renderer/c3/client/C3DisplayerView.java
@@ -5,10 +5,10 @@ import org.dashbuilder.displayer.client.AbstractGwtDisplayerView;
 import org.dashbuilder.renderer.c3.client.jsbinding.C3;
 import org.dashbuilder.renderer.c3.client.jsbinding.C3Chart;
 import org.dashbuilder.renderer.c3.client.jsbinding.C3ChartConf;
-import org.dashbuilder.renderer.c3.client.jsbinding.C3Padding;
 import org.dashbuilder.renderer.c3.client.resources.i18n.C3DisplayerConstants;
 import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.common.client.ui.ElementWrapperWidget;
+import org.gwtbootstrap3.client.ui.Label;
 
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HTML;
@@ -24,6 +24,8 @@ public abstract class C3DisplayerView<P extends C3Displayer>
     
     private HTML titleHtml = new HTML();
     private C3Chart chart;
+    private int width;
+    private int height;
     
     @Override
     public void init(P presenter) {
@@ -72,6 +74,24 @@ public abstract class C3DisplayerView<P extends C3Displayer>
         chart.getElement().getElementsByTagName("svg")
                           .getItem(0).getStyle()
                           .setBackgroundColor(color);
+    }
+    
+    @Override
+    public void noData() {
+        FlowPanel noDataPanel = new FlowPanel();
+        noDataPanel.setWidth(width + "px");
+        noDataPanel.setHeight(height + "px");
+        Label lblNoData = new Label(C3DisplayerConstants.INSTANCE.common_noData());
+        noDataPanel.add(lblNoData);
+        displayerPanel.clear();
+        displayerPanel.add(noDataPanel);
+    }
+    
+    @Override
+    public void setSize(int width, int height) {
+        this.width = width;
+        this.height = height;
+        
     }
     
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/test/java/org/dashbuilder/renderer/c3/client/C3DisplayerGeneralTests.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/test/java/org/dashbuilder/renderer/c3/client/C3DisplayerGeneralTests.java
@@ -2,6 +2,7 @@ package org.dashbuilder.renderer.c3.client;
 
 import static org.dashbuilder.dataset.ExpenseReportsData.COLUMN_AMOUNT;
 import static org.dashbuilder.dataset.ExpenseReportsData.COLUMN_DATE;
+import static org.dashbuilder.dataset.ExpenseReportsData.COLUMN_ID;
 import static org.dashbuilder.dataset.group.AggregateFunctionType.SUM;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -13,6 +14,7 @@ import java.util.List;
 
 import org.dashbuilder.dataset.DataColumn;
 import org.dashbuilder.dataset.DataSet;
+import org.dashbuilder.dataset.filter.FilterFactory;
 import org.dashbuilder.displayer.DisplayerSettings;
 import org.dashbuilder.displayer.DisplayerSettingsFactory;
 import org.dashbuilder.renderer.c3.client.charts.line.C3LineChartDisplayer;
@@ -20,6 +22,7 @@ import org.dashbuilder.renderer.c3.client.jsbinding.C3ChartConf;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -89,6 +92,21 @@ public class C3DisplayerGeneralTests extends C3BaseTest {
         assertArrayEquals(displayer.createCategories(), categories.toArray());
         assertEquals(createdSeries[0].length, seriesColumn.getValues().size() + 1);
         assertEquals(createdSeries[0][0], seriesColumn.getId());
+    }
+    
+    @Test
+    public void c3NoData() {
+        DisplayerSettings noData = DisplayerSettingsFactory.newLineChartSettings()
+                .dataset(EXPENSES)
+                .filter(COLUMN_ID, FilterFactory.isNull())
+                .group(COLUMN_DATE)
+                .column(COLUMN_DATE)
+                .column(COLUMN_AMOUNT, SUM)
+                .buildSettings();
+        displayer = c3LineChartDisplayer(noData);
+        displayer.draw();
+        C3LineChartDisplayer.View view = displayer.getView();
+        verify(view).noData();
     }
 
 }


### PR DESCRIPTION
Fixing noData state. Now when there's no data the chart won't even attempt to render, instead it will show a no data info. This fixes the bubble chart issue.

