### PR TITLE
RHPAM-2036 :Group cannot be added in Business central integrated with…

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
@@ -119,7 +119,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
             final RoleRepresentation roleRepresentation = new RoleRepresentation();
             roleRepresentation.setName(entity.getName());
             roleRepresentation.setDescription(entity.getName());
-            roleRepresentation.setScopeParamRequired(false);
+            roleRepresentation.setScopeParamRequired(new Boolean(false));
             roleRepresentation.setId(entity.getName());
             roleRepresentation.setComposite(false);
             final ClientResponse response = (ClientResponse) rolesResource.create(roleRepresentation);

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
@@ -185,6 +185,13 @@ public class KeyCloakGroupManagerTest extends DefaultKeyCloakTest {
                     ROLE + 49);
     }
 
+    @Test
+    public void testCreateGroup() {
+        String groupName = "newgroup";
+        Group newgroup = groupsManager.create(SecurityManagementUtils.createGroup("newgroup"));
+        assertGroup(newgroup, groupName);
+    }
+
     @Test(expected = UnsupportedServiceCapabilityException.class)
     public void testUpdateGroup() {
         groupsManager.update(SecurityManagementUtils.createGroup("id1"));


### PR DESCRIPTION
… RHSSO integration

- We are getting this error "java.lang.NoSuchMethodError:org.keycloak.representations.idm.RoleRepresentation.setScopeParamRequired(Ljava/lang/Boolean;)V" because at runtime appformer is calling method setScopeParamRequired in keycloak-core with a primitive boolean, while the method itself accept a Boolean wrapper type.
- Added Boolean wrapper type as method argument.
![add-group-rhsso](https://user-images.githubusercontent.com/23648802/61127918-3f13ef00-a4ce-11e9-9362-a92a6467c1e9.png)
