### PR TITLE
DROOLS-3344: [DMN Designer] Data Types - UX improvements in the Data Type List View

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQuery.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQuery.java
@@ -17,6 +17,7 @@
 package org.uberfire.client.views.pfly.selectpicker;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import elemental2.dom.Element;
 import elemental2.dom.Node;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
@@ -30,6 +31,9 @@ public abstract class JQuery {
     @JsMethod(namespace = GLOBAL, name = "jQuery")
     public native static JQuery $(final Node selector);
 
+    @JsMethod(namespace = GLOBAL, name = "jQuery")
+    public native static JQuery $(final String selector);
+
     public native JQuery animate(final JavaScriptObject properties,
                                  final int duration);
 
@@ -41,6 +45,8 @@ public abstract class JQuery {
     public native JQuery css(final JavaScriptObject properties);
 
     public native JQuery detach();
+
+    public native JQueryList<Element> filter(final String selector);
 
     @JsFunction
     public interface CallbackFunction {

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQueryList.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQueryList.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.selectpicker;
+
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true)
+public abstract class JQueryList<T> {
+
+    public int length;
+
+    public abstract T get(final int index);
+}


### PR DESCRIPTION
# DROOLS-3344

See https://issues.jboss.org/browse/DROOLS-3344

This PR introduces two king of enhancements: **I) The introduction of keyboard shortcuts** in the Data Types tab, and **II) Visual changes** to clarify some concepts to the user.

## Keyboard shortcuts:

### Navigation based on arrows:
Now users can use <kbd>↑</kbd> and <kbd>↓</kbd> to navigate between Data Types, and expand/collapse by using <kbd>→</kbd>/<kbd>←</kbd>, respectively:
![navigation-arrows](https://user-images.githubusercontent.com/1079279/50112353-2ee0ad80-0226-11e9-9515-82440b92e7b6.gif)

Also, when users are searching for some DT, they can just press <kbd>Tab</kbd> to navigate in the results (ahh.. but they can press <kbd>↓</kbd> to go to the first result too):
![tab-arrows](https://user-images.githubusercontent.com/1079279/50112352-2ee0ad80-0226-11e9-804a-c6dc0cd1d4da.gif)

BTW.. the navigation can be disabled by pressing <kbd>Esc</kbd>.

### Updating Data Types:
When users want to update a Data Type, they just need to press <kbd>Ctrl</kbd> + <kbd>E</kbd> to activate the edit mode, and then, they can save the changes by pressing <kbd>Ctrl</kbd> + <kbd>S</kbd>:
![edit-mode-dtrl-e](https://user-images.githubusercontent.com/1079279/50112351-2ee0ad80-0226-11e9-9bf8-c203afe6166a.gif)

However, if they don't want to update anything, they can close the edit mode by pressing <kbd>Esc</kbd>:
![edit-mode-by-esc](https://user-images.githubusercontent.com/1079279/50112349-2e481700-0226-11e9-8a76-fca903573aff.gif)

### Creating Data Types:
Now the flow for creating Data Types is improved to avoid the use of the mouse. When users want to create a nested DT, they can just press <kbd>Ctrl</kbd> + <kbd>N</kbd>, or <kbd>Ctrl</kbd> + <kbd>U</kbd> for a DT above, or even <kbd>Ctrl</kbd> + <kbd>D</kbd> for a DT below:
![many-things-creation-easy](https://user-images.githubusercontent.com/1079279/50112350-2ee0ad80-0226-11e9-9478-7d2f9043b424.gif)


### List of shortcuts:
<kbd>↑</kbd> - Go to the next Data Type
<kbd>↓</kbd> - Go to the previous Data Type
<kbd>→</kbd> - Expand the Data Type
<kbd>←</kbd> - Collapse the Data Type
<kbd> Ctrl </kbd> + <kbd>E</kbd> - Activate edit mode
<kbd> Ctrl </kbd> + <kbd>S</kbd> - Save the Data Type
<kbd> Ctrl </kbd> + <kbd>B</kbd> - Create a nested Data Type
<kbd> Ctrl </kbd> + <kbd>U</kbd> - Create a Data Type above (up)
<kbd> Ctrl </kbd> + <kbd>D</kbd> - Create a Data Type below (down)
<kbd> Ctrl </kbd> + <kbd>Backspace</kbd> - Delete the Data Type
<kbd>Esc</kbd> - Exit

## Visual changes:
<img width="1750" alt="screen shot 2018-12-17 at 1 59 57 pm" src="https://user-images.githubusercontent.com/1079279/50112077-7e72a980-0225-11e9-9f75-d24451360805.png">


---


Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/586
- https://github.com/kiegroup/kie-wb-common/pull/2352
