### PR TITLE
DROOLS-3590/DROOLS-3589: [DMN Designer] Data Types - When users create a Data Type, they must be able to perform shortcut operations in the last created DT / Shortcut tooltip remains opened in some scenarios

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQuery.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQuery.java
@@ -21,12 +21,16 @@ import elemental2.dom.Element;
 import elemental2.dom.Node;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
 import static jsinterop.annotations.JsPackage.GLOBAL;
 
 @JsType(isNative = true)
 public abstract class JQuery {
+
+    @JsProperty(namespace = GLOBAL, name = "jQuery")
+    public static JQuery $;
 
     @JsMethod(namespace = GLOBAL, name = "jQuery")
     public native static JQuery $(final Node selector);
@@ -47,6 +51,9 @@ public abstract class JQuery {
     public native JQuery detach();
 
     public native JQueryList<Element> filter(final String selector);
+
+    public native boolean contains(final Element container,
+                                   final Element contained);
 
     @JsFunction
     public interface CallbackFunction {


### PR DESCRIPTION
See:
- [DROOLS-3590](https://issues.jboss.org/browse/DROOLS-3590): [DMN Designer] Data Types - When users create a Data Type, they must be able to perform shortcut operations in the last created DT
- [DROOLS-3589](https://issues.jboss.org/browse/DROOLS-3589): [DMN Designer] Data Types - Shortcut tooltip remains opened in some scenarios

---

**DROOLS-3590**

![2019-02-11 19 21 20](https://user-images.githubusercontent.com/1079279/52594626-1d391200-2e33-11e9-8b5b-25bcb622a74a.gif)

---

**DROOLS-3589**

Before:
![2019-02-06 18 28 15](https://user-images.githubusercontent.com/1079279/52594650-2a560100-2e33-11e9-8a97-45e65fdfdc78.gif)

After:
![2019-02-11 18 56 30](https://user-images.githubusercontent.com/1079279/52594656-2de98800-2e33-11e9-956d-f9720ac9ddf8.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/630
- https://github.com/kiegroup/kie-wb-common/pull/2466
