### PR TITLE
AF-2054 :Open asset is not updated for user who push the change

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
@@ -382,6 +382,7 @@ public abstract class BaseEditor<T, M> {
             @Override
             public void execute(final ObservablePath.OnConcurrentUpdateEvent eventInfo) {
                 concurrentUpdateSessionInfo = eventInfo;
+                showConcurrentUpdatePopup();
             }
         });
 

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
@@ -309,9 +309,6 @@ public class LockManagerImpl implements LockManager {
 
     void onResourceUpdated(@Observes ResourceUpdatedEvent res) {
         if (lockTarget != null && res.getPath().equals(lockTarget.getPath())) {
-            if (!res.getSessionInfo().getIdentity().equals(user)) {
-                reload();
-            }
             releaseLock();
         }
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/LockManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/LockManagerTest.java
@@ -287,7 +287,7 @@ public class LockManagerTest {
                                                                "",
                                                                new SessionInfoImpl(new UserImpl("differentUser"))));
 
-        assertEquals(1,
+        assertEquals(0,
                      reloads);
     }
 


### PR DESCRIPTION
- Opened asset will now be updated even for user who push the change
- A warning popup will be shown to the user if he has lock on the asset. He can then accept the incoming changes or discard and save his current changes.
![Screenshot from 2019-08-22 16-00-28](https://user-images.githubusercontent.com/23648802/63523147-33790680-c517-11e9-884b-cf3639ab96cd.png)
