### PR TITLE
AF-2053: Dialog remains open after asset is deleted at the same time

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
@@ -16,18 +16,6 @@
 
 package org.uberfire.ext.editor.commons.client;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.IsWidget;
 import elemental2.promise.Promise;
@@ -67,16 +55,15 @@ import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.uberfire.ext.editor.commons.client.menu.MenuItems.COPY;
-import static org.uberfire.ext.editor.commons.client.menu.MenuItems.DELETE;
-import static org.uberfire.ext.editor.commons.client.menu.MenuItems.DOWNLOAD;
-import static org.uberfire.ext.editor.commons.client.menu.MenuItems.HISTORY;
-import static org.uberfire.ext.editor.commons.client.menu.MenuItems.RENAME;
-import static org.uberfire.ext.editor.commons.client.menu.MenuItems.SAVE;
-import static org.uberfire.ext.editor.commons.client.menu.MenuItems.VALIDATE;
-import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.newConcurrentDelete;
-import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.newConcurrentRename;
-import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.newConcurrentUpdate;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.uberfire.ext.editor.commons.client.menu.MenuItems.*;
+import static org.uberfire.ext.widgets.common.client.common.ConcurrentChangePopup.*;
 
 public abstract class BaseEditor<T, M> {
 
@@ -447,7 +434,7 @@ public abstract class BaseEditor<T, M> {
     }
 
     private void disableDeletePopup() {
-        if(deletePopUpPresenter.isOpened()) {
+        if (deletePopUpPresenter.isOpened()) {
             deletePopUpPresenter.cancel();
         }
     }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/DeletePopUpPresenter.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/DeletePopUpPresenter.java
@@ -16,10 +16,6 @@
 
 package org.uberfire.ext.editor.commons.client.file.popups;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.ext.editor.commons.client.file.popups.commons.ToggleCommentPresenter;
 import org.uberfire.ext.editor.commons.client.validation.ValidationErrorReason;
@@ -27,15 +23,20 @@ import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.ext.editor.commons.client.validation.ValidatorWithReasonCallback;
 import org.uberfire.mvp.ParameterizedCommand;
 
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
-@Dependent
+@ApplicationScoped
 public class DeletePopUpPresenter {
 
     private Validator validator;
     private ParameterizedCommand<String> command;
     private View view;
     private ToggleCommentPresenter toggleCommentPresenter;
+    private boolean opened = false;
 
     @Inject
     public DeletePopUpPresenter(View view,
@@ -58,10 +59,12 @@ public class DeletePopUpPresenter {
                      final ParameterizedCommand<String> command) {
         this.validator = validator == null ? defaultValidator() : validator;
         this.command = command;
+        this.opened = true;
         view.show();
     }
 
     public void cancel() {
+        this.opened = false;
         view.hide();
     }
 
@@ -71,6 +74,10 @@ public class DeletePopUpPresenter {
 
     public ParameterizedCommand<String> getCommand() {
         return command;
+    }
+
+    public boolean isOpened() {
+        return opened;
     }
 
     public void delete() {
@@ -96,6 +103,7 @@ public class DeletePopUpPresenter {
             public void onSuccess() {
                 command.execute(comment);
                 view.hide();
+                opened = false;
             }
 
             @Override


### PR DESCRIPTION
The issue was caused when two users were trying to delete the same asset at same time (with the delete popup opened). When first user finally deletes the asset the second user gets the concurrent delete notification, whatever option he chooses (cancel or ignore) on that popup, the delete popup will still be opened, so he will be able click on the delete button, getting that error.

To prevent that situation, we'll be hiding the delete popup if there's a concurrent deletion.

@tomasdavidorg @adrielparedes @ederign Could you please take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/appformer/pull/731
https://github.com/kiegroup/kie-wb-common/pull/2740
