### PR TITLE
[AF-2232] IllegalStateException when logging out from BC

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -1131,6 +1131,8 @@ public class PlaceManagerImpl implements PlaceManager {
                 } else {
                     return;
                 }
+            } else {
+                activity.onClose();
             }
 
             getPlaceHistoryHandler().registerClose(activity,

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
@@ -423,6 +423,16 @@ public class PlaceManagerTest {
     }
 
     @Test
+    public void testClosePlaceAlwaysCloseActivityBeforeDestroy() {
+        when(kansasActivity.isType(any())).thenReturn(false);
+
+        placeManager.closePlace(kansas);
+
+        verify(kansasActivity).onClose();
+        verify(activityManager).destroyActivity(kansasActivity);
+    }
+
+    @Test
     public void testCanceledCloseExistingScreenActivity() throws Exception {
         when(kansasActivity.onMayClose()).thenReturn(false);
         when(kansasActivity.isType(ActivityResourceType.SCREEN.name())).thenReturn(true);

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
@@ -428,8 +428,9 @@ public class PlaceManagerTest {
 
         placeManager.closePlace(kansas);
 
-        verify(kansasActivity).onClose();
-        verify(activityManager).destroyActivity(kansasActivity);
+        InOrder inOrder = inOrder(activityManager, kansasActivity);
+        inOrder.verify(kansasActivity).onClose();
+        inOrder.verify(activityManager).destroyActivity(kansasActivity);
     }
 
     @Test


### PR DESCRIPTION
**[AF-2232](https://issues.jboss.org/browse/AF-2232) IllegalStateException when logging out from BC**

**Issue:**
* Some activities are not `closed` before calling `destroy` in shutdown (logout) operation

**Solution:**
* Always call `close` before `destroy`