### PR TITLE
JBPM-8232: Horizontal scrollbars missing in task inbox

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/ColumnPicker.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/ColumnPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 JBoss, by Red Hat, Inc
+ * Copyright 2019 JBoss, by Red Hat, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,11 @@ import org.uberfire.ext.widgets.table.client.UberfireColumnPicker;
 
 public class ColumnPicker<T> extends UberfireColumnPicker<T> {
 
+    public static int DETAULT_COLUMN_WIDTH = 120;
     private GridPreferencesStore gridPreferences;
     private Optional<String> columnZeroWidth = Optional.empty();
+    private int dataGridMinWidth = 0;
+    private int defaultColumnWidthSize = DETAULT_COLUMN_WIDTH;
 
     public ColumnPicker(DataGrid<T> dataGrid,
                         GridPreferencesStore gridPreferences) {
@@ -159,6 +162,7 @@ public class ColumnPicker<T> extends UberfireColumnPicker<T> {
             dataGrid.setColumnWidth(dataGrid.getColumn(0),
                                     100,
                                     Style.Unit.PCT);
+            dataGridMinWidth = defaultColumnWidthSize;
             return;
         }
 
@@ -213,5 +217,15 @@ public class ColumnPicker<T> extends UberfireColumnPicker<T> {
                 }
             }
         }
+        dataGridMinWidth = fixedColumnsWidth + columnsToCalculate.size() * defaultColumnWidthSize;
     }
+
+    public int getDataGridMinWidth() {
+        return this.dataGridMinWidth;
+    }
+
+    public void setDefaultColumnWidthSize(int defaultColumnSize) {
+        this.defaultColumnWidthSize = defaultColumnSize;
+    }
+
 }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 JBoss, by Red Hat, Inc
+ * Copyright 2019 JBoss, by Red Hat, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,11 +52,15 @@ public class PagedTable<T>
     public Select pageSizesSelector;
 
     @UiField
+    public Column dataGridContainer;
+
+    @UiField
     public Column topToolbar;
 
     protected boolean showPageSizesSelector = false;
     private int pageSize;
     private AbstractDataProvider<T> dataProvider;
+    private boolean dataGridMinWidthEnabled = false;
 
     public PagedTable() {
         this(DEFAULT_PAGE_SIZE);
@@ -171,6 +175,21 @@ public class PagedTable<T>
             this.dataGrid.setHeight(height);
             this.dataGrid.redraw();
         }
