### PR TITLE
RHPAM-2036 :Group cannot be added in Business central integrated with…

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/BaseKeyCloakManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/BaseKeyCloakManager.java
@@ -205,12 +205,11 @@ public abstract class BaseKeyCloakManager {
                          Boolean.toString(isEmailVerified));
         user.setProperty(ATTRIBUTE_USER_ENABLED,
                          Boolean.toString(isEnabled));
-        final Map<String, Object> attrs = userRepresentation.getAttributes();
+        final Map<String, List<String>> attrs = userRepresentation.getAttributes();
         if (attrs != null && !attrs.isEmpty()) {
-            for (final Map.Entry<String, Object> entry : attrs.entrySet()) {
-                final String v = entry.getValue() != null ? entry.getValue().toString() : null;
-                user.setProperty(entry.getKey(),
-                                 v);
+            for (final Map.Entry<String, List<String>> entry : attrs.entrySet()) {
+                final String v = entry.getValue() != null ? String.join(", ",entry.getValue()) : null;
+                user.setProperty(entry.getKey(), v);
             }
         }
     }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
@@ -116,10 +116,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
                      entity);
         consumeRealm(realmResource -> {
             final RolesResource rolesResource = realmResource.roles();
-            final RoleRepresentation roleRepresentation = new RoleRepresentation();
-            roleRepresentation.setName(entity.getName());
-            roleRepresentation.setDescription(entity.getName());
-            roleRepresentation.setScopeParamRequired(false);
+            final RoleRepresentation roleRepresentation = new RoleRepresentation(entity.getName(), entity.getName(), Boolean.FALSE);
             roleRepresentation.setId(entity.getName());
             roleRepresentation.setComposite(false);
             final ClientResponse response = (ClientResponse) rolesResource.create(roleRepresentation);

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
@@ -17,6 +17,7 @@
 package org.uberfire.ext.security.management.keycloak;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,19 +197,19 @@ public abstract class DefaultKeyCloakTest extends BaseKeyCloakTest {
         when(userRepresentation.getEmail()).thenReturn(mail);
         when(userRepresentation.isEmailVerified()).thenReturn(true);
         when(userRepresentation.isEnabled()).thenReturn(true);
-        Map<String, Object> attributes = new HashMap<String, Object>(6);
+        Map<String, List<String>> attributes = new HashMap<String, List<String>>(6);
         attributes.put(BaseKeyCloakManager.ATTRIBUTE_USER_ID,
-                       id);
+                       Arrays.asList(id));
         attributes.put(BaseKeyCloakManager.ATTRIBUTE_USER_FIRST_NAME,
-                       fName);
+                       Arrays.asList(fName));
         attributes.put(BaseKeyCloakManager.ATTRIBUTE_USER_LAST_NAME,
-                       lName);
+                       Arrays.asList(lName));
         attributes.put(BaseKeyCloakManager.ATTRIBUTE_USER_ENABLED,
-                       "true");
+                       Arrays.asList("true"));
         attributes.put(BaseKeyCloakManager.ATTRIBUTE_USER_EMAIL,
-                       mail);
+                       Arrays.asList(mail));
         attributes.put(BaseKeyCloakManager.ATTRIBUTE_USER_EMAIL_VERIFIED,
-                       "true");
+                       Arrays.asList("true"));
         when(userRepresentation.getAttributes()).thenReturn(attributes);
     }
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
@@ -185,6 +185,13 @@ public class KeyCloakGroupManagerTest extends DefaultKeyCloakTest {
                     ROLE + 49);
     }
 
+    @Test
+    public void testCreateGroup() {
+        String groupName = "newgroup";
+        Group newgroup = groupsManager.create(SecurityManagementUtils.createGroup("newgroup"));
+        assertGroup(newgroup, groupName);
+    }
+
     @Test(expected = UnsupportedServiceCapabilityException.class)
     public void testUpdateGroup() {
         groupsManager.update(SecurityManagementUtils.createGroup("id1"));


### PR DESCRIPTION
… RHSSO integration

- The error message was displayed since method setScopeParamRequired is no longer present in keycloak version 4.8.3.
- Upgraded keycloak version to 4.8.3.
- Upgrade was needed due to change in some method signatures in latest version that were causing conflicts with our current version.
- PR for keycloak upgrade in kie-parent  - https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1003.