### PR TITLE
[DROOLS-4083] After asset renaming, column width is automatically changed

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
@@ -288,7 +288,6 @@ public abstract class BaseEditor<T, M> {
 
     protected Command getBeforeSaveAndRenameCommand() {
         return () -> {
-
         };
     }
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
@@ -282,7 +282,14 @@ public abstract class BaseEditor<T, M> {
                 .addContentSupplier(getContentSupplier())
                 .addIsDirtySupplier(isDirtySupplier())
                 .addSuccessCallback(onSuccess())
+                .addBeforeSaveAndRenameCommand(getBeforeSaveAndRenameCommand())
                 .build();
+    }
+
+    protected Command getBeforeSaveAndRenameCommand() {
+        return () -> {
+
+        };
     }
 
     protected Supplier<Boolean> getSaveValidator() {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/BaseEditor.java
@@ -285,7 +285,7 @@ public abstract class BaseEditor<T, M> {
                 .build();
     }
 
-    Supplier<Boolean> getSaveValidator() {
+    protected Supplier<Boolean> getSaveValidator() {
 
         return () -> {
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
@@ -62,6 +62,8 @@ public class SaveAndRenameCommandBuilder<T, M> {
     };
     private Command onError = () -> {
     };
+    private Command beforeSaveAndRenameCommand = () -> {
+    };
 
     @Inject
     public SaveAndRenameCommandBuilder(final RenamePopUpPresenter renamePopUpPresenter,
@@ -120,6 +122,11 @@ public class SaveAndRenameCommandBuilder<T, M> {
         return this;
     }
 
+    public SaveAndRenameCommandBuilder<T, M> addBeforeSaveAndRenameCommand(final Command beforeSaveAndRenameCommand) {
+        this.beforeSaveAndRenameCommand = beforeSaveAndRenameCommand;
+        return this;
+    }
+
     public Command build() {
 
         checkNotNull("pathSupplier", pathSupplier);
@@ -158,6 +165,8 @@ public class SaveAndRenameCommandBuilder<T, M> {
 
         final String newFileName = details.getNewFileName();
         final String commitMessage = details.getCommitMessage();
+
+        beforeSaveAndRenameCommand.execute();
 
         renameCaller.call(onSuccess(), onError()).saveAndRename(getPath(),
                                                                 newFileName,

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
@@ -147,21 +147,21 @@ public class SaveAndRenameCommandBuilder<T, M> {
         };
     }
 
-    CommandWithFileNameAndCommitMessage makeSaveAndRenameCommand() {
+    protected CommandWithFileNameAndCommitMessage makeSaveAndRenameCommand() {
         return (details) -> {
             showBusyIndicator();
             callSaveAndRename(details);
         };
     }
 
-    CommandWithFileNameAndCommitMessage makeRenameCommand() {
+    protected CommandWithFileNameAndCommitMessage makeRenameCommand() {
         return (details) -> {
             showBusyIndicator();
             callRename(details);
         };
     }
 
-    void callSaveAndRename(final FileNameAndCommitMessage details) {
+    protected void callSaveAndRename(final FileNameAndCommitMessage details) {
 
         final String newFileName = details.getNewFileName();
         final String commitMessage = details.getCommitMessage();
@@ -175,7 +175,7 @@ public class SaveAndRenameCommandBuilder<T, M> {
                                                                 commitMessage);
     }
 
-    void callRename(final FileNameAndCommitMessage details) {
+    protected void callRename(final FileNameAndCommitMessage details) {
 
         final String newFileName = details.getNewFileName();
         final String commitMessage = details.getCommitMessage();
@@ -185,7 +185,7 @@ public class SaveAndRenameCommandBuilder<T, M> {
                                                          commitMessage);
     }
 
-    RemoteCallback<Path> onSuccess() {
+    protected RemoteCallback<Path> onSuccess() {
         return (Path path) -> {
             notifyRenameInProgress();
             onSuccess.execute(path);

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/SaveAndRenameCommandBuilder.java
@@ -185,7 +185,7 @@ public class SaveAndRenameCommandBuilder<T, M> {
                                                          commitMessage);
     }
 
-    protected RemoteCallback<Path> onSuccess() {
+    RemoteCallback<Path> onSuccess() {
         return (Path path) -> {
             notifyRenameInProgress();
             onSuccess.execute(path);

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/BaseEditorTest.java
@@ -111,6 +111,8 @@ public class BaseEditorTest {
         final Supplier isDirtySupplier = mock(Supplier.class);
         final ParameterizedCommand parameterizedCommand = mock(ParameterizedCommand.class);
         final Command command = mock(Command.class);
+        final Command beforeSaveCommand = mock(Command.class);
+
 
         doReturn(pathSupplier).when(editor).getPathSupplier();
         doReturn(renameValidator).when(editor).getRenameValidator();
@@ -120,6 +122,7 @@ public class BaseEditorTest {
         doReturn(contentSupplier).when(editor).getContentSupplier();
         doReturn(isDirtySupplier).when(editor).isDirtySupplier();
         doReturn(parameterizedCommand).when(editor).onSuccess();
+        doReturn(beforeSaveCommand).when(editor).getBeforeSaveAndRenameCommand();
         doReturn(command).when(builder).build();
 
         final Command saveAndRenameCommand = editor.getSaveAndRename();
@@ -134,6 +137,7 @@ public class BaseEditorTest {
         verify(builder).addContentSupplier(contentSupplier);
         verify(builder).addIsDirtySupplier(isDirtySupplier);
         verify(builder).addSuccessCallback(parameterizedCommand);
+        verify(builder).addBeforeSaveAndRenameCommand(beforeSaveCommand);
     }
 
     @Test

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/PerspectiveEditorPresenterTest.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/PerspectiveEditorPresenterTest.java
@@ -56,6 +56,7 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.promise.SyncPromises;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -251,6 +252,7 @@ public class PerspectiveEditorPresenterTest {
         when(saveAndRenameCommandBuilder.addContentSupplier(any())).thenReturn(saveAndRenameCommandBuilder);
         when(saveAndRenameCommandBuilder.addIsDirtySupplier(any())).thenReturn(saveAndRenameCommandBuilder);
         when(saveAndRenameCommandBuilder.addSuccessCallback(any())).thenReturn(saveAndRenameCommandBuilder);
+        when(saveAndRenameCommandBuilder.addBeforeSaveAndRenameCommand(isA(Command.class))).thenReturn(saveAndRenameCommandBuilder);
         when(saveAndRenameCommandBuilder.build()).thenReturn(() -> {
         });
     }


### PR DESCRIPTION
To resolve the issue, I changed the `SaveAndRenameCommandBuilder` to launch a command BEFORE the saveAndRename call is invoked. In this way, it's possibile to add a command witch synchronizes the columns widths from front-end model to back-end model.

@jomarko @gitgabrio @danielezonca

Related PR: https://github.com/kiegroup/drools-wb/pull/1227