### PR TITLE
DROOLS-3399: [DMN Designer] Data Types - Disable the global 'Save' button when edit mode is enabled

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
@@ -593,10 +593,23 @@ public abstract class BaseEditor<T, M> {
         disableMenuItem(MenuItems.VALIDATE);
     }
 
-    private void disableMenuItem(final MenuItems menuItem) {
-        if (menus.getItemsMap().containsKey(menuItem)) {
-            menus.getItemsMap().get(menuItem).setEnabled(false);
+    public void disableMenuItem(final MenuItems menuItem) {
+        setEnableMenuItem(menuItem, false);
+    }
+
+    public void enableMenuItem(final MenuItems menuItem) {
+        setEnableMenuItem(menuItem, true);
+    }
+
+    private void setEnableMenuItem(final MenuItems menuItem,
+                                   final boolean isEnabled) {
+        if (menus().getItemsMap().containsKey(menuItem)) {
+            menus().getItemsMap().get(menuItem).setEnabled(isEnabled);
         }
+    }
+
+    Menus menus() {
+        return menus;
     }
 
     public Command getValidateCommand() {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorTest.java
@@ -17,7 +17,9 @@
 package org.uberfire.ext.editor.commons.client;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import com.google.gwt.user.client.ui.IsWidget;
@@ -44,6 +46,7 @@ import org.uberfire.mvp.Command;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.Menus;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -538,6 +541,38 @@ public class BaseEditorTest {
         final Integer expectedHash = fakeContent.hashCode();
 
         assertEquals(expectedHash, actualHash);
+    }
+
+    @Test
+    public void testDisableMenuItem() {
+
+        final Menus menus = mock(Menus.class);
+        final MenuItem menuItem = mock(MenuItem.class);
+        final Map<Object, MenuItem> itemMap = new HashMap<>();
+
+        itemMap.put(SAVE, menuItem);
+        when(menus.getItemsMap()).thenReturn(itemMap);
+        doReturn(menus).when(editor).menus();
+
+        editor.disableMenuItem(SAVE);
+
+        verify(menuItem).setEnabled(false);
+    }
+
+    @Test
+    public void testEnableMenuItem() {
+
+        final Menus menus = mock(Menus.class);
+        final MenuItem menuItem = mock(MenuItem.class);
+        final Map<Object, MenuItem> itemMap = new HashMap<>();
+
+        itemMap.put(SAVE, menuItem);
+        when(menus.getItemsMap()).thenReturn(itemMap);
+        doReturn(menus).when(editor).menus();
+
+        editor.enableMenuItem(SAVE);
+
+        verify(menuItem).setEnabled(true);
     }
 
     private DefaultMetadata fakeMetadata(final int hashCode) {


### PR DESCRIPTION
See: https://issues.jboss.org/browse/DROOLS-3399

![2019-01-20 23 11 27](https://user-images.githubusercontent.com/1079279/51448991-2c83de80-1d11-11e9-9466-543dadc760ad.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/609
- https://github.com/kiegroup/kie-wb-common/pull/2411
