### PR TITLE
AF-1966: Changing from ManagedBean back to newInstance

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/widgets/LayoutElementPropertiesPresenter.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/widgets/LayoutElementPropertiesPresenter.java
@@ -23,13 +23,13 @@ import org.uberfire.ext.layout.editor.client.event.LayoutElementPropertyChangedE
 import org.uberfire.ext.layout.editor.client.infra.LayoutEditorCssHelper;
 import org.uberfire.ext.properties.editor.model.PropertyEditorCategory;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 
-@ApplicationScoped
+@Dependent
 public class LayoutElementPropertiesPresenter {
 
     public interface View extends UberView<LayoutElementPropertiesPresenter> {


### PR DESCRIPTION
ManagedBean respects the ApplicationScoped annotation, which means it always returns the same instance. In LayoutEditorPropertiesPresenter instances of LayoutElementPropertiesPresenter - if instances of LayoutElementPropertiesPresenter are created with ManagedInstance, then only a single one will be created. With newInstances the cache is correctly created for each element.