### PR TITLE
[BAQE-888] Investigate a fix JGit community tests failures on windows

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitCacheInvalidationTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitCacheInvalidationTest.java
@@ -150,5 +150,8 @@ public class JGitCacheInvalidationTest extends AbstractTestInfra {
         realInstanceFs1.lock();
         assertThat(realInstanceFs1.hasBeenInUse()).isTrue();
         assertThat(anotherInstanceOfFs1.hasBeenInUse()).isTrue();
+
+        // Unlock the lock so that cleanup can finish on Windows
+        realInstanceFs1.unlock();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderPostCommitHookTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderPostCommitHookTest.java
@@ -17,6 +17,7 @@
 package org.uberfire.java.nio.fs.jgit;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,7 +26,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.extensions.FileSystemHookExecutionContext;
 import org.uberfire.java.nio.file.extensions.FileSystemHooks;
@@ -138,14 +138,20 @@ public class JGitFileSystemImplProviderPostCommitHookTest extends AbstractTestIn
 
         FileUtils.write(destHookFile, SCRIPT + code, Charset.defaultCharset());
 
-        Set<PosixFilePermission> perms = new HashSet<>();
-        perms.add(PosixFilePermission.OWNER_READ);
-        perms.add(PosixFilePermission.OWNER_WRITE);
-        perms.add(PosixFilePermission.GROUP_EXECUTE);
-        perms.add(PosixFilePermission.OTHERS_EXECUTE);
-        perms.add(PosixFilePermission.OWNER_EXECUTE);
+        if (SystemUtils.IS_OS_WINDOWS) {
+            destHookFile.setReadable(true);
+            destHookFile.setWritable(true);
+            destHookFile.setExecutable(true);
+        } else {
+            Set<PosixFilePermission> perms = new HashSet<>();
+            perms.add(PosixFilePermission.OWNER_READ);
+            perms.add(PosixFilePermission.OWNER_WRITE);
+            perms.add(PosixFilePermission.GROUP_EXECUTE);
+            perms.add(PosixFilePermission.OTHERS_EXECUTE);
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
 
-        Files.setPosixFilePermissions(destHookFile.toPath(), perms);
+            Files.setPosixFilePermissions(destHookFile.toPath(), perms);
+        }
     }
 
     private void commitFile() throws IOException {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
@@ -112,8 +112,8 @@ public class JGitForkTest extends AbstractTestInfra {
         assertThat(new ListRefs(cloned.getRepository()).execute().get(0).getName()).isEqualTo("refs/heads/master");
         assertThat(new ListRefs(cloned.getRepository()).execute().get(1).getName()).isEqualTo("refs/heads/user_branch");
 
-        final String remotePath = ((GitImpl) cloned)._remoteList().call().get(0).getURIs().get(0).getPath();
-        assertThat(remotePath).isEqualTo(gitSource.getPath() + "/");
+        final String remotePath = new File(((GitImpl) cloned)._remoteList().call().get(0).getURIs().get(0).getPath()).getAbsolutePath();
+        assertThat(remotePath).isEqualTo(new File(gitSource.getPath()).getAbsolutePath());
     }
 
     @Test(expected = GitException.class)
@@ -300,8 +300,8 @@ public class JGitForkTest extends AbstractTestInfra {
 
         assertThat(new ListRefs(cloned.getRepository()).execute().get(0).getName()).isEqualTo("refs/heads/user_branch");
 
-        final String remotePath = ((GitImpl) cloned)._remoteList().call().get(0).getURIs().get(0).getPath();
-        assertThat(remotePath).isEqualTo(gitSource.getPath() + "/");
+        final String remotePath = new File(((GitImpl) cloned)._remoteList().call().get(0).getURIs().get(0).getPath()).getAbsolutePath();
+        assertThat(remotePath).isEqualTo(new File(gitSource.getPath()).getAbsolutePath());
 
         boolean foundPreCommitHook = false;
         boolean foundPostCommitHook = false;


### PR DESCRIPTION
* Unlock locked 'doraFs' instance after the asserts
Locks make this test fail on Windows, because of how
Windows handles files in use. 
Also multiple tests can't be executed because `AbstractTestInfra` is unable to deleted locked files on Windows.

* Set file permisions differently when running on Windows
PosixFilePermission is not supported in Windows environment, adds a branch  that sets permissions in compatible way 

* Wrap path assertions strings with File to make it OS agnostic 

Use File to make asserts that check paths work on windows properly too
