### PR TITLE
Fix Failed to create session factory

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemsEventsManagerTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemsEventsManagerTest.java
@@ -18,6 +18,8 @@ package org.uberfire.java.nio.fs.jgit.ws;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,7 @@ import org.uberfire.java.nio.fs.jgit.ws.cluster.JGitEventsBroadcast;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
+import static org.uberfire.commons.cluster.ClusterParameters.APPFORMER_JMS_CONNECTION_MODE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JGitFileSystemsEventsManagerTest {
@@ -54,6 +57,12 @@ public class JGitFileSystemsEventsManagerTest {
                 return mock(JGitFileSystemWatchServices.class);
             }
         };
+    }
+
+    @AfterClass
+    public static void clearProperty() {
+        System.setProperty(ClusterParameters.APPFORMER_JMS_CONNECTION_MODE,
+                           ConnectionMode.NONE.toString());
     }
 
     @Test


### PR DESCRIPTION
The test JGitFileSystemsEventsManagerTest.java defining system property APPFORMER_JMS_CONNECTION_MODE=REMOTE, due to this fact, tests are failing if they performing after JGitFileSystemsEventsManagerTest.