### PR TITLE
changed uberfire-bom version to KIE version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -931,12 +931,7 @@
       <dependency>
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-bom</artifactId>
-        <!-- Using ${uberfire.version} instead of ${project.version} enables easier way to create hot fixes
-             (one-off patches). This pom is a parent for all uberfire modules, so when version is changed in
-             one of them, the ${project.version} property changes too and therefore also required version of
-             uberfire-bom. Usage of  this property makes it possible to change version of the (sub)module
-             and still use the original version of uberfire-bom. -->
-        <version>${uberfire.version}</version>
+        <version>${version.org.kie}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/scripts/release/update-version.sh
+++ b/scripts/release/update-version.sh
@@ -45,10 +45,6 @@ startDateTime=`date +%s`
 cd $uberfireTopLevelDir
 mvnVersionsSet $newVersion
 
-# fix leftovers not covered by the first run
-cd $uberfireTopLevelDir/uberfire-bom
-mvnVersionsSet $newVersion
-
 endDateTime=`date +%s`
 spentSeconds=`expr $endDateTime - $startDateTime`
 

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
@@ -17,6 +17,7 @@
 
   <properties>
     <version.org.uberfire>${project.version}</version.org.uberfire>
+    <version.org.kie>${version.org.kie}</version.org.kie>
 
     <version.de.benediktmeurer.gwt-slf4j>${version.de.benediktmeurer.gwt-slf4j}</version.de.benediktmeurer.gwt-slf4j>
     <version.ch.qos.logback>${version.ch.qos.logback}</version.ch.qos.logback>
@@ -100,7 +101,7 @@
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-bom</artifactId>
         <type>pom</type>
-        <version>\${version.org.uberfire}</version>
+        <version>\${version.org.kie}</version>
         <scope>import</scope>
       </dependency>
 


### PR DESCRIPTION
The commit https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/34dfe2ec1c3634a0d06db0b16f49b57e5e085301 moved uberfire-bom from appformer into droolsjbpm-build-bootstrap, with uberfire-bom version kept as Appformer version. Since this is not very user-friendly and breaks product build, this PR proposes a change of uberfire-bom version to KIE version to align it with the rest of the BOMs.

Related PRs: 
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1009
- https://github.com/kiegroup/droolsjbpm-integration/pull/1873
- https://github.com/kiegroup/drools-wb/pull/1198
- https://github.com/kiegroup/jbpm-designer/pull/856
- https://github.com/kiegroup/jbpm-wb/pull/1375
- https://github.com/kiegroup/kie-uberfire-extensions/pull/87
- https://github.com/kiegroup/kie-wb-common/pull/2780
- https://github.com/kiegroup/kie-wb-distributions/pull/947
- https://github.com/kiegroup/optaplanner-wb/pull/342