### PR TITLE
AF-1821: Readiness and Liveness endpoints

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
@@ -85,7 +85,6 @@ public class BasicAuthSecurityFilter implements Filter {
         if (isExceptionPath(request)) {
             chain.doFilter(request, response);
             return;
-
         }
 
         HttpSession session = request.getSession(false);
@@ -123,6 +122,10 @@ public class BasicAuthSecurityFilter implements Filter {
 
         while (requestURI != null && requestURI.endsWith("/")) {
             requestURI = requestURI.substring(0, requestURI.length() - 1);
+        }
+
+        if (requestURI != null && requestURI.startsWith(request.getContextPath())) {
+            requestURI = requestURI.replaceFirst(request.getContextPath(), "");
         }
 
         return excludedPaths.contains(requestURI);

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/BasicAuthSecurityFilter.java
@@ -17,6 +17,10 @@
 package org.uberfire.ext.security.server;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -34,20 +38,24 @@ import org.jboss.errai.security.shared.api.identity.User;
 import org.jboss.errai.security.shared.exception.FailedAuthenticationException;
 import org.jboss.errai.security.shared.service.AuthenticationService;
 
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 public class BasicAuthSecurityFilter implements Filter {
 
     public static final String REALM_NAME_PARAM = "realmName";
     public static final String INVALIDATE_PARAM = "invalidate";
-
+    public static final String EXCEPTION_PATHS = "excludedPaths";
 
     @Inject
     AuthenticationService authenticationService;
 
     private String realmName = "UberFire Security Extension Default Realm";
     private Boolean invalidate = true;
+    private Set<String> excludedPaths = new HashSet<>();
 
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
+    public void init(final FilterConfig filterConfig) {
         final String realmName = filterConfig.getInitParameter(REALM_NAME_PARAM);
         if (realmName != null) {
             this.realmName = realmName;
@@ -55,6 +63,10 @@ public class BasicAuthSecurityFilter implements Filter {
         final String invalidate = filterConfig.getInitParameter(INVALIDATE_PARAM);
         if (invalidate != null) {
             this.invalidate = Boolean.valueOf(invalidate);
+        }
+        final String excludedPaths = filterConfig.getInitParameter(EXCEPTION_PATHS);
+        if (excludedPaths != null) {
+            this.excludedPaths = Arrays.stream(excludedPaths.split(",")).filter(s -> !isBlank(s)).collect(toSet());
         }
     }
 
@@ -66,8 +78,15 @@ public class BasicAuthSecurityFilter implements Filter {
     public void doFilter(final ServletRequest _request,
                          final ServletResponse _response,
                          final FilterChain chain) throws IOException, ServletException {
+
         final HttpServletRequest request = (HttpServletRequest) _request;
         final HttpServletResponse response = (HttpServletResponse) _response;
+
+        if (isExceptionPath(request)) {
+            chain.doFilter(request, response);
+            return;
+
+        }
 
         HttpSession session = request.getSession(false);
         final User user = authenticationService.getUser();
@@ -97,6 +116,16 @@ public class BasicAuthSecurityFilter implements Filter {
                 }
             }
         }
+    }
+
+    private boolean isExceptionPath(final HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+
+        while (requestURI != null && requestURI.endsWith("/")) {
+            requestURI = requestURI.substring(0, requestURI.length() - 1);
+        }
+
+        return excludedPaths.contains(requestURI);
     }
 
     public void challengeClient(final HttpServletRequest request,

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/BasicAuthSecurityFilterTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/BasicAuthSecurityFilterTest.java
@@ -56,6 +56,22 @@ public class BasicAuthSecurityFilterTest {
     private HttpSession httpSession;
 
     @Test
+    public void excludedPathsWithNonEmptyContextSkipsAuthentication() throws IOException, ServletException {
+        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter();
+
+        final FilterConfig config = mock(FilterConfig.class);
+        when(config.getInitParameter(BasicAuthSecurityFilter.EXCEPTION_PATHS)).thenReturn("/test/foo");
+        filter.init(config);
+
+        when(request.getRequestURI()).thenReturn("/my-context/test/foo");
+        when(request.getContextPath()).thenReturn("/my-context");
+        filter.doFilter(request,response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(request, never()).getSession(anyBoolean());
+    }
+
+    @Test
     public void excludedPathsWithEmptyPathSkipsAuthentication() throws IOException, ServletException {
         final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter();
 
@@ -64,6 +80,7 @@ public class BasicAuthSecurityFilterTest {
         filter.init(config);
 
         when(request.getRequestURI()).thenReturn("/test/foo");
+        when(request.getContextPath()).thenReturn("");
         filter.doFilter(request,response, chain);
 
         verify(chain).doFilter(request, response);
@@ -79,6 +96,7 @@ public class BasicAuthSecurityFilterTest {
         filter.init(config);
 
         when(request.getRequestURI()).thenReturn("/test/foo");
+        when(request.getContextPath()).thenReturn("");
         filter.doFilter(request,response, chain);
 
         verify(chain).doFilter(request, response);
@@ -94,6 +112,7 @@ public class BasicAuthSecurityFilterTest {
         filter.init(config);
 
         when(request.getRequestURI()).thenReturn("/test/bar/");
+        when(request.getContextPath()).thenReturn("");
         filter.doFilter(request,response, chain);
 
         verify(chain).doFilter(request, response);

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/BasicAuthSecurityFilterTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/BasicAuthSecurityFilterTest.java
@@ -16,8 +16,11 @@
 
 package org.uberfire.ext.security.server;
 
+import java.io.IOException;
+
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -51,6 +54,51 @@ public class BasicAuthSecurityFilterTest {
 
     @Mock
     private HttpSession httpSession;
+
+    @Test
+    public void excludedPathsWithEmptyPathSkipsAuthentication() throws IOException, ServletException {
+        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter();
+
+        final FilterConfig config = mock(FilterConfig.class);
+        when(config.getInitParameter(BasicAuthSecurityFilter.EXCEPTION_PATHS)).thenReturn("/test/foo,,");
+        filter.init(config);
+
+        when(request.getRequestURI()).thenReturn("/test/foo");
+        filter.doFilter(request,response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(request, never()).getSession(anyBoolean());
+    }
+
+    @Test
+    public void excludedPathSkipsAuthentication() throws IOException, ServletException {
+        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter();
+
+        final FilterConfig config = mock(FilterConfig.class);
+        when(config.getInitParameter(BasicAuthSecurityFilter.EXCEPTION_PATHS)).thenReturn("/test/foo,/test/bar");
+        filter.init(config);
+
+        when(request.getRequestURI()).thenReturn("/test/foo");
+        filter.doFilter(request,response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(request, never()).getSession(anyBoolean());
+    }
+
+    @Test
+    public void excludedPathWithTrailingSlashSkipsAuthentication() throws IOException, ServletException {
+        final BasicAuthSecurityFilter filter = new BasicAuthSecurityFilter();
+
+        final FilterConfig config = mock(FilterConfig.class);
+        when(config.getInitParameter(BasicAuthSecurityFilter.EXCEPTION_PATHS)).thenReturn("/test/foo,/test/bar");
+        filter.init(config);
+
+        when(request.getRequestURI()).thenReturn("/test/bar/");
+        filter.doFilter(request,response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(request, never()).getSession(anyBoolean());
+    }
 
     @Test
     public void testIndependentSessionInvalidated() throws Exception {


### PR DESCRIPTION
This PR adds a init-param to the `BasicAuthSecurityFilter` so that it's possible to configure URIs that should not be authenticated.

Related PRs:
https://github.com/kiegroup/appformer/pull/645
https://github.com/kiegroup/kie-wb-common/pull/2492
https://github.com/kiegroup/kie-wb-distributions/pull/881