### PR TITLE
AF-1956: Cleanup and Organize Dashbuilder Persistence

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/src/test/java/org/dashbuilder/dataset/DataSetDefRegistryCDITest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/src/test/java/org/dashbuilder/dataset/DataSetDefRegistryCDITest.java
@@ -34,9 +34,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.uberfire.backend.server.spaces.SpacesAPIImpl;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.StandardDeleteOption;
+import org.uberfire.java.nio.file.FileSystem;
 
 import static org.mockito.Mockito.*;
 
@@ -65,6 +65,9 @@ public class DataSetDefRegistryCDITest extends BaseCDITest {
     @Mock
     Event<DataSetStaleEvent> dataSetStaleEvent;
 
+    @Mock(name = "datasetsFS")
+    FileSystem fileSystem;
+
     DataSetDefRegistryCDI dataSetDefRegistry;
 
     public DataSetDef dataSetDef = DataSetDefFactory
@@ -79,9 +82,9 @@ public class DataSetDefRegistryCDITest extends BaseCDITest {
         dataSetDefRegistry = spy(new DataSetDefRegistryCDI(
                 10485760,
                 mockIOService(),
+                fileSystem,
                 dataSetProviderRegistry,
                 scheduler,
-                new SpacesAPIImpl(),
                 exceptionManager,
                 dataSetDefModifiedEvent,
                 dataSetDefRegisteredEvent,

--- a/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/src/main/java/org/dashbuilder/navigation/service/PerspectivePluginServicesImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/src/main/java/org/dashbuilder/navigation/service/PerspectivePluginServicesImpl.java
@@ -50,7 +50,7 @@ public class PerspectivePluginServicesImpl implements PerspectivePluginServices 
 
     @Override
     public Collection<Plugin> listPlugins() {
-        return pluginServices.listPlugins();
+        return pluginServices.listPlugins(PluginType.PERSPECTIVE_LAYOUT);
     }
 
     @Override

--- a/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/src/main/java/org/dashbuilder/navigation/storage/NavTreeStorage.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/src/main/java/org/dashbuilder/navigation/storage/NavTreeStorage.java
@@ -15,8 +15,6 @@
  */
 package org.dashbuilder.navigation.storage;
 
-import java.net.URI;
-import java.util.HashMap;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -28,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileSystem;
-import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
 import org.uberfire.java.nio.file.Path;
 
 @ApplicationScoped
@@ -45,7 +42,7 @@ public class NavTreeStorage {
 
     @Inject
     public NavTreeStorage(@Named("ioStrategy") IOService ioService,
-                          @Named("pluginsFS") FileSystem fileSystem) {
+                          @Named("navigationFS") FileSystem fileSystem) {
         this.ioService = ioService;
         this.fileSystem = fileSystem;
         this.jsonMarshaller = NavTreeJSONMarshaller.get();
@@ -53,7 +50,7 @@ public class NavTreeStorage {
 
     @PostConstruct
     public void init() {
-        this.root = fileSystem.getRootDirectories().iterator().next();
+        root = fileSystem.getRootDirectories().iterator().next();
     }
 
     protected Path getNavRootPath() {

--- a/dashbuilder/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/dataset/editor/csv/CSVDataSetDefAttributesEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-widgets/src/main/java/org/dashbuilder/client/widgets/dataset/editor/csv/CSVDataSetDefAttributesEditor.java
@@ -123,7 +123,7 @@ public class CSVDataSetDefAttributesEditor implements IsWidget, org.dashbuilder.
 
             @Override
             public String getUploadFileUrl() {
-                String csvPath = "default://master@system/datasets/tmp/" + value.getUUID() + ".csv";
+                String csvPath = "default://master@dashbuilder/datasets/tmp/" + value.getUUID() + ".csv";
                 return dataSetClientServices.getUploadFileUrl(csvPath);
             }
         });

--- a/dashbuilder/dashbuilder-client/dashbuilder-widgets/src/test/java/org/dashbuilder/client/widgets/dataset/editor/csv/CSVDataSetDefAttributesEditorTest.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-widgets/src/test/java/org/dashbuilder/client/widgets/dataset/editor/csv/CSVDataSetDefAttributesEditorTest.java
@@ -75,7 +75,7 @@ public class CSVDataSetDefAttributesEditorTest {
         presenter.setValue(dataSetDef);
         FileUploadEditor.FileUploadEditorCallback fileCallback = callbackCaptor.getValue();
         String fileUrl = fileCallback.getUploadFileUrl();
-        assertEquals(fileUrl, "default://master@system/datasets/tmp/test.csv");
+        assertEquals(fileUrl, "default://master@dashbuilder/datasets/tmp/test.csv");
     }
     
     @Test

--- a/uberfire-api/src/main/java/org/uberfire/spaces/SpacesAPI.java
+++ b/uberfire-api/src/main/java/org/uberfire/spaces/SpacesAPI.java
@@ -10,6 +10,9 @@ public interface SpacesAPI {
     String DEFAULT_SPACE_NAME = "system";
     Space DEFAULT_SPACE = new Space(DEFAULT_SPACE_NAME);
 
+    String DASHBUILDER_SPACE_NAME = "dashbuilder";
+    Space DASHBUILDER_SPACE = new Space(DASHBUILDER_SPACE_NAME);
+
     String CONFIG_FOLDER_NAME = ".config";
     String CONFIG_REPOSITORY_NAME = "config";
 

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/SystemConfigProducer.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/SystemConfigProducer.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.net.URI;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.event.Observes;
@@ -68,6 +69,7 @@ import org.uberfire.java.nio.file.WatchService;
 import org.uberfire.java.nio.file.attribute.UserPrincipalLookupService;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 import org.uberfire.spaces.SpacesAPI;
+import org.uberfire.spaces.Space;
 
 public class SystemConfigProducer implements Extension {
 
@@ -83,6 +85,9 @@ public class SystemConfigProducer implements Extension {
     private final Comparator<OrderedBean> priorityComparator = (o1, o2) -> o1.priority - o2.priority;
     private boolean systemFSNotExists = true;
     private boolean pluginsFSNotExists = true;
+    private boolean perspectivesFSNotExists = true;
+    private boolean datasetsFSNotExists = true;
+    private boolean navigationFSNotExists = true;
     private boolean ioStrategyBeanNotFound = true;
 
     public void processSystemFSProducer(@Observes ProcessProducer<?, FileSystem> pp) {
@@ -97,6 +102,23 @@ public class SystemConfigProducer implements Extension {
         }
     }
 
+    public void processPerspectivesFSProducer(@Observes ProcessProducer<?, FileSystem> pp) {
+        if (pp.getAnnotatedMember().getJavaMember().getName().equals("perspectivesFS")) {
+            perspectivesFSNotExists = false;
+        }
+    }
+
+    public void processDatasetsFSProducer(@Observes ProcessProducer<?, FileSystem> pp) {
+        if (pp.getAnnotatedMember().getJavaMember().getName().equals("datasetsFS")) {
+            datasetsFSNotExists = false;
+        }
+    }
+
+    public void processNavigationFSProducer(@Observes ProcessProducer<?, FileSystem> pp) {
+        if (pp.getAnnotatedMember().getJavaMember().getName().equals("navigationFS")) {
+            navigationFSNotExists = false;
+        }
+    }
     public void processIOServiceProducer(@Observes ProcessProducer<?, IOService> pp) {
         if (pp.getAnnotatedMember().getJavaMember().getName().equals("ioStrategy")) {
             ioStrategyBeanNotFound = false;
@@ -108,6 +130,12 @@ public class SystemConfigProducer implements Extension {
             systemFSNotExists = false;
         } else if (event.getBean().getName() != null && event.getBean().getName().equals("pluginsFS")) {
             pluginsFSNotExists = false;
+        } else if (event.getBean().getName() != null && event.getBean().getName().equals("perspectivesFS")) {
+            perspectivesFSNotExists = false;
+        } else if (event.getBean().getName() != null && event.getBean().getName().equals("datasetsFS")) {
+            datasetsFSNotExists = false;
+        } else if (event.getBean().getName() != null && event.getBean().getName().equals("navigationFS")) {
+            navigationFSNotExists = false;
         } else if (event.getBean().getName() != null && event.getBean().getName().equals("ioStrategy")) {
             ioStrategyBeanNotFound = false;
         }
@@ -183,6 +211,21 @@ public class SystemConfigProducer implements Extension {
                             bm);
         }
 
+        if (perspectivesFSNotExists) {
+            buildPerspectivesFS(abd,
+                                bm);
+        }
+
+        if (datasetsFSNotExists) {
+            buildDatasetsFS(abd,
+                            bm);
+        }
+
+        if (navigationFSNotExists) {
+            buildNavigationFS(abd,
+                              bm);
+        }
+
         if (pluginsFSNotExists) {
             buildPluginsFS(abd,
                            bm);
@@ -200,17 +243,55 @@ public class SystemConfigProducer implements Extension {
 
         abd.addBean(createFileSystemBean(bm,
                                          it,
+                                         SpacesAPI.DEFAULT_SPACE,
                                          "ioStrategy",
                                          "pluginsFS",
                                          "plugins"));
     }
 
+    void buildPerspectivesFS(final AfterBeanDiscovery abd,
+                             final BeanManager bm) {
+        final InjectionTarget<DummyFileSystem> it = bm.createInjectionTarget(bm.createAnnotatedType(DummyFileSystem.class));
+
+        abd.addBean(createFileSystemBean(bm,
+                                         it,
+                                         SpacesAPI.DASHBUILDER_SPACE,
+                                         "ioStrategy",
+                                         "perspectivesFS",
+                                         "perspectives"));
+    }
+
+
+    void buildDatasetsFS(final AfterBeanDiscovery abd,
+                         final BeanManager bm) {
+        final InjectionTarget<DummyFileSystem> it = bm.createInjectionTarget(bm.createAnnotatedType(DummyFileSystem.class));
+
+        abd.addBean(createFileSystemBean(bm,
+                                         it,
+                                         SpacesAPI.DASHBUILDER_SPACE,
+                                         "ioStrategy",
+                                         "datasetsFS",
+                                         "datasets"));
+    }
+
+    void buildNavigationFS(final AfterBeanDiscovery abd,
+                           final BeanManager bm) {
+        final InjectionTarget<DummyFileSystem> it = bm.createInjectionTarget(bm.createAnnotatedType(DummyFileSystem.class));
+
+        abd.addBean(createFileSystemBean(bm,
+                                         it,
+                                         SpacesAPI.DASHBUILDER_SPACE,
+                                         "ioStrategy",
+                                         "navigationFS",
+                                         "navigation"));
+    }
     void buildSystemFS(final AfterBeanDiscovery abd,
                        final BeanManager bm) {
         final InjectionTarget<DummyFileSystem> it = bm.createInjectionTarget(bm.createAnnotatedType(DummyFileSystem.class));
 
         abd.addBean(createFileSystemBean(bm,
                                          it,
+                                         SpacesAPI.DEFAULT_SPACE,
                                          "configIO",
                                          "systemFS",
                                          "system"));
@@ -218,6 +299,7 @@ public class SystemConfigProducer implements Extension {
 
     Bean<FileSystem> createFileSystemBean(final BeanManager bm,
                                           final InjectionTarget<DummyFileSystem> it,
+                                          final Space space,
                                           String ioService,
                                           String beanName,
                                           String fsName) {
@@ -281,32 +363,24 @@ public class SystemConfigProducer implements Extension {
 
             @Override
             public FileSystem create(CreationalContext<FileSystem> ctx) {
+                final SpacesAPI spaces = getSpaces(bm);
                 final Bean<IOService> bean = (Bean<IOService>) bm.getBeans(ioService).iterator().next();
                 final CreationalContext<IOService> _ctx = bm.createCreationalContext(bean);
                 final IOService ioService = (IOService) bm.getReference(bean,
                                                                         IOService.class,
                                                                         _ctx);
 
-                final SpacesAPI spaces = getSpaces(bm);
-                FileSystem fs;
-                try {
-                    fs = ioService.newFileSystem(spaces.resolveFileSystemURI(SpacesAPI.Scheme.GIT,
-                                                                             SpacesAPI.DEFAULT_SPACE,
-                                                                             fsName),
-                                                 new HashMap<String, Object>() {{
-                                                     put("init",
-                                                         Boolean.TRUE);
-                                                     put("internal",
-                                                         Boolean.TRUE);
-                                                 }});
-                } catch (FileSystemAlreadyExistsException e) {
-                    fs = ioService.getFileSystem(spaces.resolveFileSystemURI(SpacesAPI.Scheme.GIT,
-                                                                             SpacesAPI.DEFAULT_SPACE,
-                                                                             fsName));
-                }
+                URI uri = spaces.resolveFileSystemURI(SpacesAPI.Scheme.DEFAULT,
+                                                      space,
+                                                      fsName);
 
-                PriorityDisposableRegistry.register(beanName,
-                                                    fs);
+                HashMap<String, Object> env = new HashMap<String, Object>() {{
+                    put("init", Boolean.TRUE);
+                    put("internal", Boolean.TRUE);
+                }};
+
+                FileSystem fs = ioService.getOrNewFileSystem(uri, env);
+                PriorityDisposableRegistry.register(beanName, fs);
 
                 return fs;
             }

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/SystemConfigProducerTest.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/SystemConfigProducerTest.java
@@ -35,6 +35,7 @@ import org.uberfire.commons.lifecycle.PriorityDisposableRegistry;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.spaces.SpacesAPI;
+import org.uberfire.spaces.Space;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -75,15 +76,15 @@ public class SystemConfigProducerTest {
                              any(CreationalContext.class)))
                 .thenReturn(ioServiceMock);
 
-        when(ioServiceMock.newFileSystem(any(URI.class),
+        when(ioServiceMock.getOrNewFileSystem(any(URI.class),
                                          any(Map.class)))
                 .thenReturn(fs);
 
         final Bean fileSystemBean = producer.createFileSystemBean(bm,
                                                                   mock(InjectionTarget.class),
+                                                                  mock(Space.class),
                                                                   "configIO",
                                                                   "systemFS",
-
                                                                   "system");
 
         assertNull(PriorityDisposableRegistry.get("systemFS"));
@@ -110,6 +111,7 @@ public class SystemConfigProducerTest {
 
         verify(producerSpy).createFileSystemBean(eq(bm),
                                                  any(),
+                                                 any(),
                                                  eq("configIO"),
                                                  eq("systemFS"),
                                                  eq("system"));
@@ -126,6 +128,7 @@ public class SystemConfigProducerTest {
                                    bm);
 
         verify(producerSpy).createFileSystemBean(eq(bm),
+                                                 any(),
                                                  any(),
                                                  eq("ioStrategy"),
                                                  eq("pluginsFS"),

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/src/main/java/org/uberfire/ext/layout/editor/impl/PerspectiveServicesImpl.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/src/main/java/org/uberfire/ext/layout/editor/impl/PerspectiveServicesImpl.java
@@ -33,6 +33,7 @@ import org.uberfire.ext.plugin.backend.PluginServicesImpl;
 import org.uberfire.ext.plugin.model.LayoutEditorModel;
 import org.uberfire.ext.plugin.model.Plugin;
 import org.uberfire.ext.plugin.model.PluginType;
+import org.uberfire.spaces.SpacesAPI;
 
 @Service
 @ApplicationScoped
@@ -66,7 +67,7 @@ public class PerspectiveServicesImpl implements PerspectiveServices {
 
     @Override
     public Collection<LayoutTemplate> listLayoutTemplates() {
-        return pluginServices.listPlugins().stream()
+        return pluginServices.listPlugins(PluginType.PERSPECTIVE_LAYOUT).stream()
                 .map(this::getLayoutTemplate)
                 .collect(Collectors.toList());
     }
@@ -95,7 +96,7 @@ public class PerspectiveServicesImpl implements PerspectiveServices {
         if (perspectiveName == null) {
             return null;
         }
-        for (Plugin plugin : pluginServices.listPlugins()) {
+        for (Plugin plugin : pluginServices.listPlugins(PluginType.PERSPECTIVE_LAYOUT)) {
             if (PluginType.PERSPECTIVE_LAYOUT.equals(plugin.getType()) && plugin.getName().equals(perspectiveName)) {
                 return plugin;
             }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/src/test/java/org/uberfire/ext/layout/editor/impl/PerspectiveServicesImplTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-backend/src/test/java/org/uberfire/ext/layout/editor/impl/PerspectiveServicesImplTest.java
@@ -35,6 +35,7 @@ import org.uberfire.ext.plugin.model.Plugin;
 import org.uberfire.ext.plugin.model.PluginType;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
@@ -74,6 +75,7 @@ public class PerspectiveServicesImplTest {
 
         when(pluginServices.createNewPlugin(anyString(), any())).thenReturn(plugin);
         when(plugin.getPath()).thenReturn(path);
+        when(plugin.getName()).thenReturn("plugin1");
         when(pluginServices.copy(any(), anyString(), anyString())).thenReturn(path2);
         when(pluginServices.copy(any(), anyString(), any(), anyString())).thenReturn(path2);
         when(pluginServices.rename(any(), anyString(), anyString())).thenReturn(path2);
@@ -95,12 +97,14 @@ public class PerspectiveServicesImplTest {
     @Test
     public void testList() {
         Plugin layoutPlugin = new Plugin("layout", PluginType.PERSPECTIVE_LAYOUT, path2);
-        when(pluginServices.listPlugins()).thenReturn(Collections.singletonList(layoutPlugin));
+        when(pluginServices.listPlugins(PluginType.PERSPECTIVE_LAYOUT))
+            .thenReturn(Collections.singletonList(layoutPlugin));
 
         Collection<LayoutTemplate> layouts = perspectiveServices.listLayoutTemplates();
         assertEquals(layouts.size(), 1);
         LayoutTemplate layoutTemplate = layouts.iterator().next();
         assertEquals(layoutTemplate.getName(), "layout");
+        verify(pluginServices).listPlugins(PluginType.PERSPECTIVE_LAYOUT);
     }
 
     @Test
@@ -185,5 +189,18 @@ public class PerspectiveServicesImplTest {
         perspectiveServices.saveAndRename(path, newFileName, metadata, content, comment);
 
         verify(saveAndRenameService).saveAndRename(path, newFileName, metadata, content, comment);
+    }
+
+    @Test
+    public void testGetLayoutTemplate() {
+        LayoutTemplate layoutTemplate = perspectiveServices.getLayoutTemplate(path2);
+        verify(pluginServices).getLayoutEditor(path2, PluginType.PERSPECTIVE_LAYOUT);
+        assertTrue(layoutTemplate.getName().equals("layout"));
+    }
+
+    @Test
+    public void testGetLayoutTemplatePlugin() {
+        Plugin retPlugin = perspectiveServices.getLayoutTemplatePlugin(plugin.getName());
+        verify(pluginServices).listPlugins(PluginType.PERSPECTIVE_LAYOUT);
     }
 }

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/src/main/java/org/uberfire/ext/plugin/model/PluginType.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/src/main/java/org/uberfire/ext/plugin/model/PluginType.java
@@ -20,6 +20,7 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 
 @Portable
 public enum PluginType {
+    DEFAULT,
     PERSPECTIVE,
     PERSPECTIVE_LAYOUT,
     SCREEN,

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/src/main/java/org/uberfire/ext/plugin/service/PluginServices.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-api/src/main/java/org/uberfire/ext/plugin/service/PluginServices.java
@@ -46,6 +46,8 @@ public interface PluginServices extends SupportsDelete,
 
     Collection<Plugin> listPlugins();
 
+    Collection<Plugin> listPlugins(final PluginType type);
+
     Plugin createNewPlugin(final String name,
                            final PluginType type);
 

--- a/uberfire-io/src/main/java/org/uberfire/io/IOService.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/IOService.java
@@ -84,6 +84,19 @@ public interface IOService extends PriorityDisposable {
             throws IllegalArgumentException, FileSystemAlreadyExistsException,
             ProviderNotFoundException, IOException, SecurityException;
 
+    default FileSystem getOrNewFileSystem(final URI uri, final Map<String, ?> env)
+    throws IllegalArgumentException, ProviderNotFoundException, IOException, SecurityException {
+        FileSystem fileSystem;
+
+        try {
+            fileSystem = newFileSystem(uri, env);
+        } catch (FileSystemAlreadyExistsException e) {
+            fileSystem = getFileSystem(uri);
+        }
+
+        return fileSystem;
+    }
+
     void onNewFileSystem(final NewFileSystemListener listener);
 
     InputStream newInputStream(final Path path,

--- a/uberfire-io/src/test/java/org/uberfire/io/GitIOServiceDotFileTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/GitIOServiceDotFileTest.java
@@ -26,7 +26,9 @@ import java.util.Random;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemMetadata;
+import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
 
@@ -121,6 +123,38 @@ public class GitIOServiceDotFileTest extends CommonIOExceptionsServiceDotFileTes
         assertNotNull(iterator.next());
 
         assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testGetFileSystemInvalidURI() {
+        URI uri = URI.create("git://" + new Date().getTime() + "-repo-test");
+        FileSystem fs = ioService().getFileSystem(uri);
+
+        assertNull(fs);
+    }
+
+    @Test(expected = FileSystemAlreadyExistsException.class)
+    public void testCreateFileSystemTwice() {
+        URI uri = URI.create("git://" + new Date().getTime() + "-repo-test");
+        ioService().newFileSystem(uri, new HashMap<>());
+        ioService().newFileSystem(uri, new HashMap<>());
+    }
+
+    @Test
+    public void testGetOrNewFileSystem() {
+        URI uri = URI.create("git://" + new Date().getTime() + "-repo-test");
+        FileSystem fs1 = ioService().getOrNewFileSystem(uri, new HashMap<>());
+        FileSystem fs2 = ioService().getOrNewFileSystem(uri, new HashMap<>());
+
+        assertNotNull(fs1);
+        assertNotNull(fs2);
+        assertEquals(fs1, fs2);
+
+        uri = URI.create("git://" + new Date().getTime() + "-repo-test");
+        FileSystem fs3 = ioService().getOrNewFileSystem(uri, new HashMap<>());
+
+        assertNotNull(fs3);
+        assertNotEquals(fs1, fs3);
     }
 
     @Test

--- a/uberfire-testing-utils/src/main/java/org/uberfire/mocks/FileSystemTestingUtils.java
+++ b/uberfire-testing-utils/src/main/java/org/uberfire/mocks/FileSystemTestingUtils.java
@@ -42,12 +42,18 @@ public class FileSystemTestingUtils {
     }
 
     public void setup(boolean initRepo) throws IOException {
+        setup(initRepo, "git://amend-repo-test");
+    }
+
+    public void setup(String repoPath) throws IOException {
+        setup(true, repoPath);
+    }
+
+    public void setup(boolean initRepo, String repoPath) throws IOException {
         ioService = new IOServiceDotFileImpl();
 
         createTempDirectory();
-        setupJGitRepository("git://amend-repo-test",
-                            initRepo
-        );
+        setupJGitRepository(repoPath, initRepo);
     }
 
     private void createTempDirectory()


### PR DESCRIPTION
**Description**
[Task AF-1956](https://issues.jboss.org/browse/AF-1956) is the first step towards completion of [Epic AF-1914](https://issues.jboss.org/browse/AF-1914) (Dashbuilder Import/Export Feature). In this task, we should organize the storage of Dashbuilder data (datasets, perspectives and navigation) into a new structure to facilitate the implementation of import/export feature in Dashbuilder.

**Current Storage Structure**
1. Datasets inside system/datasets.git
2. Perspectives inside system/plugins.git
3. Navigation inside system/plugins.git
```
# view of .niogit
.
└── system
    ├── datasets.git
    ├── plugins.git
    ├── preferences.git
    ├── security.git
    └── system.git

# after git clone
.
├── datasets
│   ├── definitions
│   │   ├── clusterMetrics.dset
│   │   ├── expenseReports.csv
│   │   ├── expenseReports.dset
│   │   ├── salesOpportunities.dset
│   │   ├── worldResidents.csv
│   │   └── worldResidents.dset
│   └── readme.md
└── plugins
    ├── navigation
    │   └── navtree.json
    ├── Page1
    │   ├── perspective_layout
    │   └── perspective_layout.plugin
    └── readme.md
```

**New Storage Structure**
1. Datasets inside dashbuilder/datasets.git
2. Perspectives inside dashbuilder/perspectives.git
3. Navigation inside dashbuilder/navigation.git
```
# view of .niogit
.
├── dashbuilder
│   ├── datasets.git
│   ├── navigation.git
│   └── perspectives.git
└── system
    ├── plugins.git
    ├── preferences.git
    ├── security.git
    └── system.git

# after git clone
.
├── datasets
│   ├── definitions
│   │   ├── clusterMetrics.dset
│   │   ├── expenseReports.csv
│   │   ├── expenseReports.dset
│   │   ├── salesOpportunities.dset
│   │   ├── worldResidents.csv
│   │   └── worldResidents.dset
│   └── readme.md
├── navigation
│   ├── navigation
│   │   └── navtree.json
│   └── readme.md
└── perspectives
    ├── Page1
    │   ├── perspective_layout
    │   └── perspective_layout.plugin
    └── readme.md
```

**Notes**
* Perspectives is still a Plugin object. I tried to remove the dependency from Plugin and did a good progress but this requires a huge effort and a lot of refactoring. We should make this change in another PR.
* Did not find an easy way to make perspectives to be stored in its own filesystem. Perspectives is a plugin, and PluginServices is @ApplicationScopped, which will be a Singleton. I can't extend from PluginServices because it will break RPC calls that are generic to all Plugins. The only way I could find, with help from William and Eder, is to add logic to PluginServices to handle 2 filesystem simultaneously.
* I did not write new unit tests, just fixed the old ones. What kind of tests are required to this PR ? The behavior is the same, just the storage location has changed.