### PR TITLE
DROOLS-4211 / DROOLS-4212: Search feature - Implement search mechanism PoC on GDT / DMN graph

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/GridHighlightHelper.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/GridHighlightHelper.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.util;
+
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+
+public class GridHighlightHelper {
+
+    private double paddingX = 0d;
+
+    private double paddingY = 0d;
+
+    private double minX = 0d;
+
+    private double minY = 0d;
+
+    private boolean isPinnedGrid = false;
+
+    private final GridLienzoPanel gridPanel;
+
+    private final GridWidget gridWidget;
+
+    public GridHighlightHelper(final GridLienzoPanel gridPanel,
+                               final GridWidget gridWidget) {
+        this.gridPanel = gridPanel;
+        this.gridWidget = gridWidget;
+    }
+
+    public void highlight(final int row,
+                          final int column) {
+
+        final double rowOffset = calculateRowOffset(row);
+        final double columnOffset = calculateColumnOffset(column);
+        final double y = applyPinnedGridConstraints(rowOffset);
+        final double x = applyPinnedGridConstraints(columnOffset);
+
+        select(row, column);
+        moveCanvasTo(x, y);
+    }
+
+    public void clearSelections() {
+
+        final GridWidget gridWidget = getGridWidget();
+
+        gridWidget.getModel().clearSelections();
+        gridWidget.draw();
+    }
+
+    public GridHighlightHelper withPaddingX(final double paddingX) {
+        this.paddingX = paddingX;
+        return this;
+    }
+
+    public GridHighlightHelper withPaddingY(final double paddingY) {
+        this.paddingY = paddingY;
+        return this;
+    }
+
+    public GridHighlightHelper withPinnedGrid() {
+        this.isPinnedGrid = true;
+        return this;
+    }
+
+    public GridHighlightHelper withMinX(final double minX) {
+        this.minX = minX;
+        return this;
+    }
+
+    public GridHighlightHelper withMinY(final double minY) {
+        this.minY = minY;
+        return this;
+    }
+
+    private void select(final int row,
+                        final int column) {
+        gridWidget.selectCell(row, column, false, false);
+        gridWidget.draw();
+    }
+
+    void moveCanvasTo(final double x,
+                      final double y) {
+
+        final double deltaY = calculateDeltaY(y);
+        final double deltaX = calculateDeltaX(x);
+        final Transform newTransform = getTransform().copy().translate(deltaX, deltaY);
+
+        getViewport().setTransform(newTransform);
+        getDefaultGridLayer().batch();
+        getGridPanel().refreshScrollPosition();
+    }
+
+    private double calculateDeltaY(final double y) {
+
+        final double rawY = -(y - getPaddingY());
+        final Range yRange = new Range(getVisibleBounds().getY() + getPaddingY(),
+                                       getVisibleBounds().getY() + getVisibleBounds().getHeight() - getPaddingY());
+
+        if (yRange.contains(rawY)) {
+            return 0d;
+        }
+
+        return y - (getTransform().getTranslateY() / getTransform().getScaleY());
+    }
+
+    private double calculateDeltaX(final double x) {
+
+        final double rawX = -(x - getPaddingX());
+        final Range xRange = new Range(getVisibleBounds().getX() + getPaddingX(),
+                                       getVisibleBounds().getX() + getVisibleBounds().getWidth() - getPaddingX());
+
+        if (xRange.contains(rawX)) {
+            return 0d;
+        }
+
+        return x - (getTransform().getTranslateX() / getTransform().getScaleX());
+    }
+
+    private double calculateColumnOffset(final int column) {
+        return -(getMinX() + getRendererHelper().getColumnOffset(column) - getPaddingX());
+    }
+
+    private double calculateRowOffset(final int row) {
+        return -(getMinY() + getRendererHelper().getRowOffset(row) - getPaddingY());
+    }
+
+    private BaseGridRendererHelper getRendererHelper() {
+        return getGridWidget().getRendererHelper();
+    }
+
+    private double applyPinnedGridConstraints(final double value) {
+        if (isPinnedGrid && value > 0) {
+            return 0;
+        } else {
+            return value;
+        }
+    }
+
+    private Bounds getVisibleBounds() {
+        return getDefaultGridLayer().getVisibleBounds();
+    }
+
+    private Transform getTransform() {
+        return getViewport().getTransform();
+    }
+
+    private Viewport getViewport() {
+        return getDefaultGridLayer().getViewport();
+    }
+
+    private GridLienzoPanel getGridPanel() {
+        return gridPanel;
+    }
+
+    private GridWidget getGridWidget() {
+        return gridWidget;
+    }
+
+    private double getPaddingX() {
+        return paddingX;
+    }
+
+    private double getPaddingY() {
+        return paddingY;
+    }
+
+    private double getMinX() {
+        return minX;
+    }
+
+    private double getMinY() {
+        return minY;
+    }
+
+    private DefaultGridLayer getDefaultGridLayer() {
+        return getGridPanel().getDefaultGridLayer();
+    }
+
+    class Range {
+
+        final double min;
+        final double max;
+
+        Range(final double min,
+              final double max) {
+            this.min = min;
+            this.max = max;
+        }
+
+        boolean contains(final double value) {
+            return value > min && value < max;
+        }
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/GridHighlightHelperTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/GridHighlightHelperTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.util;
+
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class GridHighlightHelperTest {
+
+    @Mock
+    private GridLienzoPanel gridPanel;
+
+    @Mock
+    private GridWidget gridWidget;
+
+    @Mock
+    private BaseGridRendererHelper rendererHelper;
+
+    @Mock
+    private DefaultGridLayer defaultGridLayer;
+
+    @Mock
+    private Bounds visibleBounds;
+
+    @Mock
+    private Viewport viewport;
+
+    @Mock
+    private Transform transform;
+
+    private int column = 2;
+
+    private int row = 4;
+
+    private int x = 64;
+
+    private int y = 128;
+
+    private double columnOffset = 64;
+
+    private double rowOffset = 128;
+
+    private double defaultPaddingX = 1;
+
+    private double defaultPaddingY = 2;
+
+    private double defaultScale = 1;
+
+    private double defaultTranslate = 1;
+
+    private double visibleBoundsX = -800;
+
+    private double visibleBoundsY = -600;
+
+    private double visibleBoundsWidth = 810;
+
+    private double visibleBoundsHeight = 620;
+
+    private GridHighlightHelper highlightHelper;
+
+    @Before
+    public void init() {
+
+        highlightHelper = spy(new GridHighlightHelper(gridPanel, gridWidget));
+        highlightHelper.withPaddingX(defaultPaddingX);
+        highlightHelper.withPaddingY(defaultPaddingY);
+
+        when(gridPanel.getDefaultGridLayer()).thenReturn(defaultGridLayer);
+        when(gridWidget.getRendererHelper()).thenReturn(rendererHelper);
+
+        // BaseGridRendererHelper
+        when(rendererHelper.getColumnOffset(column)).thenReturn(columnOffset);
+        when(rendererHelper.getRowOffset(row)).thenReturn(rowOffset);
+
+        // DefaultGridLayer
+        when(defaultGridLayer.getVisibleBounds()).thenReturn(visibleBounds);
+        when(defaultGridLayer.getViewport()).thenReturn(viewport);
+
+        // VisibleBounds
+        when(visibleBounds.getX()).thenReturn(visibleBoundsX);
+        when(visibleBounds.getY()).thenReturn(visibleBoundsY);
+        when(visibleBounds.getWidth()).thenReturn(visibleBoundsWidth);
+        when(visibleBounds.getHeight()).thenReturn(visibleBoundsHeight);
+
+        // Viewport
+        when(viewport.getTransform()).thenReturn(transform);
+        when(transform.getScaleY()).thenReturn(defaultScale);
+        when(transform.getScaleX()).thenReturn(defaultScale);
+        when(transform.getTranslateY()).thenReturn(defaultTranslate);
+        when(transform.getTranslateX()).thenReturn(defaultTranslate);
+    }
+
+    @Test
+    public void testHighlight() {
+
+        doNothing().when(highlightHelper).moveCanvasTo(anyInt(), anyInt());
+
+        highlightHelper.highlight(row, column);
+
+        verify(gridWidget).selectCell(row, column, false, false);
+        verify(gridWidget).draw();
+        verify(highlightHelper).moveCanvasTo(-63, -126);
+    }
+
+    @Test
+    public void testHighlightWithPinnedGrid() {
+
+        doNothing().when(highlightHelper).moveCanvasTo(anyInt(), anyInt());
+
+        highlightHelper
+                .withMinX(-256)
+                .withMinY(-512)
+                .withPinnedGrid().highlight(row, column);
+
+        verify(gridWidget).selectCell(row, column, false, false);
+        verify(gridWidget).draw();
+        verify(highlightHelper).moveCanvasTo(0, 0);
+    }
+
+    @Test
+    public void testHighlightWithPadding() {
+
+        doNothing().when(highlightHelper).moveCanvasTo(anyInt(), anyInt());
+
+        highlightHelper
+                .withPaddingX(128)
+                .withPaddingY(64)
+                .highlight(row, column);
+
+        verify(gridWidget).selectCell(row, column, false, false);
+        verify(gridWidget).draw();
+        verify(highlightHelper).moveCanvasTo(64, -64);
+    }
+
+    @Test
+    public void testHighlightWithMinValues() {
+
+        doNothing().when(highlightHelper).moveCanvasTo(anyInt(), anyInt());
+
+        highlightHelper
+                .withMinX(-256)
+                .withMinY(-512)
+                .highlight(row, column);
+
+        verify(gridWidget).selectCell(row, column, false, false);
+        verify(gridWidget).draw();
+        verify(highlightHelper).moveCanvasTo(193, 386);
+    }
+
+    @Test
+    public void testMoveCanvasToWhenTheElementIsVisible() {
+
+        final int expectedDeltaX = 0;
+        final int expectedDeltaY = 0;
+        final Transform copy = mock(Transform.class);
+        final Transform newTransform = mock(Transform.class);
+
+        when(transform.copy()).thenReturn(copy);
+        when(copy.translate(anyInt(), anyInt())).thenReturn(newTransform);
+
+        highlightHelper.moveCanvasTo(x, y);
+
+        verify(copy).translate(expectedDeltaX, expectedDeltaY);
+        verify(viewport).setTransform(newTransform);
+        verify(defaultGridLayer).batch();
+        verify(gridPanel).refreshScrollPosition();
+    }
+
+    @Test
+    public void testMoveCanvasToWhenElementIsNotHorizontallyVisible() {
+
+        final int expectedDeltaX = -747;
+        final int expectedDeltaY = 0;
+        final Transform copy = mock(Transform.class);
+        final Transform newTransform = mock(Transform.class);
+
+        when(transform.copy()).thenReturn(copy);
+        when(copy.translate(anyInt(), anyInt())).thenReturn(newTransform);
+
+        highlightHelper.moveCanvasTo(x - visibleBoundsWidth, y);
+
+        verify(copy).translate(expectedDeltaX, expectedDeltaY);
+        verify(viewport).setTransform(newTransform);
+        verify(defaultGridLayer).batch();
+        verify(gridPanel).refreshScrollPosition();
+    }
+
+    @Test
+    public void testMoveCanvasToWhenElementIsNotVerticallyVisible() {
+
+        final int expectedDeltaX = 0;
+        final int expectedDeltaY = -493;
+        final Transform copy = mock(Transform.class);
+        final Transform newTransform = mock(Transform.class);
+
+        when(transform.copy()).thenReturn(copy);
+        when(copy.translate(anyInt(), anyInt())).thenReturn(newTransform);
+
+        highlightHelper.moveCanvasTo(x, y - visibleBoundsHeight);
+
+        verify(copy).translate(expectedDeltaX, expectedDeltaY);
+        verify(viewport).setTransform(newTransform);
+        verify(defaultGridLayer).batch();
+        verify(gridPanel).refreshScrollPosition();
+    }
+
+    @Test
+    public void testClearSelections() {
+
+        final GridData model = mock(GridData.class);
+
+        when(gridWidget.getModel()).thenReturn(model);
+
+        highlightHelper.clearSelections();
+
+        verify(model).clearSelections();
+        verify(gridWidget).draw();
+    }
+}


### PR DESCRIPTION
### JIRAs:

- https://issues.jboss.org/browse/DROOLS-4211
- https://issues.jboss.org/browse/DROOLS-4212

---

### Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/738
- https://github.com/kiegroup/kie-wb-common/pull/2749
- https://github.com/kiegroup/drools-wb/pull/1191

---

### Description
DROOLS-4211 and DROOLS-4212 JIRAs comprehend only the search mechanism. Thus, the PR implements that for Guided Decision Tables, DMN graphs, and DMN boxed expressions, without a rich user experience (which will be implemented on [DROOLS-4306](https://issues.jboss.org/browse/DROOLS-4306)).
 
To test this PR, just execute the following code into the _browser inspector_:
 
```javascript
document.querySelector('.kie-search-bar').style.display = ""
```

The search component will be enabled, and now you can type something and press <kbd>Enter</kbd> to trigger the search.

![2019-07-11 12 57 45](https://user-images.githubusercontent.com/1079279/61076885-a01ac480-a3f3-11e9-8eba-35faafb3a1e2.gif)