### PR TITLE
[AF-2214] User confirmation when closing the workbench with unsaved stuff

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
@@ -182,6 +182,11 @@ public class MockPlaceManager implements PlaceManager {
     }
 
     @Override
+    public boolean canCloseAllPlaces() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
     public List<PlaceRequest> getUncloseablePlaces() {
         throw new UnsupportedOperationException("Not implemented.");
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
@@ -186,6 +186,8 @@ public interface PlaceManager {
 
     boolean canClosePlace(PlaceRequest place);
 
+    boolean canCloseAllPlaces();
+
     /**
      * @return All opened PlaceRequests that cannot be closed (@onMayClose method returns false).
      */

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -1198,6 +1198,11 @@ public class PlaceManagerImpl implements PlaceManager {
         return false;
     }
 
+    @Override
+    public boolean canCloseAllPlaces() {
+        return getUncloseablePlaces().isEmpty();
+    }
+
     @SuppressWarnings("unused")
     private void onWorkbenchPartOnFocus(@Observes PlaceGainFocusEvent event) {
         final PlaceRequest place = event.getPlace();

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PluginPlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PluginPlaceManagerImpl.java
@@ -231,6 +231,12 @@ public class PluginPlaceManagerImpl implements PlaceManager {
     }
 
     @Override
+    public boolean canCloseAllPlaces() {
+        fail();
+        return false;
+    }
+
+    @Override
     public List<PlaceRequest> getUncloseablePlaces() {
         fail();
         return null;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/WorkbenchConstants.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/WorkbenchConstants.java
@@ -55,4 +55,6 @@ public interface WorkbenchConstants
     String switchToDefaultView();
 
     String switchToCompactView();
+
+    String closingWindowMessage();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -46,6 +47,7 @@ import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.resources.WorkbenchResources;
+import org.uberfire.client.resources.i18n.WorkbenchConstants;
 import org.uberfire.client.workbench.events.ApplicationReadyEvent;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
@@ -232,7 +234,18 @@ public class Workbench {
         }
 
         // Ensure orderly shutdown when Window is closed (eg. saves workbench state)
-        Window.addWindowClosingHandler(event -> workbenchCloseHandler.onWindowClose(workbenchCloseCommand));
+        Window.addCloseHandler(event -> workbenchCloseHandler.onWindowClose(workbenchCloseCommand));
+
+        Window.addWindowClosingHandler(event -> {
+            if (!placeManager.canCloseAllPlaces()) {
+                // Setting a non-null message will make the browser to present a confirmation dialog that asks the user
+                // whether or not they wish to navigate away from the page. The message in the dialog, however,
+                // is not customizable anymore mainly due to scammers using such a message to trick people.
+                // Thus, each browser shows its own message. If the user has an outdated browser, then our custom
+                // message might be shown.
+                event.setMessage(WorkbenchConstants.INSTANCE.closingWindowMessage());
+            }
+        });
 
         // Resizing the Window should resize everything
         Window.addResizeHandler(event -> layout.resizeTo(event.getWidth(),

--- a/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/i18n/WorkbenchConstants.properties
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/i18n/WorkbenchConstants.properties
@@ -28,3 +28,4 @@ lockedMessage=This asset is currently being edited by {0}. Once they commit thei
 splashScreenNoneAvailable=-- None --
 switchToDefaultView=Switch to Default View
 switchToCompactView=Switch to Compact View
+closingWindowMessage=You have unsaved changes in the Workbench, and they will be lost if you proceed. This action cannot be undone. Do you want to proceed anyway?


### PR DESCRIPTION
JIRA task: [AF-2214](https://issues.jboss.org/browse/AF-2214)

If the user has unsaved changes and closes the browser, then they lost all changes without being warned about. Thus, as a last resort, in this PR the browser will ask the user for confirmation when closing the tab, closing the browser or refreshing the page.

**DEMO**
![AF-2214-2019-09-10](https://user-images.githubusercontent.com/638737/65062814-41257e80-d953-11e9-8502-f4b1c53fbbb8.gif)

