### PR TITLE
BXMSPROD-8: refactor to build without jboss-ip-bom

### DIFF
--- a/appformer-js/pom.xml
+++ b/appformer-js/pom.xml
@@ -25,6 +25,26 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-install</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>${frontend-maven-plugin.version}</version>

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
@@ -107,11 +107,6 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
-    
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-common</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/dashbuilder/dashbuilder-packaging/dashbuilder-all/pom.xml
+++ b/dashbuilder/dashbuilder-packaging/dashbuilder-all/pom.xml
@@ -26,7 +26,7 @@
   </parent>
 
   <artifactId>dashbuilder-all</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
 
   <name>Dashbuilder All Libraries</name>
 

--- a/dashbuilder/dashbuilder-packaging/dashbuilder-server-all/pom.xml
+++ b/dashbuilder/dashbuilder-packaging/dashbuilder-server-all/pom.xml
@@ -68,5 +68,30 @@
     </dependency>
 
   </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -671,6 +671,22 @@
       <artifactId>uberfire-ssh-backend</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-data-binding</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-cdi-shared</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jboss.integration-platform</groupId>
-    <artifactId>jboss-integration-platform-bom</artifactId>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-parent</artifactId>
+    <version>7.24.0-SNAPSHOT</version>
     <!-- Keep in sync with the parent version of uberfire-bom/pom.xml -->
-    <version>8.6.0.Final</version>
   </parent>
+
 
   <groupId>org.uberfire</groupId>
   <artifactId>uberfire-parent</artifactId>
@@ -201,7 +202,8 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
+	  <artifactId>maven-enforcer-plugin</artifactId>
+	  <version>${version.enforcer.plugin}</version>
           <dependencies>
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
@@ -518,44 +520,6 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>jaxb2-maven-plugin</artifactId>
           <version>1.3</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-          <executions>
-            <!-- No OSGi manifestEntries for <goal>jar</goal>: if it supported, then felix has already added them -->
-            <execution>
-              <id>attach-test-jar</id>
-              <goals>
-                <goal>test-jar</goal>
-              </goals>
-              <configuration>
-                <excludes>
-                  <exclude>**/logback-test.xml</exclude>
-                  <exclude>**/jndi.properties</exclude>
-                </excludes>
-                <archive>
-                  <manifestEntries>
-                    <Bundle-SymbolicName>${project.artifactId}.tests</Bundle-SymbolicName>
-                    <Bundle-Version>
-                      ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${osgi.snapshot.qualifier}
-                    </Bundle-Version>
-                    <Bundle-Name>${project.name}</Bundle-Name>
-                    <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
-                  </manifestEntries>
-                </archive>
-              </configuration>
-            </execution>
-          </executions>
-          <configuration>
-            <archive>
-              <manifest>
-                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              </manifest>
-            </archive>
-          </configuration>
         </plugin>
 
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
@@ -885,6 +849,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-platform-bom</artifactId>
+        <version>${version.org.kie}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-bom</artifactId>
@@ -1341,6 +1313,11 @@
         <artifactId>logback-classic</artifactId>
         <version>${version.ch.qos.logback}</version>
       </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${version.ch.qos.logback}</version>
+      </dependency>
 
       <!-- Lienzo Charts -->
       <dependency>
@@ -1492,6 +1469,10 @@
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-requirement-spi</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -1508,6 +1489,22 @@
         <version>${version.org.jboss.shrinkwrap}</version>
         <scope>test</scope>
       </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${version.junit}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${version.org.mockito}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${version.org.assertj}</version>
+    </dependency>
 
     </dependencies>
   </dependencyManagement>
@@ -1528,6 +1525,14 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- tests in guvnor -->
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <!-- DistributionManagement is inherited from org.jboss:jboss-parent -->

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -20,11 +20,10 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jboss.integration-platform</groupId>
-    <artifactId>jboss-integration-platform-parent</artifactId>
-    <!-- Keep in sync with the parent version of ../pom.xml -->
-    <version>8.6.0.Final</version>
-    <relativePath/>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-parent</artifactId>
+      <version>7.24.0-SNAPSHOT</version>
+    <!-- Keep in sync with the parent version in ../pom.xml (kie-parent)  -->
   </parent>
 
   <groupId>org.uberfire</groupId>

--- a/uberfire-commons/src/test/java/org/uberfire/commons/cluster/events/ClusterEventObserverTest.java
+++ b/uberfire-commons/src/test/java/org/uberfire/commons/cluster/events/ClusterEventObserverTest.java
@@ -16,7 +16,9 @@
 package org.uberfire.commons.cluster.events;
 
 import java.lang.annotation.Annotation;
+import java.util.concurrent.CompletionStage;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.EventMetadata;
 import javax.enterprise.inject.spi.InjectionPoint;
