### PR TITLE
fix beans.xml parsing error

### DIFF
--- a/uberfire-api/src/main/resources/META-INF/beans.xml
+++ b/uberfire-api/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
 
 </beans>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/resources/META-INF/beans.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,5 @@
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
+       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
 
 </beans>


### PR DESCRIPTION
Most/all *-wb test failures seems related to a parsing error on beans.xml in `uberfire-api`
Considering that it don't contain any real configuration and that empty file is enough, I think we can remove the content and keep the file empty
@mbiarnes 