### PR TITLE
[AF-1800]: Mockito version downgraded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,9 @@
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
+    <!-- Mockio version downgrade, need changes in tests to upgrade to ip-bom (AF-1800) -->
+    <version.org.mockito>1.10.19</version.org.mockito>
+
     <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
     <version.org.freemarker>2.3.26.jbossorg-1</version.org.freemarker>
     <version.org.jboss.errai>4.4.2-SNAPSHOT</version.org.jboss.errai>


### PR DESCRIPTION
ip-bom contains 2.x mockito version that is not compatible with our tests. A new Jira was created to do the alignment, meanwhile a downgrade is required to maintain compatibility.

@ederign @mbiarnes would you mind to review?