### PR TITLE
JBPM-7916 - Stunner - Process Documentation (Template Engine)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         instance.-->
     <version.org.webjars.bower.jspdf>1.2.61</version.org.webjars.bower.jspdf>
     <version.org.webjars.bowergithub.gliffy.canvas2svg>0.1</version.org.webjars.bowergithub.gliffy.canvas2svg>
+    <version.org.webjars.bower.mustachejs>3.0.1</version.org.webjars.bower.mustachejs>
     <version.org.webjars.bower.d3js>5.5.0</version.org.webjars.bower.d3js>
     <version.org.webjars.bower.c3>0.6.6</version.org.webjars.bower.c3>
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/TemplateRenderer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/TemplateRenderer.java
@@ -20,7 +20,7 @@ package org.uberfire.ext.editor.commons.template;
  * Represents a template engine rendering.
  * @param <D> is the model to rendered on the template.
  */
-public interface TemplateRenderer<D extends Object> {
+public interface TemplateRenderer<D> {
 
     String render(String template, D data);
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/TemplateRenderer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/TemplateRenderer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.template;
+
+/**
+ * Represents a template engine rendering.
+ * @param <D> is the model to rendered on the template.
+ */
+public interface TemplateRenderer<D extends Object> {
+
+    String render(String template, D data);
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/mustache/MustacheTemplateRenderer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/mustache/MustacheTemplateRenderer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.template.mustache;
+
+import org.uberfire.ext.editor.commons.template.TemplateRenderer;
+
+/**
+ * Represents a {@link TemplateRenderer} based on Mustache engine.
+ * May have implementations for Client and Backend.
+ * <p>
+ * See {@linktourl https://mustache.github.io/}
+ * See {@linktourl https://github.com/janl/mustache.js}
+ * See {@linktourl https://github.com/spullara/mustache.java}
+ * @param <D> data model to be rendered on the template.
+ */
+public interface MustacheTemplateRenderer<D extends Object> extends TemplateRenderer<D> {
+
+    String render(String template, D data);
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/mustache/MustacheTemplateRenderer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/template/mustache/MustacheTemplateRenderer.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.editor.commons.template.TemplateRenderer;
  * See {@linktourl https://github.com/spullara/mustache.java}
  * @param <D> data model to be rendered on the template.
  */
-public interface MustacheTemplateRenderer<D extends Object> extends TemplateRenderer<D> {
+public interface MustacheTemplateRenderer<D> extends TemplateRenderer<D> {
 
     String render(String template, D data);
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/resources/org/uberfire/ext/editor/commons/UberfireCommonsEditorAPI.gwt.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/resources/org/uberfire/ext/editor/commons/UberfireCommonsEditorAPI.gwt.xml
@@ -26,5 +26,6 @@
   <source path='readonly'/>
   <source path='version'/>
   <source path='service'/>
+  <source path='template'/>
 
 </module>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -137,10 +137,12 @@
 
   <build>
     <plugins>
+      <!-- WebJars Dependencies -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
+          <!-- File Saver -->
           <execution>
             <id>unpack-filesaver</id>
             <phase>process-resources</phase>
@@ -162,6 +164,7 @@
               <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
+          <!-- JsPDF -->
           <execution>
             <id>unpack-jspdf</id>
             <phase>process-resources</phase>
@@ -183,7 +186,7 @@
               <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
-
+          <!-- Canvas2svg -->
           <execution>
             <id>unpack-canvas2svg</id>
             <phase>process-resources</phase>
@@ -205,13 +208,37 @@
               <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
-
+          <!-- MustacheJS -->
+          <execution>
+            <id>unpack-mustachejs</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.webjars.bower</groupId>
+                  <artifactId>mustache.js</artifactId>
+                  <version>${version.org.webjars.bower.mustachejs}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/mustachejs</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
+
+      <!-- Copy JS from WebJars to resources Path, where it should be injected on the application with JsInterop -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
+          <!-- File Saver -->
           <execution>
             <id>copy-filesaver-resources</id>
             <phase>process-resources</phase>
@@ -230,6 +257,7 @@
               </resources>
             </configuration>
           </execution>
+          <!-- JsPDF -->
           <execution>
             <id>copy-jspdf-resources</id>
             <phase>process-resources</phase>
@@ -248,7 +276,7 @@
               </resources>
             </configuration>
           </execution>
-
+          <!-- Canvas2svg -->
           <execution>
             <id>copy-canvas2svg-resources</id>
             <phase>process-resources</phase>
@@ -262,6 +290,29 @@
                   <directory>${project.build.directory}/canvas2svg/META-INF/resources/webjars/canvas2svg/</directory>
                   <includes>
                     <include>canvas2svg.js</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <!-- MustacheJS -->
+          <execution>
+            <id>copy-mustachejs-resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>
+                ${project.build.outputDirectory}/org/uberfire/ext/editor/commons/client/template/mustache/
+              </outputDirectory>
+              <resources>
+                <resource>
+                  <directory>
+                    ${project.build.directory}/mustachejs/META-INF/resources/webjars/mustache.js/${version.org.webjars.bower.mustachejs}/
+                  </directory>
+                  <includes>
+                    <include>mustache.js</include>
                   </includes>
                 </resource>
               </resources>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
@@ -20,20 +20,16 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.management.Attribute;
-
 import elemental2.core.Array;
 import elemental2.dom.CanvasGradient;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLCanvasElement;
 import elemental2.dom.ImageData;
-import elemental2.dom.Node;
 import elemental2.dom.TextMetrics;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
-import org.jboss.errai.codegen.Parameter;
 
 /**
  * This is a JsInterop class responsible to make the interface to the <b>canvas2svg</b> library,
@@ -52,6 +48,9 @@ class C2S {
         settings.setCtx(nativeContext);
         C2S c2S = new C2S(settings);
         c2S.setImageSmoothingEnabled(false);
+        //setting the viewBox on the svg root, this is necessary to scaling th svg on html
+        final String viewBox = "0 0 " + width + " " + height;
+        c2S.__root.setAttribute("viewBox", viewBox);
         return c2S;
     }
 
@@ -257,7 +256,7 @@ class C2S {
     public Element __currentElement;
 
     @JsProperty
-    public Node __root;
+    public Element __root;
 
     @JsProperty
     public Object __currentElementsToStyle;

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2S.java
@@ -49,9 +49,15 @@ class C2S {
         C2S c2S = new C2S(settings);
         c2S.setImageSmoothingEnabled(false);
         //setting the viewBox on the svg root, this is necessary to scaling th svg on html
-        final String viewBox = "0 0 " + width + " " + height;
-        c2S.__root.setAttribute("viewBox", viewBox);
+        c2S.setViewBox(width, height);
         return c2S;
+    }
+
+    @JsOverlay
+    protected final void setViewBox(double width, double height) {
+        final String viewBox = "0 0 " + width + " " + height;
+        Optional.ofNullable(this.__root)
+                .ifPresent(root -> root.setAttribute("viewBox", viewBox));
     }
 
     protected C2S(C2SSettings options) {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/ClientMustacheTemplateRenderer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/ClientMustacheTemplateRenderer.java
@@ -40,7 +40,7 @@ public class ClientMustacheTemplateRenderer implements MustacheTemplateRenderer<
 
     @Inject
     public ClientMustacheTemplateRenderer() {
-        this(GWT.create(MustacheSource.class), ScriptInjector::fromString);
+        this(() -> GWT.create(MustacheSource.class), ScriptInjector::fromString);
     }
 
     protected ClientMustacheTemplateRenderer(final Supplier<MustacheSource> sourceSupplier, final Function<String,

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/ClientMustacheTemplateRenderer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/ClientMustacheTemplateRenderer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.template.mustache;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.ScriptInjector;
+import org.uberfire.ext.editor.commons.template.TemplateRenderer;
+import org.uberfire.ext.editor.commons.template.mustache.MustacheTemplateRenderer;
+
+/**
+ * Client implementation for {@link TemplateRenderer} based on MustacheJS engine.
+ * See {@linktourl https://github.com/janl/mustache.js}
+ */
+@ApplicationScoped
+public class ClientMustacheTemplateRenderer implements MustacheTemplateRenderer<Object> {
+
+    private final Function<String, ScriptInjector.FromString> scriptInjector;
+    private final Supplier<MustacheSource> sourceSupplier;
+
+    @Inject
+    public ClientMustacheTemplateRenderer() {
+        this(GWT.create(MustacheSource.class), ScriptInjector::fromString);
+    }
+
+    protected ClientMustacheTemplateRenderer(final Supplier<MustacheSource> sourceSupplier, final Function<String,
+            ScriptInjector.FromString> scriptInjector) {
+        this.sourceSupplier = sourceSupplier;
+        this.scriptInjector = scriptInjector;
+    }
+
+    @PostConstruct
+    protected void init() {
+        //Injecting the JS native script
+        final MustacheSource source = sourceSupplier.get();
+        inject(source.mustache().getText());
+    }
+
+    private void inject(final String raw) {
+        final ScriptInjector.FromString js = scriptInjector.apply(raw);
+        js.setWindow(ScriptInjector.TOP_WINDOW).setRemoveTag(false).inject();
+    }
+
+    public String render(final String template, final Object data) {
+        return Mustache.to_html(template, data);
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/Mustache.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/Mustache.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.template.mustache;
+
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+/**
+ * JSInterop for MustacheJS native library.
+ * See {@linktourl https://github.com/janl/mustache.js/blob/master/mustache.js}
+ */
+@JsType(isNative = true, namespace = JsPackage.GLOBAL)
+public final class Mustache {
+
+    @JsMethod
+    public static final native String to_html(String template, Object bean);
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/MustacheSource.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/template/mustache/MustacheSource.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.template.mustache;
+
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.TextResource;
+
+/**
+ * Holds the source for the unpacked MustacheJS.
+ */
+public interface MustacheSource extends ClientBundle {
+
+    @Source("mustache.js")
+    TextResource mustache();
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2DTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/exports/jso/svg/C2SContext2DTest.java
@@ -18,7 +18,6 @@ package org.uberfire.ext.editor.commons.client.file.exports.jso.svg;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
@@ -32,7 +31,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -58,6 +56,9 @@ public class C2SContext2DTest {
 
     private C2S c2S;
 
+    @Mock
+    private Element root;
+
     @Before
     public void setUp() throws Exception {
         c2S = spy(C2S.create(100, 100, nativeContext));
@@ -65,6 +66,15 @@ public class C2SContext2DTest {
         c2S.__groupStack = groupStack;
         when(groupStack.pop()).thenReturn(element);
         c2S.__stack = stack;
+        c2S.__root = root;
+    }
+
+    @Test
+    public void testSetViewBox() {
+        final double width = 100;
+        final double height = 100;
+        c2S.setViewBox(width, height);
+        verify(root).setAttribute("viewBox", "0 0 " + width + " " + height);
     }
 
     @Test
@@ -173,7 +183,7 @@ public class C2SContext2DTest {
     public void saveGroup() {
         final String key = "id";
         final String value = "value";
-        final Map<String, String> id = new HashMap<String, String>(){{
+        final Map<String, String> id = new HashMap<String, String>() {{
             put(key, value);
         }};
         c2SContext2D.saveGroup(id);

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/template/mustache/ClientMustacheTemplateRendererTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/template/mustache/ClientMustacheTemplateRendererTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.editor.commons.client.template.mustache;
+
+import java.util.function.Function;
+
+import com.google.gwt.core.client.ScriptInjector;
+import com.google.gwt.resources.client.TextResource;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ClientMustacheTemplateRendererTest {
+
+    private ClientMustacheTemplateRenderer tested;
+
+    @Mock
+    private MustacheSource mustacheSource;
+
+    @Mock
+    private ScriptInjector.FromString script;
+
+    @Mock
+    private TextResource source;
+
+    private final String SOURCE_TXT = "source";
+
+    @Mock
+    private Function<String, ScriptInjector.FromString> injector;
+
+    @Before
+    public void setUp() throws Exception {
+        tested = new ClientMustacheTemplateRenderer(() -> mustacheSource, injector);
+        when(mustacheSource.mustache()).thenReturn(source);
+        when(source.getText()).thenReturn(SOURCE_TXT);
+        when(injector.apply(SOURCE_TXT)).thenReturn(script);
+        when(script.setWindow(any())).thenReturn(script);
+        when(script.setRemoveTag(anyBoolean())).thenReturn(script);
+    }
+
+    @Test
+    public void init() {
+        tested.init();
+        verify(source).getText();
+        verify(injector).apply(SOURCE_TXT);
+        verify(script).setWindow(ScriptInjector.TOP_WINDOW);
+        verify(script).setRemoveTag(false);
+        verify(script).inject();
+    }
+}


### PR DESCRIPTION
Inserting a _template engine_ to run on Client that is based on [Mustache](https://mustache.github.io/) using the implementation for `Javascript` [MustacheJS](https://github.com/janl/mustache.js). The idea is to process text templates on client side now, although it will allow us to keep the same API having an implementation on backend if necessary since there is a Java implementation (https://github.com/spullara/mustache.java).
The template engine is going to be used on Stunner to generate the **Process Documentation**.

Related PR https://github.com/kiegroup/kie-wb-common/pull/2363

@romartin 
@ederign 
@LuboTerifaj 