+        if (isDataGridMinWidthEnabled()) {
+            dataGridContainer.getElement().setAttribute("style", "min-width:" + super.columnPicker.getDataGridMinWidth() + Style.Unit.PX.getType());
+        }
+    }
+
+    public boolean isDataGridMinWidthEnabled() {
+        return dataGridMinWidthEnabled;
+    }
+
+    public void enableDataGridMinWidth(boolean enabled) {
+        this.dataGridMinWidthEnabled = enabled;
+    }
+
+    public void setDefaultColumWidthSize(int defaultColumWidthSize) {
+        super.columnPicker.setDefaultColumnWidthSize(defaultColumWidthSize);
     }
 
     public void setShowLastPagerButton(boolean showLastPagerButton) {
@@ -216,6 +235,10 @@ public class PagedTable<T>
 
     public HasWidgets getTopToolbar() {
         return topToolbar;
+    }
+
+    protected void setColumnPicker(ColumnPicker columnPicker) {
+        super.columnPicker = columnPicker;
     }
 
     interface Binder

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.ui.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.ui.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2015 JBoss, by Red Hat, Inc
+  ~ Copyright 2019 JBoss, by Red Hat, Inc
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
            type="org.uberfire.ext.widgets.table.client.resources.i18n.CommonConstants"/>
 
   <ui:style>
-    .dataGridContainer {
+    .pagedTableContainer {
       padding-top: 10px;
       padding-bottom: 10px;
     }
@@ -58,9 +58,13 @@
       padding-top: 5px;
     }
 
+    .dataGridContainer {
+      overflow: auto;
+    }
+
   </ui:style>
 
-  <g:FlowPanel addStyleNames="{style.dataGridContainer}">
+  <g:FlowPanel addStyleNames="{style.pagedTableContainer}">
     <b:Row>
       <b:Column size="MD_12" ui:field="topToolbar"/>
     </b:Row>
@@ -78,8 +82,8 @@
         </bh:Div>
       </b:Column>
     </b:Row>
-    <b:Row>
-      <b:Column size="MD_12">
+    <b:Row addStyleNames="{style.dataGridContainer}">
+      <b:Column size="MD_12" ui:field="dataGridContainer">
         <bg:DataGrid ui:field="dataGrid"/>
       </b:Column>
     </b:Row>
@@ -87,10 +91,10 @@
       <b:Column size="MD_12">
         <uf:UberfireSimplePager ui:field="pager" addStyleNames="pagination pagination-right pull-right {style.pager}"/>
         <s:Select ui:field="pageSizesSelector" width="100px">
-          <s:Option text="10 {i18n.Items}"  value="10"/>
-          <s:Option text="20 {i18n.Items}"  value="20"/>
-          <s:Option text="50 {i18n.Items}"  value="50"/>
-          <s:Option text="100 {i18n.Items}"  value="100"/>
+          <s:Option text="10 {i18n.Items}" value="10"/>
+          <s:Option text="20 {i18n.Items}" value="20"/>
+          <s:Option text="50 {i18n.Items}" value="50"/>
+          <s:Option text="100 {i18n.Items}" value="100"/>
         </s:Select>
       </b:Column>
     </b:Row>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/ColumnPickerTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/ColumnPickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2019 JBoss Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,8 +73,7 @@ public class ColumnPickerTest {
                 columns.add((Column) invocationOnMock.getArguments()[0]);
                 return null;
             }
-        }).when(dataGrid).addColumn(any(Column.class),
-                                    any(Header.class));
+        }).when(dataGrid).addColumn(any(Column.class), any(Header.class));
 
         doAnswer(new Answer<Void>() {
             @Override
@@ -113,68 +112,54 @@ public class ColumnPickerTest {
     public void testAddRemoveColumn() {
         final Column column = mock(Column.class);
         when(column.getDataStoreName()).thenReturn("id");
-        final ColumnMeta meta = new ColumnMeta(column,
-                                               "caption");
+        final ColumnMeta meta = new ColumnMeta(column, "caption");
         meta.setHeader(new TextHeader("header"));
+
         columnPicker.addColumn(meta);
+
         assertTrue(columnPicker.getColumnMetaList().contains(meta));
-        verify(dataGrid).insertColumn(0,
-                                      column,
-                                      meta.getHeader());
-        assertEquals(1,
-                     dataGrid.getColumnCount());
+        verify(dataGrid).insertColumn(0, column, meta.getHeader());
+        assertEquals(1, dataGrid.getColumnCount());
+
         columnPicker.removeColumn(meta);
+
         assertFalse(columnPicker.getColumnMetaList().contains(meta));
         verify(dataGrid).removeColumn(0);
-        assertEquals(0,
-                     dataGrid.getColumnCount());
+        assertEquals(0, dataGrid.getColumnCount());
     }
 
 
     @Test
     public void testSortColumn() {
         final Column column1 = mock(Column.class);
-        final ColumnMeta meta1 = new ColumnMeta(column1,
-                                                "caption1",
-                                                true,
-                                                1);
+        final ColumnMeta meta1 = new ColumnMeta(column1, "caption1", true, 1);
         meta1.setHeader(new TextHeader("header1"));
         final Column column0 = mock(Column.class);
-        final ColumnMeta meta0 = new ColumnMeta(column0,
-                                                "caption0",
-                                                true,
-                                                0);
+        final ColumnMeta meta0 = new ColumnMeta(column0, "caption0", true, 0);
         meta0.setHeader(new TextHeader("header0"));
-        columnPicker.addColumns(Arrays.asList(meta1,
-                                              meta0));
-        assertEquals(2,
-                     columnPicker.getColumnMetaList().size());
-        verify(dataGrid).insertColumn(1,
-                                      column0,
-                                   meta0.getHeader());
-        verify(dataGrid).insertColumn(0,
-                                   column1,
-                                   meta1.getHeader());
-        assertEquals(2,
-                     dataGrid.getColumnCount());
+
+        columnPicker.addColumns(Arrays.asList(meta1, meta0));
+
+        assertEquals(2, columnPicker.getColumnMetaList().size());
+        verify(dataGrid).insertColumn(1, column0, meta0.getHeader());
+        verify(dataGrid).insertColumn(0, column1, meta1.getHeader());
+        assertEquals(2, dataGrid.getColumnCount());
     }
 
     @Test
     public void testColumnPreference() {
         final Column column = mock(Column.class);
         when(column.getDataStoreName()).thenReturn("id");
-        final ColumnMeta meta = new ColumnMeta(column,
-                                               "caption");
+        final ColumnMeta meta = new ColumnMeta(column, "caption");
         meta.setHeader(new TextHeader("header"));
+
         columnPicker.addColumn(meta);
         final List<GridColumnPreference> columnsState = columnPicker.getColumnsState();
-        assertEquals(1,
-                     columnsState.size());
+        assertEquals(1, columnsState.size());
+
         final GridColumnPreference preference = columnsState.get(0);
-        assertEquals(preference.getName(),
-                     column.getDataStoreName());
-        assertEquals(0,
-                     preference.getPosition().intValue());
+        assertEquals(preference.getName(), column.getDataStoreName());
+        assertEquals(0, preference.getPosition().intValue());
     }
 
     @Test
@@ -195,26 +180,14 @@ public class ColumnPickerTest {
 
     @Test
     public void testAdjustColumnWidths() {
-        final Column column1 = createColumn("col1",
-                                            "col1");
-        final ColumnMeta meta1 = new ColumnMeta(column1,
-                                                "caption1",
-                                                true,
-                                                1);
+        final Column column1 = createColumn("col1", "col1");
+        final ColumnMeta meta1 = new ColumnMeta(column1, "caption1", true, 1);
         meta1.setHeader(new TextHeader("header1"));
-        final Column column2 = createColumn("col2",
-                                            "col2");
-        final ColumnMeta meta2 = new ColumnMeta(column2,
-                                                "caption2",
-                                                true,
-                                                0);
+        final Column column2 = createColumn("col2", "col2");
+        final ColumnMeta meta2 = new ColumnMeta(column2, "caption2", true, 0);
         meta2.setHeader(new TextHeader("header2"));
-        final Column column3 = createColumn("col3",
-                                            "col3");
-        final ColumnMeta meta3 = new ColumnMeta(column3,
-                                                "caption3",
-                                                true,
-                                                0);
+        final Column column3 = createColumn("col3", "col3");
+        final ColumnMeta meta3 = new ColumnMeta(column3, "caption3", true, 0);
         meta3.setHeader(new TextHeader("header3"));
 
         when(dataGrid.getColumnWidth(column1)).thenReturn("35px");
@@ -227,14 +200,9 @@ public class ColumnPickerTest {
         columnMetasList.add(meta3);
         columnPicker.addColumns(columnMetasList);
 
-        verify(dataGrid).setColumnWidth(column1,
-                                        "35px");
-        verify(dataGrid).setColumnWidth(column2,
-                                        50,
-                                        Style.Unit.PCT);
-        verify(dataGrid).setColumnWidth(column3,
-                                        50,
-                                        Style.Unit.PCT);
+        verify(dataGrid).setColumnWidth(column1, "35px");
+        verify(dataGrid).setColumnWidth(column2, 50, Style.Unit.PCT);
+        verify(dataGrid).setColumnWidth(column3, 50, Style.Unit.PCT);
     }
 
     private Column createColumn(String value,
@@ -253,44 +221,24 @@ public class ColumnPickerTest {
 
     @Test
     public void testSetColumnWidth() {
-        final Column column1 = createColumn("col1",
-                                            "col1");
-        final ColumnMeta meta1 = new ColumnMeta(column1,
-                                                "caption1",
-                                                true,
-                                                1);
-
-        final Column column2 = createColumn("col2",
-                                            "col2");
-        final ColumnMeta meta2 = new ColumnMeta(column2,
-                                                "caption2",
-                                                true,
-                                                0);
+        final Column column1 = createColumn("col1", "col1");
+        final ColumnMeta meta1 = new ColumnMeta(column1, "caption1", true, 1);
+        final Column column2 = createColumn("col2", "col2");
+        final ColumnMeta meta2 = new ColumnMeta(column2, "caption2", true, 0);
 
         when(dataGrid.getColumnWidth(column1)).thenReturn("38.0px");
 
-        columnPicker.addColumns(Lists.newArrayList(meta1,
-                                                   meta2));
+        columnPicker.addColumns(Lists.newArrayList(meta1, meta2));
 
-        verify(dataGrid).setColumnWidth(eq(column1),
-                                        eq("38px"));
+        verify(dataGrid).setColumnWidth(eq(column1), eq("38px"));
     }
 
     @Test
     public void testAddColumnsIncrementally() {
-        final Column column1 = createColumn("col1",
-                                            "col1");
-        final ColumnMeta meta1 = new ColumnMeta(column1,
-                                                "caption1",
-                                                true,
-                                                1);
-
-        final Column column2 = createColumn("col2",
-                                            "col2");
-        final ColumnMeta meta2 = new ColumnMeta(column2,
-                                                "caption2",
-                                                true,
-                                                0);
+        final Column column1 = createColumn("col1", "col1");
+        final ColumnMeta meta1 = new ColumnMeta(column1, "caption1", true, 1);
+        final Column column2 = createColumn("col2", "col2");
+        final ColumnMeta meta2 = new ColumnMeta(column2, "caption2", true, 0);
 
         when(dataGrid.getColumn(0)).thenReturn(column1);
         when(dataGrid.getColumn(1)).thenReturn(column2);
@@ -299,16 +247,36 @@ public class ColumnPickerTest {
 
         columnPicker.addColumns(Collections.singletonList(meta1));
 
-        verify(dataGrid).setColumnWidth(eq(column1),
-                                        eq(100.0),
-                                        eq(Style.Unit.PCT));
+        verify(dataGrid).setColumnWidth(eq(column1), eq(100.0), eq(Style.Unit.PCT));
 
         columnPicker.addColumns(Collections.singletonList(meta2));
 
-        verify(dataGrid).setColumnWidth(eq(column1),
-                                        eq("100px"));
-        verify(dataGrid).setColumnWidth(eq(column2),
-                                        eq(100.0),
-                                        eq(Style.Unit.PCT));
+        verify(dataGrid).setColumnWidth(eq(column1), eq("100px"));
+        verify(dataGrid).setColumnWidth(eq(column2), eq(100.0), eq(Style.Unit.PCT));
+    }
+
+    @Test
+    public void testDataGridMinWidthCalculation() {
+        int defaultColumnWidthSize = 150;
+        int fixedColumn1Width = 38;
+        final Column column1 = createColumn("col1", "col1");
+        final ColumnMeta meta1 = new ColumnMeta(column1, "caption1", true, 1);
+        final Column column2 = createColumn("col2", "col2");
+        final ColumnMeta meta2 = new ColumnMeta(column2, "caption2", true, 0);
+        final Column column3 = createColumn("col3", "col3");
+        final ColumnMeta meta3 = new ColumnMeta(column3, "caption3", false, 2);
+
+        when(dataGrid.getColumn(0)).thenReturn(column1);
+        when(dataGrid.getColumn(1)).thenReturn(column2);
+        when(dataGrid.getColumnWidth(column1)).thenReturn(fixedColumn1Width + Style.Unit.PX.getType());
+        when(dataGrid.getColumnWidth(column2)).thenReturn(100 + Style.Unit.PC.getType());
+        when(dataGrid.getColumnWidth(column3)).thenReturn(57 + Style.Unit.PX.getType());
+
+        columnPicker.addColumns(Arrays.asList(meta1, meta2, meta3));
+        assertEquals(fixedColumn1Width + ColumnPicker.DETAULT_COLUMN_WIDTH, columnPicker.getDataGridMinWidth());
+
+        columnPicker.setDefaultColumnWidthSize(defaultColumnWidthSize);
+        columnPicker.adjustColumnWidths();
+        assertEquals(fixedColumn1Width + defaultColumnWidthSize, columnPicker.getDataGridMinWidth());
     }
 }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/PagedTableTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/PagedTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 
 package org.uberfire.ext.widgets.common.client.tables;
 
-import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Element;
 import com.google.gwt.view.client.AsyncDataProvider;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
@@ -58,11 +59,9 @@ public class PagedTableTest {
         pagedTable.dataGrid = spy(pagedTable.dataGrid);
         when(pagedTable.dataGrid.getRowCount()).thenReturn(ROWS);
 
-        verify(pagedTable.dataGrid,
-               times(0)).setHeight(anyString());
+        verify(pagedTable.dataGrid, times(0)).setHeight(anyString());
         pagedTable.loadPageSizePreferences();
-        verify(pagedTable.dataGrid,
-               times(1)).setHeight(eq(EXPECTED_HEIGHT_PX + "px"));
+        verify(pagedTable.dataGrid, times(1)).setHeight(eq(EXPECTED_HEIGHT_PX + "px"));
     }
 
     @Test
@@ -74,11 +73,9 @@ public class PagedTableTest {
         pagedTable.dataGrid = spy(pagedTable.dataGrid);
         when(pagedTable.dataGrid.getRowCount()).thenReturn(ROWS);
 
-        verify(pagedTable.dataGrid,
-               times(0)).setHeight(anyString());
+        verify(pagedTable.dataGrid, times(0)).setHeight(anyString());
         pagedTable.loadPageSizePreferences();
-        verify(pagedTable.dataGrid,
-               times(1)).setHeight(eq(EXPECTED_HEIGHT_PX + "px"));
+        verify(pagedTable.dataGrid, times(1)).setHeight(eq(EXPECTED_HEIGHT_PX + "px"));
     }
 
     @Test
@@ -88,14 +85,11 @@ public class PagedTableTest {
         PagedTable pagedTable = new PagedTable(PAGE_SIZE);
         pagedTable.dataGrid = spy(pagedTable.dataGrid);
 
-        verify(pagedTable.dataGrid,
-               times(0)).setPageStart(0);
+        verify(pagedTable.dataGrid, times(0)).setPageStart(0);
 
         pagedTable.loadPageSizePreferences();
-        verify(pagedTable.dataGrid,
-               times(1)).setPageStart(0);
+        verify(pagedTable.dataGrid, times(1)).setPageStart(0);
     }
-
 
     @Test
     public void testPageSizeSelectStartValue() throws Exception {
@@ -113,5 +107,61 @@ public class PagedTableTest {
 
         verify(select).setValue(String.valueOf(DEFAULT_PAGE_SIZE));
         verify(select).addValueChangeHandler(any());
+    }
+
+    @Test
+    public void testDataGridMinWidthNotSetByDefault() throws Exception {
+        final int PAGE_SIZE = 10;
+        Element mockElement = mock(Element.class);
+        final int minWidth = 800;
+        PagedTable pagedTable = new PagedTable(PAGE_SIZE, null, null, false, false, false);
+        ColumnPicker columnPickerMock = mock(ColumnPicker.class);
+
+        when(pagedTable.dataGridContainer.getElement()).thenReturn(mockElement);
+        when(columnPickerMock.getDataGridMinWidth()).thenReturn(minWidth);
+
+        pagedTable.setColumnPicker(columnPickerMock);
+        pagedTable.setTableHeight();
+
+        verify(mockElement, never()).setAttribute(eq("style"), anyString());
+    }
+
+    @Test
+    public void testEnableDataGridMinWidth() throws Exception {
+        final int PAGE_SIZE = 10;
+        Element mockElement = mock(Element.class);
+        final int minWidth = 800;
+        PagedTable pagedTable = new PagedTable(PAGE_SIZE, null, null, false, false, false);
+        ColumnPicker columnPickerMock = mock(ColumnPicker.class);
+
+        when(pagedTable.dataGridContainer.getElement()).thenReturn(mockElement);
+        when(columnPickerMock.getDataGridMinWidth()).thenReturn(minWidth);
+
+        pagedTable.setColumnPicker(columnPickerMock);
+        pagedTable.enableDataGridMinWidth(true);
+        pagedTable.setTableHeight();
+
+        verify(columnPickerMock, never()).setDefaultColumnWidthSize(anyInt());
+        verify(mockElement).setAttribute("style", "min-width:" + minWidth + Style.Unit.PX.getType());
+    }
+
+    @Test
+    public void testDefaultColumnWidth() throws Exception {
+        final int PAGE_SIZE = 10;
+        Element mockElement = mock(Element.class);
+        final int minWidth = 800;
+        PagedTable pagedTable = new PagedTable(PAGE_SIZE, null, null, false, false, false);
+        ColumnPicker columnPickerMock = mock(ColumnPicker.class);
+
+        when(pagedTable.dataGridContainer.getElement()).thenReturn(mockElement);
+        when(columnPickerMock.getDataGridMinWidth()).thenReturn(minWidth);
+
+        pagedTable.setColumnPicker(columnPickerMock);
+        pagedTable.setDefaultColumWidthSize(150);
+        pagedTable.enableDataGridMinWidth(true);
+        pagedTable.setTableHeight();
+
+        verify(columnPickerMock).setDefaultColumnWidthSize(150);
+        verify(mockElement).setAttribute("style", "min-width:" + minWidth + Style.Unit.PX.getType());
     }
 }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/UberfireColumnPicker.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/UberfireColumnPicker.java
@@ -25,8 +25,6 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.gwtbootstrap3.client.ui.Button;
@@ -44,7 +42,7 @@ public class UberfireColumnPicker<T> {
     protected final PopupPanel popup = GWT.create(PopupPanel.class);
     protected List<ColumnChangedHandler> columnChangedHandler = new ArrayList<>();
 
-    protected DataGrid<T> getDataGrid(){
+    protected DataGrid<T> getDataGrid() {
         return dataGrid;
     }
 
@@ -216,7 +214,7 @@ public class UberfireColumnPicker<T> {
             if (addThisColumnToPopup(columnMeta)) {
                 final CheckBox checkBox = GWT.create(CheckBox.class);
                 checkBox.setText((String) columnMeta.getHeader().getValue());
-                checkBox.setName((String)columnMeta.getHeader().getValue());
+                checkBox.setName((String) columnMeta.getHeader().getValue());
                 checkBox.setValue(columnMeta.isVisible());
                 checkBox.addValueChangeHandler(handler -> addColumnOnDataGrid(handler.getValue(), columnMeta));
 
@@ -285,6 +283,12 @@ public class UberfireColumnPicker<T> {
     }
 
     protected void loadGlobalGridPreferences() {
+    }
 
+    public int getDataGridMinWidth() {
+        return -1;
+    }
+
+    public void setDefaultColumnWidthSize(int defaultColumSize) {
     }
 }


### PR DESCRIPTION
Added the ability (enableDataGridMinWidth) to configure the PagedTable to set a minimal width to ensure that have enough space to display the visible columns. In case that the required size is bigger than the avaliable space an horizonal scroll appears. The default column size is also configurable and it's applied when the column has not one fixed.