### PR TITLE
AF-2059 - Add Lock to Dashbuilder Migration Service for HA Environments

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/migration/DashbuilderDataMigration.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/migration/DashbuilderDataMigration.java
@@ -212,9 +212,8 @@ public class DashbuilderDataMigration {
     }
 
     private void runWithLock(Command command) {
-        String className = this.getClass().getName();
-        String lockName = className + ".lock";
-        String markerName = className + ".done";
+        String lockName = "data-migration.lock";
+        String markerName = "data-migration.done";
 
         TimeUnit lastAccessTimeUnit = TimeUnit.SECONDS;
         int lastAccessThreshold = 1;


### PR DESCRIPTION
[AF-2059](https://issues.jboss.org/browse/AF-2059) - Add Lock to Dashbuilder Migration Service for HA Environments

Create a **lock** mechanism to avoid conflicts in Cluster environments where multiples Pods could run the Dashbuilder Data Migration at same time. This lock also avoids the migration to run twice.

Three files are created under **.niogit/dashbuilder** to indicate that the migration process has executed. If these files are removed, the migration will run again at next system startup.
* datasets.migration.done
* perspectives.migration.done
* navigation.migration.done

This PR is related with this [commit](https://github.com/gabriel376/appformer/commit/7416921240cf2000c368cb5cf6a71def40d777dd)