### PR TITLE
DROOLS-3940: DMN Editor: Update contextual menus (headers and cells)

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataSelectionsManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridDataSelectionsManager.java
@@ -70,7 +70,12 @@ public class BaseGridDataSelectionsManager {
     }
 
     public void onDeleteColumn(final int index) {
-        final List<GridData.SelectedCell> selectedCells = gridData.getSelectedCells();
+        onDeleteColumn(index, gridData.getSelectedCells());
+        onDeleteColumn(index, gridData.getSelectedHeaderCells());
+    }
+
+    private void onDeleteColumn(final int index,
+                                final List<GridData.SelectedCell> selectedCells) {
         final List<GridData.SelectedCell> selectedCellsToRemove = new ArrayList<GridData.SelectedCell>();
         final List<GridData.SelectedCell> selectedCellsToUpdate = new ArrayList<GridData.SelectedCell>();
         for (GridData.SelectedCell sc : selectedCells) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/GridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/GridWidget.java
@@ -18,7 +18,6 @@ package org.uberfire.ext.wires.core.grids.client.widget.grid;
 import com.ait.lienzo.client.core.event.INodeXYEvent;
 import com.ait.lienzo.client.core.event.NodeMouseClickHandler;
 import com.ait.lienzo.client.core.shape.Group;
-import com.ait.lienzo.client.core.shape.GroupOf;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.types.Point2D;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
@@ -100,8 +99,18 @@ public interface GridWidget extends IPrimitive<Group>,
     boolean isSelected();
 
     /**
+     * Show context menu of a header cell at coordinates 'uiHeaderRowIndex' and 'uiHeaderColumnIndex'.
+     * If the provided coordinate does not resolve to a header cell in the Grid no operation is performed.
+     * @param uiHeaderRowIndex Header row index of cell to invoke context menu
+     * @param uiHeaderColumnIndex Header column index of cell to invoke context menu
+     * @return true if menu was shown.
+     */
+    boolean showContextMenuForHeader(final int uiHeaderRowIndex,
+                                     final int uiHeaderColumnIndex);
+
+    /**
      * Show context menu of a cell at coordinates 'uiRowIndex' and 'uiColumnIndex'.
-     * If the provided Canvas coordinate does not resolve to a cell in the Grid no operation is performed.
+     * If the provided coordinate does not resolve to a cell in the Grid no operation is performed.
      * @param uiRowIndex Row index of cell to invoke context menu
      * @param uiColumnIndex Column index of cell to invoke context menu
      * @return true if menu was shown.

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
@@ -827,6 +827,13 @@ public class BaseGridWidget extends Group implements GridWidget {
     }
 
     @Override
+    public boolean showContextMenuForHeader(final int uiHeaderRowIndex,
+                                            final int uiHeaderColumnIndex) {
+        // no operation by default
+        return false;
+    }
+
+    @Override
     public boolean showContextMenuForCell(final int uiRowIndex,
                                           final int uiColumnIndex) {
         // no operation by default

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/KeyboardOperationInvokeContextMenuForSelectedCell.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/KeyboardOperationInvokeContextMenuForSelectedCell.java
@@ -16,10 +16,16 @@
 
 package org.uberfire.ext.wires.core.grids.client.widget.grid.impl;
 
+import java.util.List;
+
 import com.google.gwt.event.dom.client.KeyCodes;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.util.CellContextUtilities;
 import org.uberfire.ext.wires.core.grids.client.util.ColumnIndexUtilities;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
 public class KeyboardOperationInvokeContextMenuForSelectedCell extends BaseKeyboardOperation {
@@ -41,7 +47,7 @@ public class KeyboardOperationInvokeContextMenuForSelectedCell extends BaseKeybo
     @Override
     public boolean isExecutable(final GridWidget gridWidget) {
         final GridData model = gridWidget.getModel();
-        return model.getSelectedCells().size() > 0;
+        return model.getSelectedHeaderCells().size() > 0 || model.getSelectedCells().size() > 0;
     }
 
     @Override
@@ -49,6 +55,29 @@ public class KeyboardOperationInvokeContextMenuForSelectedCell extends BaseKeybo
     public boolean perform(final GridWidget gridWidget,
                            final boolean isShiftKeyDown,
                            final boolean isControlKeyDown) {
+        final GridData model = gridWidget.getModel();
+        if (model.getSelectedHeaderCells().size() > 0) {
+            return performHeaderOperation(gridWidget);
+        } else if (model.getSelectedCells().size() > 0) {
+            return performBodyOperation(gridWidget);
+        }
+        return false;
+    }
+
+    protected boolean performHeaderOperation(final GridWidget gridWidget) {
+        final GridData model = gridWidget.getModel();
+        final List<GridData.SelectedCell> selectedHeaderCells = model.getSelectedHeaderCells();
+        if (selectedHeaderCells.isEmpty()) {
+            return false;
+        }
+        final GridData.SelectedCell firstSelectedHeaderCell = selectedHeaderCells.get(0);
+        final int headerRowIndex = firstSelectedHeaderCell.getRowIndex();
+        final int headerColumnIndex = ColumnIndexUtilities.findUiColumnIndex(model.getColumns(),
+                                                                             firstSelectedHeaderCell.getColumnIndex());
+        return gridWidget.showContextMenuForHeader(headerRowIndex, headerColumnIndex);
+    }
+
+    protected boolean performBodyOperation(final GridWidget gridWidget) {
         final GridData model = gridWidget.getModel();
         final GridData.SelectedCell origin = model.getSelectedCellsOrigin();
         if (origin == null) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/model/impl/GridCellSelectionsTest.java
@@ -1253,6 +1253,30 @@ public class GridCellSelectionsTest extends BaseGridTest {
     }
 
     @Test
+    public void testSelectHeaderCellDeleteColumn() {
+        constructGridData(2, 0);
+        final GridColumn<String> gc0 = gridColumns[0];
+        final GridColumn<String> gc1 = gridColumns[1];
+
+        gc0.getHeaderMetaData().add(new BaseHeaderMetaData("col0"));
+        gc1.getHeaderMetaData().add(new BaseHeaderMetaData("col1"));
+
+        gridData.selectHeaderCell(0, 0);
+        gridData.selectHeaderCell(0, 1);
+        assertEquals(2,
+                     gridData.getSelectedHeaderCells().size());
+
+        gridData.deleteColumn(gc0);
+
+        assertTrue(gridData.getSelectedHeaderCells().contains(new GridData.SelectedCell(0,
+                                                                                        0)));
+        assertFalse(gridData.getSelectedHeaderCells().contains(new GridData.SelectedCell(0,
+                                                                                         1)));
+        assertEquals(1,
+                     gridData.getSelectedHeaderCells().size());
+    }
+
+    @Test
     public void testSelectCellDeleteColumnWithAdditionalSelections() {
         constructGridData(2, 1);
         final GridColumn<String> gc1 = gridColumns[0];

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/KeyboardOperationInvokeContextMenuForSelectedCellTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/KeyboardOperationInvokeContextMenuForSelectedCellTest.java
@@ -51,7 +51,7 @@ public class KeyboardOperationInvokeContextMenuForSelectedCellTest {
     private KeyboardOperationInvokeContextMenuForSelectedCell testedOperation;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         testedOperation = new KeyboardOperationInvokeContextMenuForSelectedCell(gridLayerMock);
 
         doReturn(gridDataMock).when(gridWidgetMock).getModel();
@@ -72,6 +72,13 @@ public class KeyboardOperationInvokeContextMenuForSelectedCellTest {
     }
 
     @Test
+    public void testIsExecutableSelectedHeader() {
+        doReturn(Collections.singletonList(mock(GridData.SelectedCell.class))).when(gridDataMock).getSelectedHeaderCells();
+
+        assertThat(testedOperation.isExecutable(gridWidgetMock)).isTrue();
+    }
+
+    @Test
     public void testIsExecutableSelectedCells() {
         doReturn(Collections.singletonList(mock(GridData.SelectedCell.class))).when(gridDataMock).getSelectedCells();
 
@@ -79,7 +86,33 @@ public class KeyboardOperationInvokeContextMenuForSelectedCellTest {
     }
 
     @Test
-    public void testPerform() {
+    public void testPerformWithSelectedHeader() {
+        // non null indexes to verify the coordinates translation
+        final int headerRowIndex = 1;
+        final int headerColumnIndex = 2;
+        // translated column index as just one column used in test
+        final int uiColumnIndex = 0;
+
+        final GridData.SelectedCell selectedCellMock = mock(GridData.SelectedCell.class);
+        doReturn(Collections.singletonList(selectedCellMock)).when(gridDataMock).getSelectedHeaderCells();
+        doReturn(headerRowIndex).when(selectedCellMock).getRowIndex();
+        doReturn(headerColumnIndex).when(selectedCellMock).getColumnIndex();
+
+        final GridColumn columnMock = mock(GridColumn.class);
+        doReturn(headerColumnIndex).when(columnMock).getIndex();
+
+        doReturn(Collections.singletonList(columnMock)).when(gridDataMock).getColumns();
+
+        doReturn(true).when(gridWidgetMock).showContextMenuForHeader(headerRowIndex, uiColumnIndex);
+
+        assertThat(testedOperation.perform(gridWidgetMock, false, true))
+                .as("Menu should be shown successfully")
+                .isTrue();
+        verify(gridWidgetMock).showContextMenuForHeader(headerRowIndex, uiColumnIndex);
+    }
+
+    @Test
+    public void testPerformWithSelectedCell() {
         // non null indexes to verify the coordinates translation
         final int rowIndex = 1;
         final int columnIndex = 2;
@@ -87,6 +120,7 @@ public class KeyboardOperationInvokeContextMenuForSelectedCellTest {
         final int uiColumnIndex = 0;
 
         final GridData.SelectedCell selectedCellMock = mock(GridData.SelectedCell.class);
+        doReturn(Collections.singletonList(selectedCellMock)).when(gridDataMock).getSelectedCells();
         doReturn(rowIndex).when(selectedCellMock).getRowIndex();
         doReturn(columnIndex).when(selectedCellMock).getColumnIndex();
 
@@ -99,7 +133,7 @@ public class KeyboardOperationInvokeContextMenuForSelectedCellTest {
         doReturn(true).when(gridWidgetMock).showContextMenuForCell(rowIndex, uiColumnIndex);
 
         assertThat(testedOperation.perform(gridWidgetMock, false, true))
-                .as("Menu should be shown succesfully")
+                .as("Menu should be shown successfully")
                 .isTrue();
         verify(gridWidgetMock).showContextMenuForCell(rowIndex, uiColumnIndex);
     }
@@ -125,7 +159,7 @@ public class KeyboardOperationInvokeContextMenuForSelectedCellTest {
         doReturn(true).when(gridWidgetMock).showContextMenuForCell(rowIndex, uiColumnIndex);
 
         assertThat(testedOperation.perform(gridWidgetMock, false, true))
-                .as("Menu should not be shown succesfully")
+                .as("Menu should not be shown successfully")
                 .isFalse();
         verify(gridWidgetMock, never()).showContextMenuForCell(anyInt(), anyInt());
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-3940

(Well, not directly related, but I found whilst writing DROOLS-3940 that deleting a column that had a selected header cell lead to strange behaviour - as the _selected header cells_ were not being cleared when the column deleted).