### PR TITLE
KOGITO-136 - BPMN webapp for Kogito, fixing issue with Errai bus disabled

### DIFF
--- a/uberfire-experimental/uberfire-experimental-client/src/main/java/org/uberfire/experimental/client/UberfireExperimentalEntryPoint.java
+++ b/uberfire-experimental/uberfire-experimental-client/src/main/java/org/uberfire/experimental/client/UberfireExperimentalEntryPoint.java
@@ -19,6 +19,7 @@ package org.uberfire.experimental.client;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import org.jboss.errai.bus.client.util.BusToolsCli;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
 import org.uberfire.experimental.client.service.ClientExperimentalFeaturesDefRegistry;
@@ -42,6 +43,10 @@ public class UberfireExperimentalEntryPoint {
 
     @PostConstruct
     public void init() {
+        if (!BusToolsCli.isRemoteCommunicationEnabled()) {
+            return;
+        }
+
         defRegistry.loadRegistry();
         registryService.loadRegistry();
         activitiesAuthorizationManager.init();

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/RuntimePluginsEntryPoint.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/RuntimePluginsEntryPoint.java
@@ -16,17 +16,14 @@
 
 package org.uberfire.ext.plugin.client;
 
-import static com.google.gwt.core.client.ScriptInjector.TOP_WINDOW;
-import static org.uberfire.workbench.model.ActivityResourceType.EDITOR;
-import static org.uberfire.workbench.model.ActivityResourceType.PERSPECTIVE;
-import static org.uberfire.workbench.model.ActivityResourceType.POPUP;
-import static org.uberfire.workbench.model.ActivityResourceType.SCREEN;
-
 import java.util.Collection;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.ScriptInjector;
+import com.google.gwt.dom.client.StyleInjector;
+import org.jboss.errai.bus.client.util.BusToolsCli;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.api.EnabledByProperty;
@@ -51,8 +48,11 @@ import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.security.ResourceType;
 import org.uberfire.workbench.model.menu.MenuFactory;
 
-import com.google.gwt.core.client.ScriptInjector;
-import com.google.gwt.dom.client.StyleInjector;
+import static com.google.gwt.core.client.ScriptInjector.TOP_WINDOW;
+import static org.uberfire.workbench.model.ActivityResourceType.EDITOR;
+import static org.uberfire.workbench.model.ActivityResourceType.PERSPECTIVE;
+import static org.uberfire.workbench.model.ActivityResourceType.POPUP;
+import static org.uberfire.workbench.model.ActivityResourceType.SCREEN;
 
 @EntryPoint
 @Bundle("resources/i18n/Constants.properties")
@@ -76,7 +76,12 @@ public class RuntimePluginsEntryPoint {
 
     @PostConstruct
     public void init() {
+        if (!BusToolsCli.isRemoteCommunicationEnabled()) {
+            return;
+        }
+
         WebAppResource.INSTANCE.CSS().ensureInjected();
+
         workbench.addStartupBlocker(RuntimePluginsEntryPoint.class);
         pluginServices.call(new RemoteCallback<Collection<RuntimePlugin>>() {
             @Override

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/config/PluginConfigService.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/config/PluginConfigService.java
@@ -19,6 +19,7 @@ package org.uberfire.ext.plugin.client.config;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import org.jboss.errai.bus.client.util.BusToolsCli;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.api.EntryPoint;
@@ -34,6 +35,10 @@ public class PluginConfigService {
 
     @PostConstruct
     public void init() {
+        if (!BusToolsCli.isRemoteCommunicationEnabled()) {
+            return;
+        }
+
         pluginServices.call(new RemoteCallback<String>() {
             @Override
             public void callback(final String response) {

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
@@ -27,6 +27,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import org.jboss.errai.bus.client.util.BusToolsCli;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.api.EntryPoint;
@@ -73,6 +74,10 @@ public class PerspectiveEditorGenerator {
 
     @PostConstruct
     public void loadPerspectives() {
+        if (!BusToolsCli.isRemoteCommunicationEnabled()) {
+            return;
+        }
+
         perspectiveServices.call((Collection<LayoutTemplate> response) -> {
             response.forEach(this::generatePerspective);
         }).listLayoutTemplates();

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/plugins/RuntimePluginStartup.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/plugins/RuntimePluginStartup.java
@@ -1,11 +1,13 @@
 package org.uberfire.ext.plugin.client.plugins;
 
 import java.util.List;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.core.client.ScriptInjector;
+import org.jboss.errai.bus.client.util.BusToolsCli;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.api.EnabledByProperty;
@@ -30,10 +32,17 @@ public class RuntimePluginStartup {
 
     @PostConstruct
     public void init() {
+        if (!BusToolsCli.isRemoteCommunicationEnabled()) {
+            return;
+        }
+
         workbench.addStartupBlocker(RuntimePluginStartup.class);
     }
 
     void startPlugins(@Observes UberfireJSAPIReadyEvent event) {
+        if (!BusToolsCli.isRemoteCommunicationEnabled()) {
+            return;
+        }
 
         runtimePlugins.call(new RemoteCallback<List<RuntimePlugin>>() {
             @Override


### PR DESCRIPTION
There were necessary the Errai bus connection check on Runtime Plugins startup, to avoid issues on BPMN editor.
The long term solution could be creating a new module as discussed.

@tiagobento 
@ederign 
 