### PR TITLE
DROOLS-3435 Change the text color in highlighted cells

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/themes/impl/KIEColours.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/themes/impl/KIEColours.java
@@ -37,7 +37,7 @@ public class KIEColours {
 
     public static final String CELL_FOCUS = "#0088CE";
 
-    public static final String CELL_ERROR_FOCUS = "#CC0000";
+    public static final String CELL_ERROR_FOCUS = "#8B0000";
 
     public static final String CELL_ERROR_BACKGROUND = "#FFE6E6";
 


### PR DESCRIPTION
I made changes to the font of highlighted cells based on [DROOLS-3393](https://issues.jboss.org/browse/DROOLS-3393).

**This should be merged together with: https://github.com/kiegroup/drools-wb/pull/1041.**

The highlighted cells now look as follows:

![1](https://user-images.githubusercontent.com/16349113/51246878-be938c00-198b-11e9-990f-7e8d5cd54851.png)

@danielezonca, @Rikkola, could you please take a look?