### PR TITLE
DROOLS-3591: [DMN Designer] Data Types - Type dropdown is not navigable by keyboard

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
@@ -26,125 +26,89 @@ import static org.uberfire.client.views.pfly.sys.MomentUtils.setMomentLocale;
  */
 public class PatternFlyBootstrapper {
 
+    private static boolean isjQueryLoaded = false;
+
+    private static boolean isPrettifyLoaded = false;
+
+    private static boolean isBootstrapSelectLoaded = false;
+
+    private static boolean isBootstrapDateRangePickerLoaded = false;
+
+    private static boolean isMomentLoaded = false;
+
+    private static boolean isPatternFlyLoaded = false;
+
+    private static boolean isD3Loaded = false;
+
     /**
      * Uses GWT's ScriptInjector to put jQuery in the page if it isn't already. All Errai IOC beans that rely on
      * GWTBootstrap 3 widgets should call this before creating their first such widget.
      */
     public static void ensurejQueryIsAvailable() {
-        if (!isjQueryLoaded()) {
+        if (!isjQueryLoaded) {
             ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.jQuery().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isjQueryLoaded = true;
         }
     }
 
     public static void ensurePrettifyIsAvailable() {
-        if (!isPrettifyLoaded()) {
+        if (!isPrettifyLoaded) {
             ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.prettify().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isPrettifyLoaded = true;
         }
     }
 
     public static void ensureBootstrapSelectIsAvailable() {
-        if (!isBootstrapSelectLoaded()) {
+        if (!isBootstrapSelectLoaded) {
             ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.bootstrapSelect().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isBootstrapSelectLoaded = true;
         }
     }
 
     public static void ensurePatternFlyIsAvailable() {
         ensurejQueryIsAvailable();
         ensureBootstrapSelectIsAvailable();
-        if (!isPatternFlyLoaded()) {
+        if (!isPatternFlyLoaded) {
             ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.patternFly().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isPatternFlyLoaded = true;
         }
     }
 
     public static void ensureMomentIsAvailable() {
-        if (!isMomentLoaded()) {
+        if (!isMomentLoaded) {
             ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.moment().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isMomentLoaded = true;
         }
         setMomentLocale();
     }
 
     public static void ensureBootstrapDateRangePickerIsAvailable() {
         ensureMomentIsAvailable();
-        if (!isBootstrapDateRangePickerLoaded()) {
+        if (!isBootstrapDateRangePickerLoaded) {
             ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.bootstrapDateRangePicker().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isBootstrapDateRangePickerLoaded = true;
         }
     }
 
     public static void ensureD3IsAvailable() {
-        if (!isD3Loaded()) {
+        if (!isD3Loaded) {
             ScriptInjector.fromString(PatternFlyClientBundle.INSTANCE.d3().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
+            isD3Loaded = true;
         }
     }
-
-    /**
-     * Checks to see if jQuery is already present.
-     * @return true is jQuery is loaded, false otherwise.
-     */
-    private static native boolean isjQueryLoaded() /*-{
-        return (typeof $wnd['jQuery'] !== 'undefined');
-    }-*/;
-
-    /**
-     * Checks to see if Prettify is already present.
-     * @return true is Prettify is loaded, false otherwise.
-     */
-    private static native boolean isPrettifyLoaded() /*-{
-        return (typeof $wnd['prettyPrint'] !== 'undefined');
-    }-*/;
-
-    /**
-     * Checks to see if bootstrap-select is already present.
-     * @return true is bootstrap-select is loaded, false otherwise.
-     */
-    private static native boolean isBootstrapSelectLoaded() /*-{
-        return (typeof $wnd['Selectpicker'] !== 'undefined');
-    }-*/;
-
-    /**
-     * Checks to see if bootstrap-daterangepicker is already present.
-     * @return true is bootstrap-daterangepicker is loaded, false otherwise.
-     */
-    private static native boolean isBootstrapDateRangePickerLoaded() /*-{
-        return (typeof $wnd['DateRangePicker'] !== 'undefined');
-    }-*/;
-
-    /**
-     * Checks to see if moment is already present.
-     * @return true is moment is loaded, false otherwise.
-     */
-    public static native boolean isMomentLoaded() /*-{
-        return (typeof $wnd['moment'] !== 'undefined');
-    }-*/;
-
-    /**
-     * Checks to see if PatternFly is already present.
-     * @return true is PatternFly is loaded, false otherwise.
-     */
-    private static native boolean isPatternFlyLoaded() /*-{
-        return (typeof $wnd['patternfly'] !== 'undefined');
-    }-*/;
-
-    /**
-     * Checks to see if D3 is already present.
-     * @return true is D3 is loaded, false otherwise.
-     */
-    private static native boolean isD3Loaded() /*-{
-        return (typeof $wnd['d3'] !== 'undefined');
-    }-*/;
-
 }
 

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
@@ -26,8 +26,6 @@ import static org.uberfire.client.views.pfly.sys.MomentUtils.setMomentLocale;
  */
 public class PatternFlyBootstrapper {
 
-    private static boolean isjQueryLoaded = false;
-
     private static boolean isPrettifyLoaded = false;
 
     private static boolean isBootstrapSelectLoaded = false;
@@ -45,11 +43,10 @@ public class PatternFlyBootstrapper {
      * GWTBootstrap 3 widgets should call this before creating their first such widget.
      */
     public static void ensurejQueryIsAvailable() {
-        if (!isjQueryLoaded) {
+        if (!isjQueryLoaded()) {
             ScriptInjector.fromString(GwtBootstrap3ClientBundle.INSTANCE.jQuery().getText())
                     .setWindow(ScriptInjector.TOP_WINDOW)
                     .inject();
-            isjQueryLoaded = true;
         }
     }
 
@@ -110,5 +107,13 @@ public class PatternFlyBootstrapper {
             isD3Loaded = true;
         }
     }
+
+    /**
+     * Checks to see if jQuery is already present.
+     * @return true is jQuery is loaded, false otherwise.
+     */
+    private static native boolean isjQueryLoaded() /*-{
+        return (typeof $wnd['jQuery'] !== 'undefined');
+    }-*/;
 }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3591

Also see https://issues.jboss.org/browse/RHDM-912

The problem was that the `BootstrapSelect` Java Script was being loaded multiple times and event handlers for the component were being registered an equal number of multiple times. This lead to, for example, a cursor-down key press moving the selection multiple times.

I put a break point in `bootstrap-select.js` (L#1506) and observed the selection move one position, then another and another; for each successive registered event handler. Debugging `PatternFlyBootstrapper` showed the check failed and multiple instances of the `BootstrapSelect` were injected into the header. I also examined the `global` Java Script objects on the page and there was none for `Selectpicker` (nor `DateRangePicker` -- another script). 

This leads me to suspect GWT is obfuscating the resources in `PatternFlyClientBundle` and hence the existing checks unsuitable. That said, if anybody can think of a better solution than that posed in this PR I'm happy to try, test and modify :-) 

@jomarko This will probably need a test of Business Central.. I checked DMN and it seems to work fine to me.. however IDK where else the other libraries are used and hence it might be worth asking around (in QE) for others to check the BC WAR too to verify nothings broken. I'll leave that decision to you.