### PR TITLE
[AF-2053]: Notification is thrown once the project is created in FS.

### DIFF
--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -437,13 +438,9 @@ public class RepositoryServiceImpl implements RepositoryService {
                 configStorage.startBatch();
             }
 
-            Repository repo = this.configuredRepositories.getRepositoryByRepositoryAlias(orgUnit.getSpace(),
-                                                                                         alias);
-
-            if (repo != null) {
-                this.close(repo.getDefaultBranch());
-                notification.accept(repo);
-            }
+            Optional<Repository> repo = Optional.ofNullable(this.configuredRepositories.getRepositoryByRepositoryAlias(orgUnit.getSpace(),
+                                                                                                                       alias));
+            repo.ifPresent(r -> this.close(r.getDefaultBranch()));
 
             //Remove reference to Repository from Organizational Units
             for (Repository repository : orgUnit.getRepositories()) {
@@ -453,6 +450,7 @@ public class RepositoryServiceImpl implements RepositoryService {
                     metadataStore.delete(alias);
                 }
             }
+            repo.ifPresent(r -> notification.accept(r));
         } finally {
             if (lock) {
                 configStorage.endBatch();

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
@@ -425,7 +425,7 @@ public class RepositoryServiceImpl implements RepositoryService {
         }
     }
 
-    private void doRemoveRepository(final OrganizationalUnit orgUnit,
+    protected void doRemoveRepository(final OrganizationalUnit orgUnit,
                                     final String alias,
                                     final Optional<org.guvnor.structure.organizationalunit.config.RepositoryInfo> thisRepositoryConfig,
                                     final Consumer<Repository> notification,
@@ -458,7 +458,7 @@ public class RepositoryServiceImpl implements RepositoryService {
         }
     }
 
-    private void close(Optional<Branch> defaultBranch) {
+    protected void close(Optional<Branch> defaultBranch) {
         defaultBranch.ifPresent(branch -> {
             FileSystem fs = convert(branch.getPath()).getFileSystem();
             fs.close();

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/RepositoryServiceImplTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/RepositoryServiceImplTest.java
@@ -4,22 +4,29 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.function.Consumer;
+
 import javax.enterprise.event.Event;
 
 import org.guvnor.common.services.project.events.RepositoryContributorsUpdatedEvent;
 import org.guvnor.structure.contributors.Contributor;
 import org.guvnor.structure.contributors.ContributorType;
+import org.guvnor.structure.organizationalunit.OrganizationalUnit;
+import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
 import org.guvnor.structure.organizationalunit.config.RepositoryConfiguration;
 import org.guvnor.structure.organizationalunit.config.RepositoryInfo;
 import org.guvnor.structure.organizationalunit.config.SpaceConfigStorage;
 import org.guvnor.structure.organizationalunit.config.SpaceConfigStorageRegistry;
 import org.guvnor.structure.organizationalunit.config.SpaceInfo;
 import org.guvnor.structure.repositories.Branch;
+import org.guvnor.structure.repositories.GitMetadataStore;
 import org.guvnor.structure.repositories.Repository;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -46,6 +53,12 @@ public class RepositoryServiceImplTest {
     @Mock
     private Event<RepositoryContributorsUpdatedEvent> updatedEvent;
 
+    @Mock
+    private GitMetadataStore gitMetadataStore;
+
+    @Mock
+    private OrganizationalUnitService organizationalUnitService;
+
     @InjectMocks
     @Spy
     private RepositoryServiceImpl repositoryService;
@@ -55,6 +68,11 @@ public class RepositoryServiceImplTest {
 
     @Captor
     private ArgumentCaptor<RepositoryInfo> configCaptor;
+
+    @Before
+    public void setUp() {
+        doAnswer(invocationOnMock -> null).when(gitMetadataStore).delete(anyString());
+    }
 
     @Test
     public void testNotCreateNewAliasIfNecessary() {
@@ -141,5 +159,26 @@ public class RepositoryServiceImplTest {
                      configCaptor.getValue().getContributors().get(0).getUsername());
         assertEquals(ContributorType.OWNER,
                      configCaptor.getValue().getContributors().get(0).getType());
+    }
+
+    @Test
+    public void testDoRemoveInOrder() {
+
+        Consumer<Repository> notification = mock(Consumer.class);
+        OrganizationalUnit orgUnit = mock(OrganizationalUnit.class);
+        String alias = "alias";
+        Optional<RepositoryInfo> repositoryConfig = Optional.of(mock(RepositoryInfo.class));
+
+        doAnswer(invocationOnMock -> null).when(repositoryService).close(any());
+        when(configuredRepositories.getRepositoryByRepositoryAlias(any(), anyString())).thenReturn(repository);
+        when(repository.getAlias()).thenReturn(alias);
+        when(orgUnit.getRepositories()).thenReturn(Collections.singletonList(repository));
+
+        InOrder inOrder = inOrder(this.organizationalUnitService, notification);
+
+        this.repositoryService.doRemoveRepository(orgUnit, alias, repositoryConfig, notification, false);
+
+        inOrder.verify(this.organizationalUnitService).removeRepository(any(), any());
+        inOrder.verify(notification).accept(repository);
     }
 }


### PR DESCRIPTION
# Problem
When a project was deleted, the notification was thrown before FS deletion, so the refresh was execute before any information was deleted and the UI was not refreshed because of that.

# Solution
The solution is quite simple, the Notification is thrown after the FS is created. That way, we ensure that information is present before the refresh event arrives to other nodes in the cluster. This also fix delete modal problem.

@pefernan  @paulovmr  @ederign would you mind to review?