### PR TITLE
RHPAM-1896: UnexpecterError thrown when editing displayer display pro…

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerEditor.java
@@ -18,6 +18,8 @@ package org.dashbuilder.displayer.client.widgets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -381,7 +383,7 @@ public class DisplayerEditor implements IsWidget {
         displayerSettings = event.getDisplayerSettings();
         initDisplayer();
         showDisplayer();
-        if (! currentRenderer.equals(newRenderer)) {
+        if (newRenderer != null && ! currentRenderer.equals(newRenderer)) {
             initSettingsEditor();
             currentRenderer = newRenderer;
         }

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/DisplayerEditor.java
@@ -18,7 +18,6 @@ package org.dashbuilder.displayer.client.widgets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -231,6 +230,10 @@ public class DisplayerEditor implements IsWidget {
     public Displayer getDisplayer() {
         return displayer;
     }
+    
+    public String getCurrentRenderer() {
+        return currentRenderer;
+    }
 
     public DisplayerTypeSelector getTypeSelector() {
         return typeSelector;
@@ -383,7 +386,7 @@ public class DisplayerEditor implements IsWidget {
         displayerSettings = event.getDisplayerSettings();
         initDisplayer();
         showDisplayer();
-        if (newRenderer != null && ! currentRenderer.equals(newRenderer)) {
+        if (newRenderer != null && !currentRenderer.equals(newRenderer)) {
             initSettingsEditor();
             currentRenderer = newRenderer;
         }

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/test/java/org/dashbuilder/displayer/client/widgets/DisplayerEditorTest.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/test/java/org/dashbuilder/displayer/client/widgets/DisplayerEditorTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +43,7 @@ import org.dashbuilder.displayer.client.RendererManager;
 import org.dashbuilder.displayer.client.events.DataSetLookupChangedEvent;
 import org.dashbuilder.displayer.client.events.DisplayerEditorClosedEvent;
 import org.dashbuilder.displayer.client.events.DisplayerEditorSavedEvent;
+import org.dashbuilder.displayer.client.events.DisplayerSettingsChangedEvent;
 import org.dashbuilder.displayer.client.prototypes.DisplayerPrototypes;
 import org.junit.Before;
 import org.junit.Test;
@@ -111,6 +113,9 @@ public class DisplayerEditorTest {
 
     @Mock
     DataSetLookupConstraints lookupConstraints;
+    
+    @Mock
+    DisplayerSettingsChangedEvent displayerSettingsChangedEvent;
 
     DisplayerEditor presenter = null;
 
@@ -269,5 +274,25 @@ public class DisplayerEditorTest {
         presenter.onDataSetLookupChanged(new DataSetLookupChangedEvent(settings2.getDataSetLookup()));
         verify(settingsEditor).init(any());
         assertEquals(presenter.getDisplayerSettings().getColumnSettingsList().size(), 0);
+    }
+    
+    @Test
+    public void rendererSettingChangedTest() {
+        String otherRenderer = "otherRenderer";
+        when(displayerSettingsChangedEvent.getDisplayerSettings()).thenReturn(displayerSettings);
+        
+        presenter.onDisplayerSettingsChanged(displayerSettingsChangedEvent);
+        verify(settingsEditor, times(0)).init(any());
+        
+        when(displayerSettings.getRenderer()).thenReturn(otherRenderer);
+        presenter.onDisplayerSettingsChanged(displayerSettingsChangedEvent);
+        verify(settingsEditor).init(any());
+        assertEquals(otherRenderer, presenter.getCurrentRenderer());
+        
+        reset(displayerSettings);
+        when(displayerSettings.getRenderer()).thenReturn(null);
+        presenter.onDisplayerSettingsChanged(displayerSettingsChangedEvent);
+        assertEquals(otherRenderer, presenter.getCurrentRenderer());
+        
     }
 }


### PR DESCRIPTION
newRenderer is null when user changes other properties than renderer, without changing the renderer before.