@@ -148,6 +150,17 @@ public class ClusterEventObserverTest {
         @Override
         public void fire(T event) {
             throw new UnsupportedOperationException("mocking testing class");
+        }
+
+        @Override
+        public <U extends T> CompletionStage<U> fireAsync(U u) {
+            return null;
+        }
+
+        @Override
+        public <U extends T> CompletionStage<U> fireAsync(U u,
+                                                          NotificationOptions notificationOptions) {
+            return null;
         }
 
         @Override

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionHistoryPresenterTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionHistoryPresenterTest.java
@@ -19,7 +19,9 @@ package org.uberfire.ext.editor.commons.client.history;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
 import javax.enterprise.util.TypeLiteral;
 
 import com.google.gwt.view.client.AsyncDataProvider;
@@ -212,6 +214,17 @@ public class VersionHistoryPresenterTest {
         @Override
         public void fire(VersionSelectedEvent event) {
 
+        }
+
+        @Override
+        public <U extends VersionSelectedEvent> CompletionStage<U> fireAsync(U u) {
+            return null;
+        }
+
+        @Override
+        public <U extends VersionSelectedEvent> CompletionStage<U> fireAsync(U u,
+                                                                             NotificationOptions notificationOptions) {
+            return null;
         }
 
         @Override

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionSelectedEventMock.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionSelectedEventMock.java
@@ -17,7 +17,9 @@
 package org.uberfire.ext.editor.commons.client.history;
 
 import java.lang.annotation.Annotation;
+import java.util.concurrent.CompletionStage;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
 import javax.enterprise.util.TypeLiteral;
 
 import org.uberfire.client.callbacks.Callback;
@@ -35,6 +37,17 @@ public class VersionSelectedEventMock
     @Override
     public void fire(VersionSelectedEvent event) {
         callback.callback(event);
+    }
+
+    @Override
+    public <U extends VersionSelectedEvent> CompletionStage<U> fireAsync(U u) {
+        return null;
+    }
+
+    @Override
+    public <U extends VersionSelectedEvent> CompletionStage<U> fireAsync(U u,
+                                                                         NotificationOptions notificationOptions) {
+        return null;
     }
 
     @Override

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/elasticsearch/BaseIndexTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/elasticsearch/BaseIndexTest.java
@@ -25,9 +25,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 
 import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
 import javax.enterprise.util.TypeLiteral;
 
 import org.apache.commons.io.FileUtils;
@@ -140,6 +142,17 @@ public abstract class BaseIndexTest {
 
             @Override
             public void fire(T event) {
+            }
+
+            @Override
+            public <U extends T> CompletionStage<U> fireAsync(U u) {
+                return null;
+            }
+
+            @Override
+            public <U extends T> CompletionStage<U> fireAsync(U u,
+                                                              NotificationOptions notificationOptions) {
+                return null;
             }
 
             @Override

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/infinispan/BaseIndexTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/infinispan/BaseIndexTest.java
@@ -26,8 +26,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
 import javax.enterprise.util.TypeLiteral;
 
 import org.apache.commons.io.FileUtils;
@@ -136,6 +138,17 @@ public abstract class BaseIndexTest {
 
             @Override
             public void fire(T event) {
+            }
+
+            @Override
+            public <U extends T> CompletionStage<U> fireAsync(U u) {
+                return null;
+            }
+
+            @Override
+            public <U extends T> CompletionStage<U> fireAsync(U u,
+                                                              NotificationOptions notificationOptions) {
+                return null;
             }
 
             @Override

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/lucene/BaseIndexTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/java/org/uberfire/ext/metadata/io/lucene/BaseIndexTest.java
@@ -25,9 +25,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 
 import javax.enterprise.event.Event;
+import javax.enterprise.event.NotificationOptions;
 import javax.enterprise.util.TypeLiteral;
 
 import org.apache.commons.io.FileUtils;
@@ -125,6 +127,17 @@ public abstract class BaseIndexTest {
 
             @Override
             public void fire(T event) {
+            }
+
+            @Override
+            public <U extends T> CompletionStage<U> fireAsync(U u) {
+                return null;
+            }
+
+            @Override
+            public <U extends T> CompletionStage<U> fireAsync(U u,
+                                                              NotificationOptions notificationOptions) {
+                return null;
             }
 
             @Override

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
@@ -53,11 +53,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-backend-server</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
     </dependency>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/pom.xml
@@ -184,6 +184,21 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-properties-editor-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-service-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -238,6 +253,21 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-marshalling</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-data-binding</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-cdi-shared</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-packaging/uberfire-all/pom.xml
+++ b/uberfire-packaging/uberfire-all/pom.xml
@@ -43,4 +43,29 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  
 </project>

--- a/uberfire-packaging/uberfire-server-all/pom.xml
+++ b/uberfire-packaging/uberfire-server-all/pom.xml
@@ -64,4 +64,29 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-install</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/uberfire-showcase/uberfire-client-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-client-webapp/pom.xml
@@ -121,6 +121,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.gwtbootstrap3</groupId>
       <artifactId>gwtbootstrap3</artifactId>
     </dependency>
@@ -146,6 +152,26 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-data-binding</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-marshalling</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-cdi-shared</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-api</artifactId>
     </dependency>
@@ -158,6 +184,11 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -429,7 +429,6 @@
       <groupId>com.google.elemental2</groupId>
       <artifactId>elemental2-promise</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.google.elemental2</groupId>
       <artifactId>elemental2-core</artifactId>
@@ -441,20 +440,44 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-cdi-shared</artifactId>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- missing deps to avoid illegal transitive type dependencies -->
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-service-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-widgets-properties-editor-api</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-cdi-shared</artifactId>
+      </dependency>
+
+    <dependency>  
+      <groupId>org.jboss.errai</groupId>	      
       <artifactId>errai-marshalling</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-data-binding</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>appformer-js-bridge</artifactId>
       <scope>provided</scope>
     </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
fixing uberfire-packaging submodules and duplicate dependency

removed duplicated dependency

added missing deps because of enforcer-rule

disabled maven-jar-plugin

added missing deps

change type of artifact to pom

missing deps adn excludes for testing

updated kie-parent to 7.22.0-SNAPSHOT

updating missing versions to 7.23.0.-SNAPSHOT

disbled maven-jar-plugin

BXMSPROD-333: implementing new methods from javax.enterprise.event.Event

(cherry picked from commit 25899f41bbca0da5923e669bda2ab91c2d28cd61)

upgraded missing deps to 7.24.0-SNAPSHOT