### PR TITLE
[AF-2117] Get all users throw an exception when there is no implementation found

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/InputAutocomplete.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/InputAutocomplete.java
@@ -37,9 +37,14 @@ public class InputAutocomplete implements IsElement {
     @Inject
     private JQueryElementalProducer.JQuery<InputAutocompleteElement> jQuery;
 
-    public void setup(final Supplier<List<String>> options) {
+    public void setup(final Supplier<List<String>> optionsSupplier) {
         final InputAutocompleteOptions inputAutocompleteOptions = new InputAutocompleteOptions();
-        inputAutocompleteOptions.setSource((String[]) options.get().toArray());
+        List<String> options = optionsSupplier.get();
+        if (options != null) {
+            String[] optionsArray = options.stream()
+                    .toArray(String[]::new);
+            inputAutocompleteOptions.setSource(optionsArray);
+        }
 
         jQuery.wrap(getElement()).autocomplete(inputAutocompleteOptions);
     }


### PR DESCRIPTION
@paulovmr (String[]) options.get().toArray()) doesn't work on GWT on OSX (but works on your linux env right?)

Anyway, (String[]) options.get().toArray() doesn't work on JDK, so I changed it for a new implementation.

@karreiro this is what was generating the annoying exception on drools-wb web app. (/cc @manstis)

Child PR (but not dependent): https://github.com/kiegroup/kie-wb-common/pull/2775

Stack of the error (on OSX, chrome and with gwt:run): 

ErraiConsoleLogHandler.java:91 Error caused by: ClassCastException: null
    at BVe_g$.hHb_g$ [as createError_0_g$] (Throwable.java:120)
    at BVe_g$.rHb_g$ [as initializeBackingError_0_g$] (Throwable.java:112)
    at BVe_g$.aHb_g$ (Throwable.java:66)
    at BVe_g$.GHb_g$ (Exception.java:29)
    at BVe_g$.wsc_g$ (RuntimeException.java:29)
    at new BVe_g$ (ClassCastException.java:27)
    at ppm_g$ (InternalPreconditions.java:154)
    at Bpm_g$ (InternalPreconditions.java:138)
    at Apm_g$ (InternalPreconditions.java:133)
    at BVh_g$ (Cast.java:75)
    at K1mb_g$.O1mb_g$ [as setup_100_g$] (InputAutocomplete.java:42)
    at mIcb_g$.OIcb_g$ [as setupUsersAutocomplete_0_g$] (ContributorsListItemView.java:99)
    at mIcb_g$.HIcb_g$ [as init_368_g$] (ContributorsListItemView.java:95)
    at mIcb_g$.GIcb_g$ [as init_30_g$] (ContributorsListItemView.java:93)
    at IGcb_g$.dHcb_g$ [as setup_36_g$] (ContributorsListItemPresenter.java:120)
    at jJcb_g$.tJcb_g$ [as lambda$2_150_g$] (ContributorsListPresenter.java:125)
    at _Jcb_g$.aKcb_g$ [as accept_4_g$] (ContributorsListPresenter.java:123)
    at Vql_g$ (Iterator.java:37)
    at S9k_g$.T9k_g$ [as forEachRemaining_0_g$] (Iterator.java:34)
    at iyl_g$.nyl_g$ [as forEachRemaining_0_g$] (Spliterators.java:449)
    at thm_g$.Jhm_g$ [as forEachOrdered_3_g$] (StreamImpl.java:558)
    at thm_g$.Ihm_g$ [as forEach_0_g$] (StreamImpl.java:552)
    at jJcb_g$.BJcb_g$ [as updateView_2_g$] (ContributorsListPresenter.java:122)
    at jJcb_g$.AJcb_g$ [as updateContributors_1_g$] (ContributorsListPresenter.java:107)
    at jJcb_g$.rJcb_g$ [as lambda$0_471_g$] (ContributorsListPresenter.java:101)
    at PJcb_g$.QJcb_g$ [as accept_4_g$] (ContributorsListPresenter.java:99)
    at oMcb_g$.pMcb_g$ [as callback_39_g$] (SpaceContributorsListServiceImpl.java:125)
    at MNZ_g$.RNZ_g$ [as lambda$0_302_g$] (CallerProvider.java:94)
    at XNZ_g$.YNZ_g$ [as callback_39_g$] (CallerProvider.java:92)
    at sJA_g$.yJA_g$ [as lambda$1_101_g$] (DefaultRemoteCallBuilder.java:104)
    at XJA_g$.YJA_g$ [as callback_78_g$] (DefaultRemoteCallBuilder.java:96)
    at vNA_g$.wNA_g$ [as callback_78_g$] (ClientMessageBusImpl.java:659)
    at WLA_g$.YMA_g$ [as sendLocal_0_g$] (ClientMessageBusImpl.java:837)
    at EoB_g$ (BusToolsCli.java:54)
    at YlB_g$.$lB_g$ [as onResponseReceived_0_g$] (HttpPollingHandler.java:812)
    at xlB_g$.zlB_g$ [as onResponseReceived_0_g$] (HttpPollingHandler.java:561)
    at OAh_g$.RAh_g$ [as fireOnResponseReceived_0_g$] (Request.java:250)
    at YBh_g$.ZBh_g$ [as onReadyStateChange_0_g$] (RequestBuilder.java:412)
    at XMLHttpRequest.<anonymous> (XMLHttpRequest.java:329)
    at VTf_g$ (Impl.java:309)
    at YTf_g$ (Impl.java:361)
    at XMLHttpRequest.<anonymous> (Impl.java:78)