### PR TITLE
[AF-2182]: Added generation of base caches in case they don't exist

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/provider/IndexProvider.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-api/src/main/java/org/uberfire/ext/metadata/provider/IndexProvider.java
@@ -63,4 +63,6 @@ public interface IndexProvider extends Disposable {
                          Query query);
 
     List<String> getIndices();
+
+    void observerInitialization(Runnable runnable);
 }

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/src/main/java/org/uberfire/ext/metadata/backend/elastic/index/ElasticSearchIndexProvider.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-elasticsearch/src/main/java/org/uberfire/ext/metadata/backend/elastic/index/ElasticSearchIndexProvider.java
@@ -360,6 +360,11 @@ public class ElasticSearchIndexProvider implements IndexProvider {
         return Arrays.asList(indices).stream().filter(index -> !index.startsWith(".")).collect(Collectors.toList());
     }
 
+    @Override
+    public void observerInitialization(Runnable runnable) {
+        // Do nothing
+    }
+
     public void putMapping(String index,
                            String type,
                            MetaObject metaObject) {

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/provider/InfinispanIndexProvider.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/provider/InfinispanIndexProvider.java
@@ -231,6 +231,11 @@ public class InfinispanIndexProvider implements IndexProvider {
         return this.infinispanContext.getIndices();
     }
 
+    @Override
+    public void observerInitialization(Runnable runnable) {
+        this.infinispanContext.observeInitialization(runnable);
+    }
+
     protected QueryFactory getQueryFactory(String index) {
         return Search
                 .getQueryFactory(this.infinispanContext.getCache(index.toLowerCase()));

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/provider/LuceneIndexProvider.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/provider/LuceneIndexProvider.java
@@ -204,6 +204,11 @@ public class LuceneIndexProvider implements IndexProvider {
         return this.indexManager.getIndices();
     }
 
+    @Override
+    public void observerInitialization(Runnable runnable) {
+        // Do nothing
+    }
+
     public ScoreDoc[] findRawByQuery(List<String> indices,
                                      Query query,
                                      Sort sort,


### PR DESCRIPTION
When ISPN got rebooted the main caches were lost, also the indexes because ISPN is not a persistent cache. So when ISPN is restarted, BC generates caches again and force reindexing.