### PR TITLE
[DROOLS-3993] Add "val" method to JQuerySelectPicker

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQuerySelectPicker.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/selectpicker/JQuerySelectPicker.java
@@ -42,6 +42,8 @@ public abstract class JQuerySelectPicker {
 
     public native JQuerySelectPicker off(final String event);
 
+    public native String val();
+
     @JsFunction
     public interface CallbackFunction {
 


### PR DESCRIPTION
@manstis @jomarko @karreiro 

This is the twin part of https://github.com/kiegroup/kie-wb-common/pull/2632
It add "val" method that is used in the other PR