### PR TITLE
Remove redundant property declarations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,9 @@
     <version.bundle.plugin>3.3.0</version.bundle.plugin><!-- 3.2.0 sometimes fails with NPE during parallel build-->
     <!-- Make OSGi happy -->
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
-    <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
-    <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
     <version.io.netty.old>3.10.6.Final</version.io.netty.old>
     <version.org.elasticsearch>5.6.1</version.org.elasticsearch>
-    <version.org.apache.lucene>6.6.1</version.org.apache.lucene>
     <version.com.unboundid>3.2.0</version.com.unboundid>
     <version.org.infinispan>9.3.2.Final</version.org.infinispan>
     <version.org.infinispan.protostream>4.2.2.Final</version.org.infinispan.protostream>
@@ -141,10 +138,6 @@
 
     <!-- required to fix RHDM-293 -->
     <version.org.apache.logging.log4j.log4j-to-slf4j>2.9.0</version.org.apache.logging.log4j.log4j-to-slf4j>
-
-    <!-- this versions can be removed once these were migrated to jboss-ip-bom > 8.3.0.Final -->
-    <version.org.wildfly>14.0.1.Final</version.org.wildfly>
-    <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
 
     <version.org.arquillian.cube>1.15.3</version.org.arquillian.cube>
 


### PR DESCRIPTION
A small contribution towards more centralized version management.
Removing all properties which are already declare in one of the parent poms (jboss-parent or jboss-integration-platform-parent) with **the same** value:


```
uberfire-parent overrides 'version.org.apache.lucene' defined in jboss-integration-platform-parent from '6.6.1' to '6.6.1'
uberfire-parent overrides 'version.org.wildfly' defined in jboss-integration-platform-parent from '14.0.1.Final' to '14.0.1.Final'
uberfire-parent overrides 'version.org.wildfly.core' defined in jboss-integration-platform-parent from '6.0.2.Final' to '6.0.2.Final'
uberfire-parent overrides 'jboss.releases.repo.url' defined in jboss-parent from 'https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/' to 'https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/'
uberfire-parent overrides 'jboss.snapshots.repo.url' defined in jboss-parent from 'https://repository.jboss.org/nexus/content/repositories/snapshots/' to 'https://repository.jboss.org/nexus/content/repositories/snapshots/'
```

Apart from reducing redundancy and making future updates less painfull, this should have zero effect on the build.