### PR TITLE
JBPM-8742: Link column preferences with saved filter

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
@@ -142,6 +142,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency><!-- to get CallerMock in unit test-->
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
   </dependencies>
 
   <build>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
@@ -204,7 +204,9 @@ public class PagedTable<T>
         GridPreferencesStore gridPreferencesStore = super.getGridPreferencesStore();
         if (gridPreferencesStore != null) {
             gridPreferencesStore.setPageSizePreferences(pageSize);
-            super.saveGridPreferences();
+            if (isPersistingPreferencesOnChange()) {
+                super.saveGridPreferences();
+            }
         }
         this.pageSize = pageSize;
     }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/SimpleTable.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/SimpleTable.java
@@ -43,6 +43,8 @@ public class SimpleTable<T>
 
     private static Binder uiBinder = GWT.create(Binder.class);
     private GridPreferencesStore gridPreferencesStore;
+    private boolean persistPreferencesOnChange = true;
+
     @Inject
     private Caller<UserPreferencesService> preferencesService;
 
@@ -61,6 +63,14 @@ public class SimpleTable<T>
         if (gridGlobalPreferences != null) {
             this.gridPreferencesStore = new GridPreferencesStore(gridGlobalPreferences);
         }
+    }
+
+    public void setPersistPreferencesOnChange(boolean persistPreferencesOnChange) {
+        this.persistPreferencesOnChange = persistPreferencesOnChange;
+    }
+
+    public boolean isPersistingPreferencesOnChange() {
+        return persistPreferencesOnChange;
     }
 
     protected void setupColumnPicker() {
@@ -87,7 +97,9 @@ public class SimpleTable<T>
             for (GridColumnPreference gcp : columnsState) {
                 gridPreferencesStore.addGridColumnPreference(gcp);
             }
-            saveGridPreferences();
+            if (isPersistingPreferencesOnChange()) {
+                saveGridPreferences();
+            }
         }
     }
 
@@ -111,8 +123,14 @@ public class SimpleTable<T>
     }
 
     public void saveGridPreferences() {
-        if (gridPreferencesStore != null && preferencesService != null) {
+        if (gridPreferencesStore != null) {
             gridPreferencesStore.setPreferenceKey(gridPreferencesStore.getGlobalPreferences().getKey());
+            saveGridToUserPreferences();
+        }
+    }
+
+    public void saveGridToUserPreferences(){
+        if (preferencesService!=null && gridPreferencesStore != null) {
             gridPreferencesStore.setType(UserPreferencesType.GRIDPREFERENCES);
             preferencesService.call(response -> {
             }).saveUserPreferences(gridPreferencesStore);


### PR DESCRIPTION
Update global preferences key when GridpreferencesStore  preference key is changed.
Only persist preferences when global preferences key has value.
Added test dependency to be able to introduce test 