### PR TITLE
DROOLS-3438: Unify cell editing cancellation 

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/single/impl/BaseSingletonDOMElementFactory.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dom/single/impl/BaseSingletonDOMElementFactory.java
@@ -74,7 +74,11 @@ public abstract class BaseSingletonDOMElementFactory<T, W extends Widget, E exte
 
     @Override
     public void destroyResources() {
-        flush();
+        if (e != null) {
+            e.detach();
+            widget = null;
+            e = null;
+        }
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/keyboard/KeyDownHandlerCommon.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/keyboard/KeyDownHandlerCommon.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.grid.keyboard;
+
+import java.util.Optional;
+
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDOMElementResource;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.SelectionExtension;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+
+public class KeyDownHandlerCommon implements KeyDownHandler {
+
+    protected final GridLienzoPanel gridPanel;
+    protected final GridLayer gridLayer;
+    protected final GridWidget gridWidget;
+    protected final HasSingletonDOMElementResource gridCell;
+    protected final GridBodyCellRenderContext context;
+
+    public KeyDownHandlerCommon(final GridLienzoPanel gridPanel,
+                                final GridLayer gridLayer,
+                                final GridWidget gridWidget,
+                                final HasSingletonDOMElementResource gridCell,
+                                final GridBodyCellRenderContext context) {
+        this.gridPanel = gridPanel;
+        this.gridLayer = gridLayer;
+        this.gridWidget = gridWidget;
+        this.gridCell = gridCell;
+        this.context = context;
+    }
+
+    @Override
+    public void onKeyDown(final KeyDownEvent e) {
+        final int keyCode = e.getNativeKeyCode();
+        final boolean isShiftKeyDown = e.isShiftKeyDown();
+        switch (keyCode) {
+            case KeyCodes.KEY_TAB:
+            case KeyCodes.KEY_ENTER:
+                gridCell.flush();
+                moveSelection(keyCode,
+                              isShiftKeyDown);
+                e.preventDefault();
+
+            case KeyCodes.KEY_ESCAPE:
+                gridCell.destroyResources();
+                gridPanel.setFocus(true);
+                gridLayer.batch();
+        }
+
+        e.stopPropagation();
+    }
+
+    protected void moveSelection(final int keyCode,
+                                 final boolean isShiftKeyDown) {
+        final Optional<Integer> dx = getDelta(keyCode,
+                                              KeyCodes.KEY_TAB,
+                                              isShiftKeyDown);
+        final Optional<Integer> dy = getDelta(keyCode,
+                                              KeyCodes.KEY_ENTER,
+                                              isShiftKeyDown);
+
+        if (dx.isPresent()) {
+            gridWidget.adjustSelection(dx.get() > 0 ? SelectionExtension.RIGHT : SelectionExtension.LEFT,
+                                       false);
+        }
+
+        if (dy.isPresent()) {
+            gridWidget.adjustSelection(dy.get() > 0 ? SelectionExtension.DOWN : SelectionExtension.UP,
+                                       false);
+        }
+    }
+
+    private Optional<Integer> getDelta(final int keyCode,
+                                       final int requiredKeyCode,
+                                       final boolean isShiftKeyDown) {
+        if (keyCode == requiredKeyCode) {
+            return Optional.of(isShiftKeyDown ? -1 : 1);
+        }
+        return Optional.empty();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/keyboard/KeyDownHandlerCommonTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/keyboard/KeyDownHandlerCommonTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.grid.keyboard;
+
+import java.util.Optional;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.dom.single.HasSingletonDOMElementResource;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class KeyDownHandlerCommonTest {
+
+    @Mock
+    private GridLayer gridLayer;
+
+    @Mock
+    private GridLienzoPanel gridPanel;
+
+    @Mock
+    private GridWidget gridWidget;
+
+    @Mock
+    private HasSingletonDOMElementResource gridCell;
+
+    @Mock
+    private GridBodyCellRenderContext context;
+
+    @Mock
+    private GridColumn.HeaderMetaData headerMetaData;
+
+    @Mock
+    private GridColumnRenderer<?> columnRenderer;
+
+    protected GridData uiModel;
+
+    private KeyDownHandlerCommon handler;
+
+    @Before
+    public void setUpHandler() {
+        uiModel = new BaseGridData();
+        handler = new KeyDownHandlerCommon(gridPanel,
+                                           gridLayer,
+                                           gridWidget,
+                                           gridCell,
+                                           context);
+
+        for (int size = 0; size < 3; size++) {
+            uiModel.appendRow(new BaseGridRow());
+            uiModel.appendColumn(new BaseGridColumn<>(headerMetaData,
+                                                      columnRenderer,
+                                                      100.0));
+        }
+
+        when(gridWidget.getModel()).thenReturn(uiModel);
+    }
+
+    @Test
+    public void tabKeyCanvasActions() {
+        final KeyDownEvent e = mockKeyDownEvent(Optional.of(KeyCodes.KEY_TAB),
+                                                Optional.of(false),
+                                                Optional.of(false));
+
+        handler.onKeyDown(e);
+
+        verify(gridCell).flush();
+        verify(e).preventDefault();
+        verifyCommonActions();
+    }
+
+    @Test
+    public void enterKeyCanvasActions() {
+        final KeyDownEvent e = mockKeyDownEvent(Optional.of(KeyCodes.KEY_ENTER),
+                                                Optional.of(false),
+                                                Optional.of(false));
+
+        handler.onKeyDown(e);
+
+        verify(gridCell).flush();
+        verifyCommonActions();
+    }
+
+    @Test
+    public void escapeKeyCanvasActions() {
+        final KeyDownEvent e = mockKeyDownEvent(Optional.of(KeyCodes.KEY_ESCAPE),
+                                                Optional.of(false),
+                                                Optional.of(false));
+
+        handler.onKeyDown(e);
+
+        verify(gridCell,
+               never()).flush();
+        verifyCommonActions();
+    }
+
+    private void verifyCommonActions() {
+        verify(gridCell).destroyResources();
+        verify(gridPanel).setFocus(eq(true));
+        verify(gridLayer).batch();
+    }
+
+    private KeyDownEvent mockKeyDownEvent(final Optional<Integer> keyCode,
+                                          final Optional<Boolean> isShiftKeyDown,
+                                          final Optional<Boolean> isControlKeyDown) {
+        final KeyDownEvent e = mock(KeyDownEvent.class);
+        keyCode.ifPresent((c) -> when(e.getNativeKeyCode()).thenReturn(c));
+        isShiftKeyDown.ifPresent((c) -> when(e.isShiftKeyDown()).thenReturn(c));
+        isControlKeyDown.ifPresent((c) -> when(e.isControlKeyDown()).thenReturn(c));
+        return e;
+    }
+}


### PR DESCRIPTION
Ensemble together with:
- kiegroup/drools-wb#1112

This PR unifies the way how Guided Decision Table and Scenario Simulation user can cancel the cell edit mode.

- By enter, new value is stored, selection is moved down
- By shift + enter, new value is stored, selection is moved up
- By tab, new value is stored, selection is moved right
- By shift + tab, new value is stored, selection is moved left
- By Esc, new value is discarded, selection remains same