### PR TITLE
added missing dependencies

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/pom.xml
@@ -169,6 +169,22 @@
       </exclusions>
     </dependency>
 
+    <!-- added because enforce-direct-dependencies check failed -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-jgit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 
 </project>


### PR DESCRIPTION
appformer on Jenkins https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/master/job/deployedRep/job/appformer/15/console breaks because of enforce-direct-dependencies check in dashbuilder-services. This PR adds missing deps.