### PR TITLE
DROOLS-4415: Cell placeholder disappear in some cases

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
@@ -18,12 +18,12 @@ package org.uberfire.ext.wires.core.grids.client.model.impl;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -124,7 +124,7 @@ public class BaseGridData implements GridData {
         //Destroy column data
         for (GridRow row : rows) {
             ((BaseGridRow) row).deleteCell(index);
-            final Map<Integer, GridCell<?>> clone = new HashMap<Integer, GridCell<?>>(row.getCells());
+            final Map<Integer, GridCell<?>> clone = new TreeMap<>(row.getCells());
             for (Map.Entry<Integer, GridCell<?>> e : clone.entrySet()) {
                 if (e.getKey() > index) {
                     ((BaseGridRow) row).deleteCell(e.getKey());

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridData.java
@@ -121,9 +121,10 @@ public class BaseGridData implements GridData {
 
         removeColumn(column);
 
-        //Destroy column data
+        //Destroy column related cell
         for (GridRow row : rows) {
             ((BaseGridRow) row).deleteCell(index);
+            //Shift all cells according to the removed one
             final Map<Integer, GridCell<?>> clone = new TreeMap<>(row.getCells());
             for (Map.Entry<Integer, GridCell<?>> e : clone.entrySet()) {
                 if (e.getKey() > index) {


### PR DESCRIPTION
@kkufova @gitgabrio @danielezonca Can you please test and review it?

Basically, I only changed the Map implementation from HashMap to TreeMap for the cloned Map used to manage the cells shift when a column is deleted. It this case, the order of the cell position is critical, consider the used logic: 
```
            for (Map.Entry<Integer, GridCell<?>> e : clone.entrySet()) {
                if (e.getKey() > index) {
                    ((BaseGridRow) row).deleteCell(e.getKey());
                    ((BaseGridRow) row).setCell(e.getKey() - 1,
                                                e.getValue());
                }
            }
```
Please notice, cells are stored in a MAP, not a list.
Navigating the cloned Map without following an order, can lead to lost some cells.

. HashMap doesn't guarantee the order of the keys, so changing it with TreeMap prevent the issue. 