### PR TITLE
BXMSPROD-525 remove version.org.kie property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
 
   <properties>
     <uberfire.version>${project.version}</uberfire.version>
-    <version.org.kie>7.27.0-SNAPSHOT</version.org.kie>
     <version.org.kie.soup>${version.org.kie}</version.org.kie.soup>
     <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>


### PR DESCRIPTION
https://issues.jboss.org/browse/BXMSPROD-525

the version `version.org.kie` property is duplicated what we have in kie-parent, so it is now useless https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/pom.xml#L343