### PR TITLE
Add test resolve from parent pom

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GAVResolverFromParentPomTest.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GAVResolverFromParentPomTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.m2repo.backend.server;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.apache.commons.fileupload.FileItem;
+import org.appformer.maven.support.PomModel;
+import org.guvnor.m2repo.backend.server.helpers.FormData;
+import org.guvnor.m2repo.backend.server.helpers.HttpPostHelper;
+import org.guvnor.m2repo.backend.server.helpers.PomModelResolver;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.guvnor.m2repo.backend.server.M2RepoServiceCreator.deleteDir;
+import static org.guvnor.m2repo.model.HTMLFileManagerFields.UPLOAD_OK;
+
+public class GAVResolverFromParentPomTest {
+
+    private static final Logger log = LoggerFactory.getLogger(GAVResolverFromParentPomTest.class);
+
+    private static final String PARENT_POM = "parent-gav-pom.xml";
+
+    @AfterClass
+    public static void tearDown() {
+        log.info("Deleting all Repository instances..");
+
+        File dir = new File("repositories");
+        log.info("DELETING test repo: " + dir.getAbsolutePath());
+        deleteDir(dir);
+        log.info("TEST repo was deleted.");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        M2RepoServiceCreator m2RepoServiceCreator = new M2RepoServiceCreator();
+        HttpPostHelper helper = m2RepoServiceCreator.getHelper();
+        java.lang.reflect.Method helperMethod = m2RepoServiceCreator.getHelperMethod();
+
+        FormData uploadItem = new FormData();
+        FileItem file = new MockFileItem("pom.xml",
+                                         this.getClass().getResourceAsStream(PARENT_POM));
+        uploadItem.setFile(file);
+
+        assertEquals("Error occurred when uploading pom", UPLOAD_OK, helperMethod.invoke(helper,
+                                                                                         uploadItem));
+    }
+
+    @Test
+    public void testResolveGavFromParentPomOnlyGroupID() throws Exception {
+        String pathToPomWithoutVersion = "org/guvnor/m2repo/backend/server/helpers/gav-pom-without-version.xml";
+
+        final PomModel pomModel = resolvePom(pathToPomWithoutVersion);
+        assertEquals("The groupID does not match to child pom", "org.guvnor.m2repo.backend.server.helpers", pomModel.getReleaseId().getGroupId());
+        assertEquals("The version does not match to parent pom", "1.0", pomModel.getReleaseId().getVersion());
+    }
+
+    @Test
+    public void testResolveGavFromParentPomOnlyVersion() throws Exception {
+        String pathToPomWithoutGroup = "org/guvnor/m2repo/backend/server/helpers/gav-pom-without-group.xml";
+
+        final PomModel pomModel = resolvePom(pathToPomWithoutGroup);
+        assertEquals("The groupID does not match to parent pom", "org.guvnor.test", pomModel.getReleaseId().getGroupId());
+        assertEquals("The version does not match to child pom", "1.1.1", pomModel.getReleaseId().getVersion());
+    }
+
+    private PomModel resolvePom(String path) throws Exception {
+        InputStream pomInputStream = this.getClass().getClassLoader().getResourceAsStream(path);
+        return PomModelResolver.resolveFromPom(pomInputStream);
+    }
+}

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepoServiceCreator.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepoServiceCreator.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.m2repo.backend.server;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import javax.enterprise.inject.Instance;
+
+import org.apache.commons.io.FileUtils;
+import org.guvnor.m2repo.backend.server.helpers.FormData;
+import org.guvnor.m2repo.backend.server.helpers.HttpPostHelper;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepository;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryProducer;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryService;
+import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceNameResolver;
+import org.uberfire.mocks.MockInstanceImpl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class M2RepoServiceCreator {
+
+    private static final Logger log = LoggerFactory.getLogger(M2RepoServiceCreator.class);
+
+    private GuvnorM2Repository repo;
+    private M2RepoServiceImpl service;
+    private HttpPostHelper helper;
+    private java.lang.reflect.Method helperMethod;
+
+    public GuvnorM2Repository getRepo() {
+        return repo;
+    }
+
+    public M2RepoServiceImpl getService() {
+        return service;
+    }
+
+    public HttpPostHelper getHelper() {
+        return helper;
+    }
+
+    public Method getHelperMethod() {
+        return helperMethod;
+    }
+
+    M2RepoServiceCreator() throws Exception {
+        log.info("Deleting existing Repositories instance..");
+
+        File dir = new File("repositories");
+        log.info("DELETING test repo: " + dir.getAbsolutePath());
+        deleteDir(dir);
+        log.info("TEST repo was deleted.");
+
+        ArtifactRepositoryPreference pref = mock(ArtifactRepositoryPreference.class);
+        when(pref.getGlobalM2RepoDir()).thenReturn("repositories/kie");
+        when(pref.isGlobalM2RepoDirEnabled()).thenReturn(true);
+        when(pref.isDistributionManagementM2RepoDirEnabled()).thenReturn(true);
+        when(pref.isWorkspaceM2RepoDirEnabled()).thenReturn(false);
+        WorkspaceNameResolver resolver = mock(WorkspaceNameResolver.class);
+        when(resolver.getWorkspaceName()).thenReturn("global");
+        ArtifactRepositoryProducer producer = new ArtifactRepositoryProducer(pref,
+                                                                             resolver);
+        producer.initialize();
+        Instance<ArtifactRepository> repositories = new MockInstanceImpl<>(producer.produceLocalRepository(),
+                                                                           producer.produceGlobalRepository(),
+                                                                           producer.produceDistributionManagementRepository());
+        ArtifactRepositoryService factory = new ArtifactRepositoryService(repositories);
+        repo = new GuvnorM2Repository(factory);
+        repo.init();
+
+        //Create a shell M2RepoService and set the M2Repository
+        service = new M2RepoServiceImpl(mock(Logger.class),
+                                        repo);
+        java.lang.reflect.Field repositoryField = M2RepoServiceImpl.class.getDeclaredField("repository");
+        repositoryField.setAccessible(true);
+        repositoryField.set(service,
+                            repo);
+
+        //Make private method accessible for testing
+        helper = new HttpPostHelper();
+        helperMethod = HttpPostHelper.class.getDeclaredMethod("upload",
+                                                              FormData.class);
+        helperMethod.setAccessible(true);
+
+        //Set the repository service created above in the HttpPostHelper
+        java.lang.reflect.Field m2RepoServiceField = HttpPostHelper.class.getDeclaredField("m2RepoService");
+        m2RepoServiceField.setAccessible(true);
+        m2RepoServiceField.set(helper,
+                               service);
+    }
+
+    static boolean deleteDir(File dir) {
+        try {
+            FileUtils.deleteDirectory(dir);
+        } catch (Exception e) {
+            log.error("Couldn't delete file {}",
+                      dir);
+            log.error(e.getMessage(),
+                      e);
+        }
+
+        // The directory is now empty so delete it
+        return dir.delete();
+    }
+}

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/MockFileItem.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/MockFileItem.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.m2repo.backend.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileItemHeaders;
+
+@SuppressWarnings("serial")
+class MockFileItem implements FileItem {
+
+    private final String fileName;
+    private final InputStream fileStream;
+
+    MockFileItem(final String fileName,
+                 final InputStream fileStream) {
+        this.fileName = fileName;
+        this.fileStream = fileStream;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return fileStream;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return fileName;
+    }
+
+    @Override
+    public boolean isInMemory() {
+        return false;
+    }
+
+    @Override
+    public long getSize() {
+        return 0;
+    }
+
+    @Override
+    public byte[] get() {
+        return null;
+    }
+
+    @Override
+    public String getString(String encoding) throws UnsupportedEncodingException {
+        return null;
+    }
+
+    @Override
+    public String getString() {
+        return null;
+    }
+
+    @Override
+    public void write(File file) throws Exception {
+    }
+
+    @Override
+    public void delete() {
+    }
+
+    @Override
+    public String getFieldName() {
+        return null;
+    }
+
+    @Override
+    public void setFieldName(String name) {
+    }
+
+    @Override
+    public boolean isFormField() {
+        return false;
+    }
+
+    @Override
+    public void setFormField(boolean state) {
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public FileItemHeaders getHeaders() {
+        return null;
+    }
+
+    @Override
+    public void setHeaders(FileItemHeaders fileItemHeaders) {
+    }
+}

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/resources/org/guvnor/m2repo/backend/server/helpers/gav-pom-without-group.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/resources/org/guvnor/m2repo/backend/server/helpers/gav-pom-without-group.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>parent-gav-pom</artifactId>
+    <groupId>org.guvnor.test</groupId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>testExistingParentGavInPom</artifactId>
+  <version>1.1.1</version>
+
+</project>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/resources/org/guvnor/m2repo/backend/server/helpers/gav-pom-without-version.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/resources/org/guvnor/m2repo/backend/server/helpers/gav-pom-without-version.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>parent-gav-pom</artifactId>
+    <groupId>org.guvnor.test</groupId>
+    <version>1.0</version>
+  </parent>
+
+  <groupId>org.guvnor.m2repo.backend.server.helpers</groupId>
+  <artifactId>testExistingParentGavInPom</artifactId>
+
+</project>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/resources/org/guvnor/m2repo/backend/server/parent-gav-pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/src/test/resources/org/guvnor/m2repo/backend/server/parent-gav-pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.guvnor.test</groupId>
+  <artifactId>parent-gav-pom</artifactId>
+  <version>1.0</version>
+  <name>parent-gav-pom</name>
+  <packaging>pom</packaging>
+</project>


### PR DESCRIPTION
Moving selenium tests specifically ArtifactRepositoryBugfixTest. This is QE initiative to reduce selenium test suite.
Those tests trying to resolve missing GAV parameters from parent pom