### PR TITLE
[RHPAM-2287] Filter by asset type displaying no results

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/ickl/IckleConverter.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/ickl/IckleConverter.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
@@ -30,6 +31,7 @@ import org.apache.lucene.search.WildcardQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.ext.metadata.backend.infinispan.ickl.converters.BooleanQueryConverter;
+import org.uberfire.ext.metadata.backend.infinispan.ickl.converters.RegexpQueryConverter;
 import org.uberfire.ext.metadata.backend.infinispan.ickl.converters.TermQueryConverter;
 import org.uberfire.ext.metadata.backend.infinispan.ickl.converters.WildcardQueryConverter;
 
@@ -48,16 +50,19 @@ public class IckleConverter {
     }
 
     public String convert(Query query) {
+        Class<? extends Query> queryClass = query.getClass();
 
-        if (TermQuery.class.isAssignableFrom(query.getClass())) {
-            return new TermQueryConverter((TermQuery) query,
-                                          converterImpl).convert();
-        } else if (WildcardQuery.class.isAssignableFrom(query.getClass())) {
-            return new WildcardQueryConverter((WildcardQuery) query,
-                                              converterImpl).convert();
-        } else if (BooleanQuery.class.isAssignableFrom(query.getClass())) {
-            return new BooleanQueryConverter((BooleanQuery) query,
-                                             this).convert();
+        if (TermQuery.class.isAssignableFrom(queryClass)) {
+            return new TermQueryConverter((TermQuery) query, converterImpl).convert();
+
+        } else if (WildcardQuery.class.isAssignableFrom(queryClass)) {
+            return new WildcardQueryConverter((WildcardQuery) query, converterImpl).convert();
+
+        } else if (BooleanQuery.class.isAssignableFrom(queryClass)) {
+            return new BooleanQueryConverter((BooleanQuery) query, this).convert();
+
+        } else if (RegexpQuery.class.isAssignableFrom(queryClass)) {
+            return new RegexpQueryConverter((RegexpQuery) query).convert();
         }
 
         if (logger.isDebugEnabled()) {

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/ickl/converters/RegexpQueryConverter.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/ickl/converters/RegexpQueryConverter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.metadata.backend.infinispan.ickl.converters;
+
+import org.apache.lucene.search.RegexpQuery;
+
+public class RegexpQueryConverter implements QueryConverter {
+
+    private RegexpQuery regexpQuery;
+
+    public RegexpQueryConverter(RegexpQuery regexpQuery) {
+        this.regexpQuery = regexpQuery;
+    }
+
+    @Override
+    public String convert() {
+        return String.format("%s:/%s/",
+                             regexpQuery.getRegexp().field(),
+                             regexpQuery.getRegexp().text());
+    }
+}

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/test/java/org/uberfire/ext/metadata/backend/infinispan/ickl/IcklConverterTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/test/java/org/uberfire/ext/metadata/backend/infinispan/ickl/IcklConverterTest.java
@@ -20,6 +20,7 @@ package org.uberfire.ext.metadata.backend.infinispan.ickl;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
 import org.apache.lucene.search.TermQuery;
@@ -141,5 +142,14 @@ public class IcklConverterTest {
             String sortString = this.ickleConverter.sort(sort);
             assertThat(sortString).isEqualTo("order by a__sort__field DESC,another__sort__field ASC");
         }
+    }
+
+    @Test
+    public void testRegexpQuery() {
+        Query query = new RegexpQuery(new Term("libraryFileName", ".*(cmmn|bpmn|bpmn2|bpmn-cm)"));
+
+        String queryString = this.ickleConverter.convert(query);
+
+        assertThat(queryString).isEqualTo("libraryFileName:/.*(cmmn|bpmn|bpmn2|bpmn-cm)/");
     }
 }


### PR DESCRIPTION
**[RHPAM-2287](https://issues.jboss.org/browse/RHPAM-2287) Filter by asset type displaying no results**

* Issue caused by missing Regexp Query implementation on class IckleConverter, that converts from  Lucene to ISPN