### PR TITLE
Fix NPE in PreferenecBeanStoreImpl

### DIFF
--- a/uberfire-preferences/uberfire-preferences-backend/src/main/java/org/uberfire/preferences/backend/PreferenceBeanStoreImpl.java
+++ b/uberfire-preferences/uberfire-preferences-backend/src/main/java/org/uberfire/preferences/backend/PreferenceBeanStoreImpl.java
@@ -423,14 +423,8 @@ public class PreferenceBeanStoreImpl implements PreferenceBeanServerStore {
                 final String[] parents = portablePreference.parents();
 
                 for (String parent : parents) {
-                    if (parent != null & !parent.isEmpty()) {
-                        List<BasePreferencePortable> children = childrenByParent.get(parent);
-                        if (children == null) {
-                            children = new ArrayList<>();
-                            childrenByParent.put(parent,
-                                                 children);
-                        }
-
+                    if (parent != null && !parent.isEmpty()) {
+                        List<BasePreferencePortable> children = childrenByParent.computeIfAbsent(parent, k -> new ArrayList<>());
                         children.add(portablePreference);
                     }
                 }


### PR DESCRIPTION
I'm in a desparate situation trying to hunt down one Unexpected error which randomly appears in one of our selenium tests suites (1-2x in a suite of 20 tests). It only happens from time to time in random tests. But when it happens, it's always after the initial load of the home page:

![screenshot from 2019-01-08 10-28-33](https://user-images.githubusercontent.com/2716069/50821759-506a1c00-1330-11e9-9143-e6b6ce149a2f.png)

The error is:
```
Uncaught exception: Client-side exception occurred although RPC call succeeded. Caused by: (TypeError) : this.f is undefined
```

There is no additional detail available, but @tiagobento told me this error means that this error is thrown from success callback of some RPC call.

I'm trying the following to identify the source of this NPE: 
1. I logged in and downloaded HAR file (json file capturing client-server HTTP communication) from chrome's dev tools
2. grepped all RPC call commands done after login

<details>
  <summary>(here's the list)</summary>
  <pre>
d344ef6364d06ec6172279b361e2b44810cae5af82c6ee6f15bab63e599d10,CommandType:FinishAssociation
org.uberfire.ext.layout.editor.api.PerspectiveServices:RPC,CommandType:listLayoutTemplates:
org.uberfire.workbench.services.WorkbenchServices:RPC,CommandType:isWorkbenchOnCluster:
org.jbpm.workbench.wi.casemgmt.service.CaseProvisioningService:RPC,CommandType:getApplicationContext:
org.uberfire.backend.authz.AuthorizationService:RPC,CommandType:loadPolicy:
org.uberfire.backend.plugin.RuntimePluginService:RPC,CommandType:listFrameworksContent:
org.uberfire.ext.plugin.service.PluginServices:RPC,CommandType:listRuntimePlugins:
org.uberfire.ext.plugin.service.PluginServices:RPC,CommandType:getMediaServletURI:
org.uberfire.experimental.service.backend.BackendExperimentalFeatureDefRegistry:RPC,CommandType:loadFeatureDefinitions:java.util.Collection:
org.uberfire.experimental.service.backend.BackendExperimentalFeaturesRegistryService:RPC,CommandType:getExperimentalFeaturesSession:
org.uberfire.backend.plugin.RuntimePluginService:RPC,CommandType:getRuntimePlugins:
org.ext.uberfire.social.activities.service.SocialUserRepositoryAPI:RPC,CommandType:findSocialUser:java.lang.String:
org.dashbuilder.navigation.service.PerspectivePluginServices:RPC,CommandType:listPlugins:
cdi.event:Dispatcher,CommandType:AttachRemote
cdi.event:Dispatcher,CommandType:RemoteSubscribe
org.uberfire.backend.plugin.RuntimePluginService:RPC,CommandType:listPluginsContent:
org.uberfire.ext.plugin.service.PluginServices:RPC,CommandType:listDynamicMenus:
cdi.event:Dispatcher,CommandType:RemoteSubscribe
org.guvnor.common.services.shared.config.AppConfigService:RPC,CommandType:loadPreferences:
org.uberfire.backend.plugin.RuntimePluginService:RPC,CommandType:getTemplateContent:java.lang.String:
org.dashbuilder.navigation.service.NavigationServices:RPC,CommandType:loadNavTree:
org.kie.workbench.common.profile.api.preferences.ProfileService:RPC,CommandType:isForce: NO
org.uberfire.preferences.shared.bean.PreferenceBeanServerStore:RPC,CommandType:load:org.uberfire.preferences.shared.bean.BasePreferencePortable:
  </pre>
</details>

3. Checked the services with IntelliJ code analysis and found the code changed in this PR has NPE potential (the `&` operator doesn't have [short-circuit semantics](https://stackoverflow.com/questions/8759868/java-logical-operator-short-circuiting#answer-8759917) that `&&` has, so if `parent` is null, `parent.isEmpty()` would throw NPE)

This will probably not fix my error (I'll have to look at all the client-side places where these services are called) but it still fixes one potential NPE.

Now I'm going to look at all the client-side places that call these services to try to find more NPE potential there. If you have tips on how to track this errror down easier, please let me know.