### PR TITLE
AF-2215: Avoid losing scroll position when editor changes

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -42,6 +42,7 @@ import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
 import org.uberfire.ext.layout.editor.client.infra.ContainerResizeEvent;
 import org.uberfire.ext.layout.editor.client.infra.DragComponentEndEvent;
 import org.uberfire.ext.layout.editor.client.infra.DragHelperComponentColumn;
+import org.uberfire.ext.layout.editor.client.infra.LayoutEditorFocusController;
 import org.uberfire.ext.layout.editor.client.resources.i18n.CommonConstants;
 import org.uberfire.ext.layout.editor.client.widgets.KebabWidget;
 import org.uberfire.ext.properties.editor.model.PropertyEditorCategory;
@@ -95,6 +96,8 @@ public class ComponentColumnView
     @Inject
     private Document document;
     private ColumnDrop.Orientation contentDropOrientation;
+    @Inject
+    LayoutEditorFocusController layoutEditorFocusController;
 
     @Inject
     private DragHelperComponentColumn helper;
@@ -534,6 +537,7 @@ public class ComponentColumnView
             HTMLElement previewWidget = getPreviewElement();
             content.appendChild(kebabWidget.getElement());
             content.appendChild(previewWidget);
+            layoutEditorFocusController.restoreFocus();
         });
     }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -73,6 +73,8 @@ public class Container implements LayoutEditorElement {
     private DnDManager dndManager;
     private boolean selectable = false;
     private boolean selected = false;
+    
+    LayoutEditorFocusController layoutEditorFocusController;
 
     @Inject
     public Container(final View view,
@@ -82,7 +84,8 @@ public class Container implements LayoutEditorElement {
                      Event<ComponentDropEvent> componentDropEvent,
                      Event<LayoutEditorElementSelectEvent> containerSelectEvent,
                      Event<LayoutEditorElementUnselectEvent> containerUnselectEvent,
-                     DnDManager dndManager) {
+                     DnDManager dndManager,
+                     LayoutEditorFocusController layoutEditorFocusController) {
         this.layoutCssHelper = layoutCssHelper;
         this.rowInstance = rowInstance;
         this.emptyDropRowInstance = emptyDropRowInstance;
@@ -91,6 +94,7 @@ public class Container implements LayoutEditorElement {
         this.containerSelectEvent = containerSelectEvent;
         this.containerUnselectEvent = containerUnselectEvent;
         this.dndManager = dndManager;
+        this.layoutEditorFocusController = layoutEditorFocusController;
         this.id = idGenerator.createContainerID();
     }
 
@@ -199,6 +203,7 @@ public class Container implements LayoutEditorElement {
         }
         setupResizeRows();
         setupCssProperties();
+        layoutEditorFocusController.setTargetContainerView(view);
     }
 
     public void reset() {
@@ -525,6 +530,7 @@ public class Container implements LayoutEditorElement {
     }
 
     void updateView() {
+        layoutEditorFocusController.recordFocus();
         cleanupEmptyRows();
         setupPageStyle();
         setupResizeRows();
@@ -686,7 +692,7 @@ public class Container implements LayoutEditorElement {
             }
         }
     }
-
+    
     public List<Row> getChildElements() {
         return rows;
     }
@@ -707,4 +713,5 @@ public class Container implements LayoutEditorElement {
 
         void applyCssValues(List<CssValue> cssValues);
     }
+
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
@@ -89,6 +89,8 @@ public class Row implements LayoutEditorElement {
     private Integer height;
     private boolean canResizeUp;
     private boolean canResizeDown;
+    
+    LayoutEditorFocusController layoutEditorFocusController;
 
     @Inject
     public Row(View view,
@@ -101,7 +103,8 @@ public class Row implements LayoutEditorElement {
                Event<ComponentRemovedEvent> componentRemovedEvent,
                Event<RowResizeEvent> rowResizeEvent,
                Event<LayoutEditorElementSelectEvent> rowSelectEvent,
-               Event<LayoutEditorElementUnselectEvent> rowUnselectEvent) {
+               Event<LayoutEditorElementUnselectEvent> rowUnselectEvent,
+               LayoutEditorFocusController layoutEditorFocusController) {
 
         this.view = view;
         this.columnInstance = columnInstance;
@@ -114,6 +117,7 @@ public class Row implements LayoutEditorElement {
         this.rowResizeEvent = rowResizeEvent;
         this.rowSelectEvent = rowSelectEvent;
         this.rowUnselectEvent = rowUnselectEvent;
+        this.layoutEditorFocusController = layoutEditorFocusController;
     }
 
     public void init(ParameterizedCommand<RowDrop> dropOnRowCommand,
@@ -851,6 +855,7 @@ public class Row implements LayoutEditorElement {
     }
 
     public void updateView() {
+        layoutEditorFocusController.recordFocus();
         view.clear();
         setupColumnResizeActions();
         for (Column column : columns) {
@@ -1104,4 +1109,5 @@ public class Row implements LayoutEditorElement {
 
         void applyCssValues(List<CssValue> cssValues);
     }
+
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/LayoutEditorFocusController.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/LayoutEditorFocusController.java
@@ -1,0 +1,92 @@
+package org.uberfire.ext.layout.editor.client.infra;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.uberfire.ext.layout.editor.client.components.container.Container;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Overflow;
+
+import elemental2.dom.HTMLElement;
+import jsinterop.base.Js;
+
+@ApplicationScoped
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class LayoutEditorFocusController {
+
+    private HTMLElement scrollElement;
+    private boolean dirty = false;
+    private double recordedScrollLeft;
+    private double recordedScrollTop;
+    
+
+    public void setTargetContainerView(Container.View view) {
+        HTMLElement element = Js.cast(view.getElement());
+        Scheduler.get().scheduleDeferred(() -> {
+            scrollElement = findScrollableParent(element);
+        });
+    }
+
+    public void recordFocus() {
+        if (scrollElement != null && !dirty) {
+            recordedScrollLeft = scrollElement.scrollLeft;
+            recordedScrollTop = scrollElement.scrollTop;
+            dirty = true;
+        }
+    }
+    
+    public void restoreFocus() {
+        if (scrollElement != null) {
+            scrollElement.scrollLeft = recordedScrollLeft;
+            scrollElement.scrollTop = recordedScrollTop;
+        }
+        dirty = false;
+    }
+    
+    public boolean isDirty() {
+        return dirty;
+    }
+    
+    protected HTMLElement findScrollableParent(HTMLElement element) {
+        HTMLElement scrollElement = null;
+        while (element != null) {
+            if (isScrollable(element)) {
+                scrollElement = element;
+                break;
+            }
+            else if (element.parentNode instanceof HTMLElement) {
+                element = Js.cast(element.parentNode);
+            } else {
+                break;
+            }
+        }
+        return scrollElement;
+    }
+
+    protected void setScrollableElement(HTMLElement element) {
+        this.scrollElement = element;
+    }
+
+    private boolean isScrollable(HTMLElement element) {
+        return "auto".equals(element.style.overflow);
+    }
+    
+    
+    
+}

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/LayoutEditorFocusController.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/LayoutEditorFocusController.java
@@ -1,17 +1,3 @@
-package org.uberfire.ext.layout.editor.client.infra;
-
-import javax.enterprise.context.ApplicationScoped;
-
-import org.uberfire.ext.layout.editor.client.components.container.Container;
-
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.dom.client.Style.Overflow;
-
-import elemental2.dom.HTMLElement;
-import jsinterop.base.Js;
-
-@ApplicationScoped
 /*
  * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
@@ -28,6 +14,20 @@ import jsinterop.base.Js;
  * limitations under the License.
  */
 
+package org.uberfire.ext.layout.editor.client.infra;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.uberfire.ext.layout.editor.client.components.container.Container;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Overflow;
+
+import elemental2.dom.HTMLElement;
+import jsinterop.base.Js;
+
+@ApplicationScoped
 public class LayoutEditorFocusController {
 
     private HTMLElement scrollElement;

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
@@ -99,6 +99,8 @@ public abstract class AbstractLayoutEditorTest {
     protected EventSourceMock<LayoutEditorElementSelectEvent> columnSelectedEvent;
     @Mock
     protected EventSourceMock<LayoutEditorElementUnselectEvent> columnUnselectedEvent;
+    @Mock
+    protected LayoutEditorFocusController layoutEditorFocusController;
 
     protected EmptyDropRow emptyDropRow = new EmptyDropRow(mock(EmptyDropRow.View.class),
             dragHelper);
@@ -116,7 +118,8 @@ public abstract class AbstractLayoutEditorTest {
                              componentDropEventMock,
                              layoutElementSelectEventMock,
                              layoutElementUnselectEventMock,
-                             dnDManager) {
+                             dnDManager,
+                             layoutEditorFocusController) {
             private UniqueIDGenerator idGenerator = new UniqueIDGenerator();
 
             @Override
@@ -150,7 +153,8 @@ public abstract class AbstractLayoutEditorTest {
                        componentRemoveEventMock,
                        null,
                        rowSelectedEvent,
-                       rowUnselectedEvent) {
+                       rowUnselectedEvent,
+                       layoutEditorFocusController) {
             private UniqueIDGenerator idGenerator = new UniqueIDGenerator();
 
             @Override

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/infra/LayoutEditorFocusControllerTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/infra/LayoutEditorFocusControllerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.layout.editor.client.infra;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import elemental2.dom.CSSStyleDeclaration;
+import elemental2.dom.HTMLElement;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LayoutEditorFocusControllerTest {
+    
+    LayoutEditorFocusController controller = new LayoutEditorFocusController();
+
+    @Test
+    public void noScrollableParentTest() {
+        HTMLElement element = mock(HTMLElement.class);
+        element.style = mock(CSSStyleDeclaration.class);
+        
+        HTMLElement foundScrollParent = controller.findScrollableParent(element);
+        assertNull(foundScrollParent);
+    }
+    
+    @Test
+    public void withScrollableParentTest() {
+        HTMLElement scrollParent = mock(HTMLElement.class);
+        HTMLElement element = mock(HTMLElement.class);
+        CSSStyleDeclaration style = mock(CSSStyleDeclaration.class);
+        
+        style.overflow = "auto";
+        scrollParent.style = style;
+        element.parentNode = scrollParent;
+        element.style = mock(CSSStyleDeclaration.class);
+        
+        HTMLElement foundScrollParent = controller.findScrollableParent(element);
+        assertEquals(scrollParent, foundScrollParent);
+    }
+    
+    @Test
+    public void scrollRecoveryTest() {
+        final int initialScrollLeft = -1;
+        final int initialScrollTop = -5;
+        HTMLElement element = mock(HTMLElement.class);
+        
+        controller.setScrollableElement(element);
+        element.scrollLeft = initialScrollLeft;
+        element.scrollTop = initialScrollTop;
+        
+        controller.recordFocus();
+        assertTrue(controller.isDirty());
+        
+        element.scrollLeft = 0;
+        element.scrollTop = 0;
+
+        controller.restoreFocus();
+        assertFalse(controller.isDirty());
+        assertEquals(initialScrollLeft, element.scrollLeft, 0.001);
+        assertEquals(initialScrollTop, element.scrollTop, 0.001);
+    }
+    
+}


### PR DESCRIPTION
This solution for AF-2215 records the scroll position and restore it after the layout editor draw all layout elements.

This should be tested with Form Editor and Page Layout Editor.