### PR TITLE
[DROOLS-3377] Fix init width calculus

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
@@ -738,10 +738,13 @@ public class BaseGridData implements GridData {
         GridWidthMetadata gridWidthMetadata = new GridWidthMetadata(optionalCurrentWidth);
         int visibleWidth = getVisibleWidth();
 
+        double calculatedWidth;
         if (gridWidthMetadata.numberOfAutoColumn < 2) {
-            return visibleWidth - gridWidthMetadata.fixedWidth;
+            calculatedWidth = visibleWidth - gridWidthMetadata.fixedWidth;
+        } else {
+            calculatedWidth = (visibleWidth - gridWidthMetadata.fixedWidth) / (gridWidthMetadata.numberOfAutoColumn - 1);
         }
-        return (visibleWidth - gridWidthMetadata.fixedWidth) / (gridWidthMetadata.numberOfAutoColumn - 1);
+        return Math.max(calculatedWidth, column.getMinimumWidth());
     }
 
     private class GridWidthMetadata {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataTest.java
@@ -423,6 +423,14 @@ public class BaseGridDataTest {
         data.appendColumn(column3);
 
         assertEquals(((data.getVisibleWidth() - originalWidth) / 2), data.calculateInitWidth(column2, OptionalDouble.empty()), 0.1);
+
+        BaseGridColumn<String> column4 = new BaseGridColumn<>(header, columnRenderer, originalWidth);
+        column4.setColumnWidthMode(GridColumn.ColumnWidthMode.AUTO);
+        double minWidth = originalWidth * 10;
+        column4.setMinimumWidth(minWidth);
+        data.appendColumn(column4);
+
+        assertEquals(minWidth, column4.getWidth(), 0.1);
     }
 
     static class CustomGridCell<T> extends BaseGridCell<T> {


### PR DESCRIPTION
This fix point 2, 4, 5, 6 of the ticket https://issues.jboss.org/browse/DROOLS-3377

@kkufova @Rikkola 

PR list:
https://github.com/kiegroup/drools-wb/pull/1059
https://github.com/kiegroup/appformer/pull/626