### PR TITLE
AF-1814 : Downloaded project can't be extracted with built-in Windows unzipper

### DIFF
--- a/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/archive/Archiver.java
+++ b/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/archive/Archiver.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.zip.ZipEntry;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -91,6 +92,19 @@ public class Archiver {
 
         static protected String resolve(final String subPath,
                                         final String originalPath) {
+
+            final String fileName = resolveOriginalFileName(subPath,
+                                                            originalPath);
+
+            if (fileName.startsWith("/")) {
+                return "project" + fileName;
+            } else {
+                return fileName;
+            }
+        }
+
+        static private String resolveOriginalFileName(final String subPath,
+                                                      final String originalPath) {
             if ("/".equals(originalPath)) {
                 return subPath.substring(originalPath.length());
             } else {

--- a/uberfire-services/uberfire-services-backend/src/test/java/org/guvnor/common/services/backend/archive/FileNameResolverTest.java
+++ b/uberfire-services/uberfire-services-backend/src/test/java/org/guvnor/common/services/backend/archive/FileNameResolverTest.java
@@ -45,8 +45,8 @@ public class FileNameResolverTest {
 
     @Test
     public void testRootFolder() throws Exception {
-        assertEquals("/file.txt",
-                     Archiver.FileNameResolver.resolve("/project/file.txt",
-                                                       "/project/"));
+        assertEquals("project/file.txt",
+                     Archiver.FileNameResolver.resolve("/repositoryName/file.txt",
+                                                       "/repositoryName/"));
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/AF-1814

Problem was the default first folder was called _ when the entire repository was zipped. This PR changes the default folder to "project" in these cases.

@jomarko if you could please review and I'm open to reviews from the appformer team, who ever has time.