### PR TITLE
[AF-2058] Provide alternative implementation of uberfire-nio2-impls backed by OCP/K8S

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-api/src/main/java/org/uberfire/java/nio/file/api/FileSystemProviders.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/main/java/org/uberfire/java/nio/file/api/FileSystemProviders.java
@@ -77,7 +77,7 @@ public final class FileSystemProviders {
         final Map<String, FileSystemProvider> result = new HashMap<String, FileSystemProvider>(installedProviders.size() + 1);
         for (int i = 0; i < installedProviders.size(); i++) {
             final FileSystemProvider provider = installedProviders.get(i);
-            if (i == 0) {
+            if (i == 0 || FileSystemUtils.isK8SFileSystemProviderAsDefault(provider)) {
                 provider.forceAsDefault();
                 result.put("default",
                            provider);

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/main/java/org/uberfire/java/nio/file/api/FileSystemUtils.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/main/java/org/uberfire/java/nio/file/api/FileSystemUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.file.api;
+
+import java.util.Properties;
+
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+
+public class FileSystemUtils {
+
+    public static final String CFG_KIE_CONTROLLER_OCP_ENABLED = "org.kie.workbench.controller.openshift.enabled";
+    public static final String K8S_FS_SCHEME = "k8s";
+
+    private static ThreadLocal<Properties> configProps = ThreadLocal.withInitial(System::getProperties);
+
+    private FileSystemUtils() {}
+
+    public static Properties getConfigProps() {
+        return configProps.get();
+    }
+
+    public static boolean isOpenShiftSupported() {
+        return "true".equals(getConfigProps().getProperty(CFG_KIE_CONTROLLER_OCP_ENABLED, "false"));
+    }
+
+    public static boolean isK8SFileSystemProviderAsDefault(FileSystemProvider provider) {
+        return isOpenShiftSupported() && K8S_FS_SCHEME.equals(provider.getScheme());
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/pom.xml
@@ -31,5 +31,6 @@
   <modules>
     <module>uberfire-nio2-fs</module>
     <module>uberfire-nio2-jgit</module>
+    <module>uberfire-nio2-k8s</module>
   </modules>
 </project>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/main/java/org/uberfire/java/nio/fs/file/SimpleUnixFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/main/java/org/uberfire/java/nio/fs/file/SimpleUnixFileSystem.java
@@ -19,18 +19,28 @@ package org.uberfire.java.nio.fs.file;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.uberfire.java.nio.base.GeneralPathImpl;
 import org.uberfire.java.nio.file.FileStore;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 
 public class SimpleUnixFileSystem extends BaseSimpleFileSystem {
 
-    final FileStore fileStore = new SimpleUnixFileStore(null);
+    protected FileStore fileStore;
 
-    SimpleUnixFileSystem(final FileSystemProvider provider,
+    protected SimpleUnixFileSystem(final FileSystemProvider provider,
                          final String path) {
-        super(provider,
-              path);
+        super(provider,path);
+        fileStore = new SimpleUnixFileStore(null);
+    }
+
+    @Override
+    public Path getPath(String first, String... more) {
+        if (UNIX_SEPARATOR_STRING.equals(first) && (more == null || more.length == 0)) {
+            return GeneralPathImpl.createRoot(this, UNIX_SEPARATOR_STRING, false);
+        } else {
+            return super.getPath(first, more);
+        }
     }
 
     @Override

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/pom.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.uberfire</groupId>
+    <artifactId>uberfire-nio2-impls</artifactId>
+    <version>7.32.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>uberfire-nio2-k8s</artifactId>
+  <packaging>jar</packaging>
+
+  <name>UberFire NIO.2 :: K8S Impl</name>
+  <description>UberFire NIO.2 :: K8S Impl</description>
+
+  <properties>
+    <!-- Skip integration tests by default, they are enabled in openshift profile as the tests need connection to external OpenShift instance. -->
+    <skipITs>true</skipITs>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-fs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    
+    <!-- fabric8 kubernetes and openshift java client dependencies -->
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-server-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- log -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <environmentVariables>
+            <KUBERNETES_SERVICE_HOST>127.0.0.1</KUBERNETES_SERVICE_HOST>
+            <KUBERNETES_SERVICE_PORT>8443</KUBERNETES_SERVICE_PORT>
+            <KUBERNETES_MASTER />
+            <KUBERNETES_API_VERSION />
+            <KUBERNETES_TRUST_CERTIFICATES />
+            <KUBERNETES_CERTS_CA_FILE />
+            <KUBERNETES_CERTS_CA_DATA />
+            <KUBERNETES_CERTS_CLIENT_FILE />
+            <KUBERNETES_CERTS_CLIENT_DATA />
+            <KUBERNETES_CERTS_CLIENT_KEY_FILE />
+            <KUBERNETES_CERTS_CLIENT_KEY_DATA />
+            <KUBERNETES_CERTS_CLIENT_KEY_ALGO />
+            <KUBERNETES_CERTS_CLIENT_KEY_PASSPHRASE />
+            <KUBERNETES_AUTH_BASIC_USERNAME />
+            <KUBERNETES_AUTH_BASIC_PASSWORD />
+            <KUBERNETES_AUTH_TRYKUBECONFIG />
+            <KUBERNETES_AUTH_TRYSERVICEACCOUNT />
+            <KUBERNETES_AUTH_TOKEN />
+            <KUBERNETES_WATCH_RECONNECTINTERVAL />
+            <KUBERNETES_WATCH_RECONNECTLIMIT />
+            <KUBERNETES_REQUEST_TIMEOUT />
+            <KUBERNETES_NAMESPACE />
+            <KUBERNETES_TLS_VERSIONS>TLSv1.2,TLSv1.1,TLSv1</KUBERNETES_TLS_VERSIONS>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>openshift</id>
+      <properties>
+        <skipITs>false</skipITs>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemProperties>
+                <!-- Properties for connection to external OpenShift for integration tests. -->
+                <kubernetes.master>${kubernetes.master}</kubernetes.master>
+                <kubernetes.auth.token>${kubernetes.auth.token}</kubernetes.auth.token>
+              </systemProperties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/cloud/CloudClientConstants.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/cloud/CloudClientConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.uberfire.java.nio.fs.cloud;
+
+import java.nio.charset.StandardCharsets;
+
+public class CloudClientConstants {
+    public static final String DEFAULT_TOKEN_LOCATION = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+    public static final String ENV_VAR_API_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
+    public static final String ENV_VAR_API_SERVER_PORT = "KUBERNETES_SERVICE_PORT";
+    public static final String ENCODING = System.getProperty("file.encoding", StandardCharsets.UTF_8.name());
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/cloud/CloudClientFactory.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/cloud/CloudClientFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.uberfire.java.nio.fs.cloud;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.IOException;
+
+public interface CloudClientFactory {
+
+    default OpenShiftClient createOpenShiftClient() {
+        return new DefaultOpenShiftClient(setupConfig());
+    }
+
+    default KubernetesClient createKubernetesClient() {
+        return new DefaultKubernetesClient(setupConfig());
+    }
+
+    default Config setupConfig() {
+        final Logger logger = LoggerFactory.getLogger(CloudClientFactory.class);
+        String masterUrl = System.getProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY);
+        String token = System.getProperty(Config.KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY);
+
+        if (masterUrl == null) {
+            masterUrl = new StringBuilder("https://")
+                    .append(System.getenv(CloudClientConstants.ENV_VAR_API_SERVICE_HOST))
+                    .append(":")
+                    .append(System.getenv(CloudClientConstants.ENV_VAR_API_SERVER_PORT))
+                    .toString();
+            System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, masterUrl);
+            logger.debug("MasterUrl: {}", masterUrl);
+        }
+        
+        if (token == null || token.length() == 0) {
+            try {
+                token = new String(Files.readAllBytes(Paths.get(CloudClientConstants.DEFAULT_TOKEN_LOCATION)));
+            } catch (Exception e) {
+                logger.error("Load kubenetes oauth token failed.", e);
+            }
+            if (token == null) {
+                throw new IllegalStateException("Kubenetes oauth token missing");
+            } else {
+                System.setProperty(Config.KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY, token);
+                logger.debug("Token: [{}]", token);
+            }
+        }
+
+        return new ConfigBuilder().withMasterUrl(masterUrl).withOauthToken(token).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    default <T extends KubernetesClient, R> Optional<R> executeCloudFunction(Function<T, R> func, Class<T> type) {
+        R result = null;
+        try (T client = (T) (type == OpenShiftClient.class ? createOpenShiftClient() : createKubernetesClient())) {
+            result = func.apply(client);
+        } catch (UnsupportedOperationException uoe) {
+            throw uoe;
+        } catch (IllegalStateException ise) {
+            throw ise;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+        return Optional.ofNullable(result);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SBasicFileAttributeView.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SBasicFileAttributeView.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.base.BasicFileAttributesImpl;
+import org.uberfire.java.nio.base.FileTimeImpl;
+import org.uberfire.java.nio.base.LazyAttrLoader;
+import org.uberfire.java.nio.file.NoSuchFileException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
+import org.uberfire.java.nio.fs.cloud.CloudClientFactory;
+import org.uberfire.java.nio.fs.file.SimpleBasicFileAttributeView;
+
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_NO_IMPL;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjCM;
+
+public class K8SBasicFileAttributeView extends SimpleBasicFileAttributeView {
+    
+    private static final Logger logger = LoggerFactory.getLogger(K8SBasicFileAttributeView.class);
+
+    private BasicFileAttributes attrs = null;
+    private final CloudClientFactory ccf;
+
+    public K8SBasicFileAttributeView(final Path path, final CloudClientFactory ccf) {
+        super(path);
+        this.ccf = ccf;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T extends BasicFileAttributes> T readAttributes() {
+        if (attrs == null) {
+            final ConfigMap fileCM = ccf.executeCloudFunction(client -> getFsObjCM(client, path),
+                                                              KubernetesClient.class)
+                                        .orElseThrow(() -> new NoSuchFileException(path.toRealPath().toString()));
+
+            this.attrs = new BasicFileAttributesImpl(path.toString(),
+                                                     new FileTimeImpl(K8SFileSystemUtils.getLastModifiedTime(fileCM)),
+                                                     new FileTimeImpl(K8SFileSystemUtils.getCreationTime(fileCM)),
+                                                     null,
+                                                     new LazyAttrLoader<Long>() {
+                                                        private Long size = null;
+                                                         @Override
+                                                         public Long get() {
+                                                             if (size == null) {
+                                                                 size = K8SFileSystemUtils.getSize(fileCM);
+                                                             }
+                                                             return size;
+                                                         }
+                                                     },
+                                                     K8SFileSystemUtils.isFile(fileCM),
+                                                     K8SFileSystemUtils.isDirectory(fileCM));
+        }
+        return (T) attrs;
+    }
+
+    @Override
+    public void setAttribute(String attribute, Object value) {
+        logger.debug(K8S_FS_NO_IMPL);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<? extends BasicFileAttributeView>[] viewTypes() {
+        return new Class[]{BasicFileAttributeView.class, K8SBasicFileAttributeView.class};
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileChannel.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileChannel.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.util.Collections;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.fs.cloud.CloudClientFactory;
+
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_FSOBJ_CONTENT_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_MAX_CAPACITY_PROPERTY_NAME;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.createOrReplaceFSCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.createOrReplaceParentDirFSCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjCM;
+
+public class K8SFileChannel extends SeekableInMemoryByteChannel {
+    private static final int CAPACITY = Integer.parseInt(System.getProperty(K8S_FS_MAX_CAPACITY_PROPERTY_NAME, 
+                                                                            String.valueOf(100 * 1024)));  
+    private final CloudClientFactory ccf;
+    private final Path file;
+
+    public K8SFileChannel(Path file, CloudClientFactory ccf) {
+        super(CAPACITY);
+        this.file = file;
+        this.ccf = ccf;
+        // Constructor is not necessarily Thread-Safe as per JLS (Java Language Specification)
+        synchronized(this) {
+            this.contents = ccf.executeCloudFunction(client -> getFsObjCM(client, file), KubernetesClient.class)
+                               .filter(K8SFileSystemUtils::isFile)
+                               .map(K8SFileSystemUtils::getFsObjContentBytes)
+                               .orElse(new byte[0]);
+        }
+    }
+
+    @Override
+    public void close() {
+        ccf.executeCloudFunction(client -> createOrReplaceFSCM(client, 
+                                                               file,
+                                                               createOrReplaceParentDirFSCM(client, file, size(), false),
+                                                               Collections.singletonMap(CFG_MAP_FSOBJ_CONTENT_KEY, 
+                                                                                        super.toString()),
+                                                               false), 
+                                 KubernetesClient.class);
+        super.close();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileStore.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,36 +14,29 @@
  * limitations under the License.
  */
 
-package org.uberfire.java.nio.fs.file;
+package org.uberfire.java.nio.fs.k8s;
 
-import java.io.File;
-
-import org.uberfire.java.nio.IOException;
 import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.fs.file.SimpleUnixFileStore;
 
-public class SimpleUnixFileStore extends BaseSimpleFileStore {
+public class K8SFileStore extends SimpleUnixFileStore {
 
-    protected SimpleUnixFileStore(final Path path) {
+    K8SFileStore(final Path path) {
         super(path);
     }
 
     @Override
-    public String name() {
-        return "/";
+    public long getTotalSpace() {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public long getTotalSpace() throws IOException {
-        return File.listRoots()[0].getTotalSpace();
+    public long getUsableSpace() {
+        throw new UnsupportedOperationException();
     }
 
     @Override
-    public long getUsableSpace() throws IOException {
-        return File.listRoots()[0].getUsableSpace();
-    }
-
-    @Override
-    public long getUnallocatedSpace() throws IOException {
+    public long getUnallocatedSpace() {
         throw new UnsupportedOperationException();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystem.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.file.LockableFileSystem;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+import org.uberfire.java.nio.fs.file.SimpleUnixFileSystem;
+
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_NO_IMPL;
+
+public class K8SFileSystem extends SimpleUnixFileSystem implements LockableFileSystem {
+
+    private static final Logger logger = LoggerFactory.getLogger(K8SFileSystem.class);
+
+    K8SFileSystem(final FileSystemProvider provider, final String path) {
+        super(provider, path);
+        fileStore = new K8SFileStore(null);
+    }
+
+    @Override
+    public WatchService newWatchService() {
+        return new K8SWatchService(this);
+    }
+
+    @Override
+    public void lock() {
+        logger.debug(K8S_FS_NO_IMPL);
+    }
+
+    @Override
+    public void unlock() {
+        logger.debug(K8S_FS_NO_IMPL);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemConstants.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemConstants.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.util.regex.Pattern;
+
+public class K8SFileSystemConstants {
+    public static final String CFG_MAP_LABEL_FSOBJ_TYPE_KEY = "k8s.fs.nio.java.uberfire.org/fsobj-type";
+    public static final String CFG_MAP_LABEL_FSOBJ_APP_KEY = "k8s.fs.nio.java.uberfire.org/fsobj-app";
+    public static final String CFG_MAP_LABEL_FSOBJ_NAME_KEY_PREFIX = "k8s.fs.nio.java.uberfire.org/fsobj-name-";
+    public static final String CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY = "k8s.fs.nio.java.uberfire.org/fsobj-size";
+    public static final String CFG_MAP_ANNOTATION_FSOBJ_LAST_MODIFIED_TIMESTAMP_KEY = "k8s.fs.nio.java.uberfire.org/fsobj-lastModifiedTimestamp";
+    public static final String CFG_MAP_FSOBJ_NAME_PREFIX = "k8s-fsobj-";
+    public static final String CFG_MAP_FSOBJ_CONTENT_KEY = "fsobj-content";
+
+    public static final String K8S_FS_MAX_CAPACITY_PROPERTY_NAME = "org.uberfire.java.nio.fs.k8s.max.file.size";
+    public static final String K8S_FS_APP_PROPERTY_NAME = "org.uberfire.java.nio.fs.k8s.app";
+    public static final String K8S_FS_APP_DEFAULT_VALUE = "unknown";
+
+    public static final Pattern K8S_FS_NAME_RESTRICATION = Pattern.compile("(([A-Za-z0-9.][-A-Za-z0-9_.]*)?[A-Za-z0-9])?");
+    public static final String K8S_FS_HIDDEN_FILE_INDICATOR = ".";
+    public static final String K8S_FS_HIDDEN_FILE_INDICATOR_SUFFIX = "1";
+    
+    public static final String K8S_FS_SCHEME = "k8s"; 
+    public static final String K8S_FS_NO_IMPL = "Not implemented";
+
+    public static final int K8S_FS_NAME_MAX_LENGTH = 63;
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemObjectType.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemObjectType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+enum K8SFileSystemObjectType {
+    STORE("fsobj-filestore"),
+    ROOT("fsobj-root-directory"),
+    DIR("fsobj-directory"),
+    FILE("fsobj-regular-file"),
+    UNKNOWN("fsobj-unknown");
+
+    private final String desc;
+
+    private K8SFileSystemObjectType(String desc) {
+        this.desc = desc;
+    }
+
+    @Override
+    public String toString() {
+        return this.desc;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemProvider.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.base.AbstractBasicFileAttributeView;
+import org.uberfire.java.nio.base.BasicFileAttributesImpl;
+import org.uberfire.java.nio.base.GeneralPathImpl;
+import org.uberfire.java.nio.channels.SeekableByteChannel;
+import org.uberfire.java.nio.file.AccessDeniedException;
+import org.uberfire.java.nio.file.AccessMode;
+import org.uberfire.java.nio.file.AtomicMoveNotSupportedException;
+import org.uberfire.java.nio.file.CopyOption;
+import org.uberfire.java.nio.file.DeleteOption;
+import org.uberfire.java.nio.file.DirectoryNotEmptyException;
+import org.uberfire.java.nio.file.FileAlreadyExistsException;
+import org.uberfire.java.nio.file.FileStore;
+import org.uberfire.java.nio.file.LinkOption;
+import org.uberfire.java.nio.file.NoSuchFileException;
+import org.uberfire.java.nio.file.NotDirectoryException;
+import org.uberfire.java.nio.file.OpenOption;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
+import org.uberfire.java.nio.file.attribute.FileAttribute;
+import org.uberfire.java.nio.file.attribute.FileAttributeView;
+import org.uberfire.java.nio.fs.cloud.CloudClientFactory;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import static org.kie.soup.commons.validation.PortablePreconditions.checkCondition;
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_FSOBJ_CONTENT_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_SCHEME;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.createOrReplaceFSCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.createOrReplaceParentDirFSCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.deleteAndUpdateParentCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getPathByFsObjCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.isDirectory;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.isRoot;
+
+public class K8SFileSystemProvider extends SimpleFileSystemProvider implements CloudClientFactory {
+    private static final Logger logger = LoggerFactory.getLogger(K8SFileSystemProvider.class);
+    public K8SFileSystemProvider() {
+        super(null, OSType.UNIX_LIKE);
+        this.fileSystem = new K8SFileSystem(this, K8SFileSystem.UNIX_SEPARATOR_STRING);
+    }
+
+    @Override
+    public String getScheme() {
+        return K8S_FS_SCHEME;
+    }
+
+    @Override
+    public InputStream newInputStream(final Path path,
+                                      final OpenOption... options)
+            throws IllegalArgumentException, NoSuchFileException, IOException, SecurityException {
+        checkNotNull("path", path);
+        checkFileNotExistThenThrow(path, false);
+        logger.info("Open InputStream to file [{}]", path);
+        return Channels.newInputStream(new K8SFileChannel(toAbsoluteRealPath(path), this));
+    }
+
+    @Override
+    public OutputStream newOutputStream(final Path path,
+                                        final OpenOption... options)
+            throws IllegalArgumentException, UnsupportedOperationException, IOException, SecurityException {
+        checkNotNull("path", path);
+        Path aPath = toAbsoluteRealPath(path);
+        logger.info("Open OutputStream to file [{}]", aPath);
+        return Channels.newOutputStream(new K8SFileChannel(aPath, this));
+    }
+
+    @Override
+    public FileChannel newFileChannel(final Path path,
+                                      final Set<? extends OpenOption> options,
+                                      final FileAttribute<?>... attrs)
+            throws IllegalArgumentException, UnsupportedOperationException, IOException, SecurityException {
+        checkNotNull("path", path);
+        throw new UnsupportedOperationException();
+    }
+    
+    @Override
+    public SeekableByteChannel newByteChannel(final Path path,
+                                              final Set<? extends OpenOption> options,
+                                              final FileAttribute<?>... attrs)
+            throws IllegalArgumentException, UnsupportedOperationException, FileAlreadyExistsException, IOException, SecurityException {
+        checkNotNull("path", path);
+        return new K8SFileChannel(toAbsoluteRealPath(path), this);
+    }
+
+    @Override
+    public void createDirectory(final Path dir,
+                                final FileAttribute<?>... attrs)
+            throws UnsupportedOperationException, FileAlreadyExistsException, IOException, SecurityException {
+        checkNotNull("dir",dir);
+        Path aDir = toAbsoluteRealPath(dir);
+        Optional<ConfigMap> directoryCm = executeCloudFunction(client -> getFsObjCM(client, aDir), KubernetesClient.class);
+        if (directoryCm.isPresent()) {
+            throw new FileAlreadyExistsException(aDir.toString());
+        }
+        
+        executeCloudFunction(client -> createOrReplaceFSCM(client, 
+                                                           aDir,
+                                                           isRoot(aDir) ? Optional.empty()
+                                                                       : createOrReplaceParentDirFSCM(client, aDir, 0L, false),
+                                                           Collections.emptyMap(),
+                                                           true), 
+                             KubernetesClient.class);
+    }
+
+    @Override
+    protected Path[] getDirectoryContent(final Path dir) {
+        checkNotNull("dir", dir);
+        Path aDir = toAbsoluteRealPath(dir);
+        if (isRoot(aDir) &&
+            !executeCloudFunction(client -> getFsObjCM(client, aDir), KubernetesClient.class).isPresent()) {
+            initRoot();
+        }
+        ConfigMap dirCM = executeCloudFunction(client -> getFsObjCM(client, aDir), KubernetesClient.class)
+                .orElseThrow(() -> new NotDirectoryException(aDir.toString()));
+        if (dirCM.getData() == null || dirCM.getData().isEmpty()) {
+            return new Path[0];
+        }
+        
+        String separator = aDir.getFileSystem().getSeparator();
+        String dirPathString = getPathByFsObjCM((K8SFileSystem)fileSystem, dirCM).toString();
+        return dirCM.getData()
+                    .keySet()
+                    .stream()
+                    .map(fileName -> GeneralPathImpl.create(aDir.getFileSystem(), 
+                                                           (dirPathString.endsWith(separator) ? 
+                                                            dirPathString :
+                                                            dirPathString.concat(separator)).concat(fileName), 
+                                                            false))
+                    .toArray(Path[]::new);
+    }
+    
+    private synchronized void initRoot() {
+        Path root = this.fileSystem.getPath(K8SFileSystem.UNIX_SEPARATOR_STRING);
+        this.createDirectory(root);
+        logger.info("Root directory created.");
+    }
+
+    @Override
+    public void delete(final Path path,
+                       final DeleteOption... options) throws NoSuchFileException, DirectoryNotEmptyException, IOException, SecurityException {
+        checkNotNull("path", path);
+        checkFileNotExistThenThrow(path, false);
+        deleteIfExists(toAbsoluteRealPath(path), options);
+    }
+
+    @Override
+    public boolean deleteIfExists(final Path path,
+                                  final DeleteOption... options)
+            throws DirectoryNotEmptyException, IOException, SecurityException {
+        checkNotNull("path", path);
+        Path aPath = toAbsoluteRealPath(path);
+        synchronized (this) {
+            try {
+                return executeCloudFunction(client -> deleteAndUpdateParentCM(client, aPath), 
+                                            KubernetesClient.class).get();
+            } finally {
+                toGeneralPathImpl(aPath).clearCache();
+            }
+        }
+    }
+    
+    @Override
+    public boolean isHidden(final Path path) throws IllegalArgumentException, IOException, SecurityException {
+        checkNotNull("path", path);
+        checkFileNotExistThenThrow(path, false);
+        return path.getFileName().toString().startsWith(K8SFileSystemConstants.K8S_FS_HIDDEN_FILE_INDICATOR);
+    }
+
+    @Override
+    public void checkAccess(final Path path,
+                            AccessMode... modes)
+            throws UnsupportedOperationException, NoSuchFileException, AccessDeniedException, IOException, SecurityException {
+        checkNotNull("path", path);
+        checkNotNull("modes", modes);
+        checkFileNotExistThenThrow(path, false);
+        for (final AccessMode mode : modes) {
+            checkNotNull("mode", mode);
+            if (mode == AccessMode.EXECUTE) {
+                throw new AccessDeniedException(toAbsoluteRealPath(path).toString());
+            }
+        }
+    }
+
+    @Override
+    public FileStore getFileStore(final Path path) throws IOException, SecurityException {
+        checkNotNull("path", path);
+        return new K8SFileStore(toAbsoluteRealPath(path));
+    }
+
+    @Override
+    public <A extends BasicFileAttributes> A readAttributes(final Path path,
+                                                            final Class<A> type,
+                                                            final LinkOption... options)
+            throws NoSuchFileException, UnsupportedOperationException, IOException, SecurityException {
+        checkNotNull("path", path);
+        checkNotNull("type", type);
+        checkFileNotExistThenThrow(path, false);
+        if (type == BasicFileAttributesImpl.class || type == BasicFileAttributes.class) {
+            final K8SBasicFileAttributeView view = getFileAttributeView(toAbsoluteRealPath(path),
+                                                                        K8SBasicFileAttributeView.class,
+                                                                        options);
+            return view.readAttributes();
+        }
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected <V extends FileAttributeView> V createFileAttributeView(final GeneralPathImpl path, 
+                                                                      final Class<V> type) {
+        if (AbstractBasicFileAttributeView.class.isAssignableFrom(type)) {
+            final V newView = (V) new K8SBasicFileAttributeView(path, this);
+            path.addAttrView(newView);
+            return newView;
+        } else {
+            return null;
+        }
+    }
+    
+    @Override
+    public void copy(final Path source,
+                     final Path target,
+                     final CopyOption... options)
+            throws UnsupportedOperationException, FileAlreadyExistsException, DirectoryNotEmptyException, IOException, SecurityException {
+        checkNotNull("source", source);
+        checkNotNull("target", target);
+        checkFileExistsThenThrow(target);
+        Path aSource = toAbsoluteRealPath(source);
+        Path aTarget = toAbsoluteRealPath(target);
+
+        Optional<ConfigMap> srcCMOpt = executeCloudFunction(
+            client -> getFsObjCM(client, aSource), KubernetesClient.class);
+        checkCondition("source must exist", srcCMOpt.isPresent());
+
+        ConfigMap srcCM = srcCMOpt.orElseThrow(IllegalArgumentException::new);
+        if (isDirectory(srcCM)) {
+            throw new UnsupportedOperationException(srcCM.getMetadata().getName() + "is a directory.");
+        }
+        
+        String content = srcCM.getData().getOrDefault(CFG_MAP_FSOBJ_CONTENT_KEY, "");
+        long size = Long.parseLong(srcCM.getMetadata().getAnnotations().getOrDefault(CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY, "0"));
+        executeCloudFunction(client -> createOrReplaceFSCM(client, 
+                                                           aTarget,
+                                                           createOrReplaceParentDirFSCM(client, aTarget, size, false),
+                                                           Collections.singletonMap(CFG_MAP_FSOBJ_CONTENT_KEY, content),
+                                                           false), 
+                             KubernetesClient.class);
+    }
+
+    @Override
+    public void move(final Path source,
+                     final Path target,
+                     final CopyOption... options)
+            throws DirectoryNotEmptyException, AtomicMoveNotSupportedException, IOException, SecurityException {
+        Path aSource = toAbsoluteRealPath(source);
+        Path aTarget = toAbsoluteRealPath(target);
+        try {
+            copy(aSource, aTarget);
+        } catch (Exception e) {
+            try {
+                delete(aTarget);
+            } catch (NoSuchFileException nsfe) {
+                throw new IOException("Moving file failed.", e);
+            } catch (Exception exp) {
+                throw new IOException("Moving file failed due to these errors: Copy Source Exception [" + 
+                        e.getMessage() + "]; Delete Target Exception [" + exp.getMessage() + "].");
+            } 
+        } 
+        
+        try {
+            delete(aSource);
+        } catch (Exception e) {
+            throw new IOException("Moving file failed with clean Source Exception [" + e.getMessage() + "], " +
+                    "which will leave file system in an inconsistent state.");
+        }
+    }
+    
+    @Override
+    protected void checkFileNotExistThenThrow(final Path path, final boolean isLink) {
+        Path aPath = toAbsoluteRealPath(path);
+        executeCloudFunction(client -> getFsObjCM(client, aPath), KubernetesClient.class)
+            .orElseThrow(() -> {
+                logger.info("File not found [{}]", aPath.toUri().toString());
+                return new NoSuchFileException(aPath.toUri().toString());
+            });
+    }
+
+    @Override
+    protected void checkFileExistsThenThrow(final Path path) {
+        Path aPath = toAbsoluteRealPath(path);
+        if (executeCloudFunction(client -> getFsObjCM(client, aPath), KubernetesClient.class).isPresent()) {
+            throw new FileAlreadyExistsException(aPath.toString());
+        }
+    }
+
+    protected Path toAbsoluteRealPath(final Path path) {
+        if (path.isAbsolute()) {
+            if (path.getParent() == null) {
+                return path; // Root
+            } else if (path.getParent().toString().contains(".")) {
+                fileSystem.getPath(path.toRealPath().toString());
+            } else {
+                return path; // RealPath
+            }
+        }
+        return fileSystem.getPath(path.toAbsolutePath().toRealPath().toString());
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemUtils.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemUtils.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.io.UnsupportedEncodingException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher.Action;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.file.InvalidPathException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.StandardWatchEventKind;
+import org.uberfire.java.nio.file.WatchEvent.Kind;
+import org.uberfire.java.nio.fs.cloud.CloudClientConstants;
+
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_ANNOTATION_FSOBJ_LAST_MODIFIED_TIMESTAMP_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_FSOBJ_CONTENT_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_FSOBJ_NAME_PREFIX;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_LABEL_FSOBJ_APP_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_LABEL_FSOBJ_NAME_KEY_PREFIX;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_LABEL_FSOBJ_TYPE_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_APP_DEFAULT_VALUE;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_APP_PROPERTY_NAME;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_HIDDEN_FILE_INDICATOR;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_HIDDEN_FILE_INDICATOR_SUFFIX;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_NAME_MAX_LENGTH;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_NAME_RESTRICATION;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemObjectType.UNKNOWN;
+
+
+public class K8SFileSystemUtils {
+
+    public static final String APP_NAME = System.getProperty(K8S_FS_APP_PROPERTY_NAME, K8S_FS_APP_DEFAULT_VALUE);
+    private static final Logger logger = LoggerFactory.getLogger(K8SFileSystemUtils.class);
+
+    static Optional<ConfigMap> createOrReplaceParentDirFSCM(KubernetesClient client, 
+                                                            Path self, 
+                                                            long selfSize,
+                                                            boolean isUpdateForFileDeletion) {
+        String selfName = getFileNameString(self);
+        Path parent = Optional.ofNullable(self.getParent()).orElseThrow(IllegalArgumentException::new);
+        Map<String, String> parentContent = Optional.ofNullable(getFsObjCM(client, parent))
+                .filter(K8SFileSystemUtils::isDirectory)
+                .map(ConfigMap::getData)
+                .orElseGet(HashMap::new);
+        
+        if (isUpdateForFileDeletion) {
+            parentContent.remove(selfName);
+        } else {
+            parentContent.put(selfName, String.valueOf(selfSize));
+        }
+        final long parentSize = parentContent.values().stream().mapToLong(Long::parseLong).sum();
+
+        return Optional.of(createOrReplaceFSCM(client, parent,
+                                               isRoot(parent) ? Optional.empty()
+                                                              : createOrReplaceParentDirFSCM(client, parent, parentSize, false),
+                                               parentContent,
+                                               true));
+    }
+
+    static ConfigMap createOrReplaceFSCM(KubernetesClient client,
+                                         Path path,
+                                         Optional<ConfigMap> parentOpt,
+                                         Map<String, String> content,
+                                         boolean isDir) {
+        String fileName = getFileNameString(path);
+        long size = 0;
+        Map<String, String> labels = getFsObjNameElementLabel(path);
+        if (isDir) {
+            if (labels.isEmpty()) {
+                labels.put(CFG_MAP_LABEL_FSOBJ_TYPE_KEY, K8SFileSystemObjectType.ROOT.toString());
+            } else {
+                labels.put(CFG_MAP_LABEL_FSOBJ_TYPE_KEY, K8SFileSystemObjectType.DIR.toString());
+            }
+            size = content.values().stream().mapToLong(Long::parseLong).sum();
+        } else {
+            labels.put(CFG_MAP_LABEL_FSOBJ_TYPE_KEY, K8SFileSystemObjectType.FILE.toString());
+            size = parentOpt.map(cm -> Long.parseLong(cm.getData().get(fileName)))
+                            .orElseThrow(() -> new IllegalStateException("File [" +
+                                                                         fileName +
+                                                                         "] is not found at parent directory [" +
+                                                                         path.getParent().toString() +
+                                                                         "]"));
+        }
+        labels.put(CFG_MAP_LABEL_FSOBJ_APP_KEY, APP_NAME);
+        
+        Map<String, String> annotations = new ConcurrentHashMap<>();
+        annotations.put(CFG_MAP_ANNOTATION_FSOBJ_LAST_MODIFIED_TIMESTAMP_KEY, 
+                        ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT));
+        annotations.put(CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY, String.valueOf(size));
+        
+        String cmName = Optional.ofNullable(getFsObjCM(client, path))
+                .map(cm -> cm.getMetadata().getName())
+                .orElseGet(() -> CFG_MAP_FSOBJ_NAME_PREFIX + UUID.randomUUID().toString());
+        return parentOpt.map(parent -> client.configMaps().createOrReplace(new ConfigMapBuilder()
+                                             .withNewMetadata()
+                                               .withName(cmName)
+                                               .withLabels(labels)
+                                               .withAnnotations(annotations)
+                                               .withOwnerReferences(new OwnerReferenceBuilder()
+                                                 .withApiVersion(parent.getApiVersion())
+                                                 .withKind(parent.getKind())
+                                                 .withName(parent.getMetadata().getName())
+                                                 .withUid(parent.getMetadata().getUid())
+                                                 .build())
+                                             .endMetadata()
+                                             .withData(content)
+                                             .build()))
+                        .orElseGet(() -> client.configMaps().createOrReplace(new ConfigMapBuilder()
+                                               .withNewMetadata()
+                                                 .withName(cmName)
+                                                 .withLabels(labels)
+                                                 .withAnnotations(annotations)
+                                               .endMetadata()
+                                               .withData(content)
+                                               .build()));
+    }
+
+    static boolean deleteAndUpdateParentCM(KubernetesClient client, Path path) {
+        ConfigMap cm = getFsObjCM(client, path);
+        if (cm != null && client.configMaps()
+                                .withName(cm.getMetadata().getName())
+                                .cascading(true)
+                                .delete()) {
+            Optional.ofNullable(path.getParent())
+                    .ifPresent(p -> createOrReplaceParentDirFSCM(client, path, 0, true));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    static ConfigMap getFsObjCM(KubernetesClient client, Path path) {
+        int nameCount = path.getNameCount();
+        Map<String, String> labels = getFsObjNameElementLabel(path);
+        if (labels.isEmpty()) {
+            labels.put(CFG_MAP_LABEL_FSOBJ_TYPE_KEY, K8SFileSystemObjectType.ROOT.toString());
+        } 
+        labels.put(CFG_MAP_LABEL_FSOBJ_APP_KEY, APP_NAME);
+        Object[] configMaps = client.configMaps()
+                                           .withLabels(labels)
+                                           .list()
+                                           .getItems()
+                                           .stream()
+                                           .filter(cm -> cm.getMetadata()
+                                                           .getLabels()
+                                                           .entrySet()
+                                                           .stream()
+                                                           .filter(entry -> entry.getKey().startsWith(CFG_MAP_LABEL_FSOBJ_NAME_KEY_PREFIX))
+                                                           .count() == nameCount)
+                                           .toArray();
+        
+        if (configMaps.length > 1) {
+            throw new IllegalStateException("Ambiguous K8S FileSystem object name: [" + path.toString() +
+                                            "]; should not have be associated with more than one " +
+                                            "K8S FileSystem ConfigMaps.");
+        }
+        if (configMaps.length == 1) {
+            return (ConfigMap)configMaps[0];
+        }
+        return null;
+    }
+
+    static byte[] getFsObjContentBytes(ConfigMap cm) {
+        byte[] content = new byte[0];
+        try {
+            content = cm.getData().get(CFG_MAP_FSOBJ_CONTENT_KEY).getBytes(CloudClientConstants.ENCODING);
+        } catch (UnsupportedEncodingException e) {
+            logger.warn("Invalid encoding [{}], returns zero length byte array content.",
+                        CloudClientConstants.ENCODING);
+        } catch (Exception e) {
+            logger.error("Retrieve content from FsOjbCM [{}] failed, due to", cm, e);
+        }
+        return content;
+    }
+
+    static Map<String, String> getFsObjNameElementLabel(Path path) {
+        Map<String, String> labels = new ConcurrentHashMap<>();
+        path.iterator().forEachRemaining(
+            pathElement -> validateAndBuildPathLabel(labels, pathElement));
+        return labels;
+    }
+    
+    static void validateAndBuildPathLabel(Map<String, String> labels, Path pathElement) {
+        StringBuilder nameKeyBuilder = new StringBuilder(CFG_MAP_LABEL_FSOBJ_NAME_KEY_PREFIX); 
+        String pathElementStr = pathElement.toString();
+        
+        nameKeyBuilder.append(labels.size());
+        if (K8S_FS_NAME_RESTRICATION.matcher(pathElementStr).matches() 
+                && pathElementStr.length() < K8S_FS_NAME_MAX_LENGTH) {
+            if (pathElementStr.startsWith(K8S_FS_HIDDEN_FILE_INDICATOR)) {
+                pathElementStr = pathElementStr.substring(1);
+                nameKeyBuilder.append(K8S_FS_HIDDEN_FILE_INDICATOR).append(K8S_FS_HIDDEN_FILE_INDICATOR_SUFFIX);
+            }
+        } else {
+            throw new InvalidPathException(pathElementStr, 
+                "A valid k8s filesystem object name must be less than " +
+                K8S_FS_NAME_MAX_LENGTH + 
+                " characters and valid by '" +
+                K8S_FS_NAME_RESTRICATION.toString() + "'"); 
+        }
+        labels.put(nameKeyBuilder.toString(), pathElementStr);
+    }
+    
+    static String getFileNameString(Path path) {
+        return Optional.ofNullable(path.getFileName()).map(Path::toString).orElse(K8SFileSystem.UNIX_SEPARATOR_STRING);
+    }
+
+    static long getSize(ConfigMap fileCM) {
+        return Long.parseLong(fileCM.getMetadata().getAnnotations().getOrDefault(CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY, "0"));
+    }
+
+    static long getCreationTime(ConfigMap fileCM) {
+        return parseTimestamp(fileCM.getMetadata().getCreationTimestamp()).getEpochSecond();
+    }
+    
+    static long getLastModifiedTime(ConfigMap fileCM) {
+        return parseTimestamp(fileCM.getMetadata().getAnnotations()
+                                                  .get(CFG_MAP_ANNOTATION_FSOBJ_LAST_MODIFIED_TIMESTAMP_KEY))
+                .getEpochSecond();
+    }
+    
+    static Path getPathByFsObjCM(K8SFileSystem fs, ConfigMap cm) {
+        StringBuilder pathBuilder = new StringBuilder();
+        Map<String, String> labels = cm.getMetadata().getLabels();
+        Map<Float, Map.Entry<String, String>> labelsToBeSorted = new ConcurrentHashMap<>();
+        if (labels.isEmpty() || !labels.containsKey(CFG_MAP_LABEL_FSOBJ_TYPE_KEY)) {
+            throw new IllegalArgumentException("Invalid K8SFileSystem ConfigMap - Missing required labels");
+        }
+        if (labels.containsValue(K8SFileSystemObjectType.ROOT.toString())) {
+            return fs.getPath(fs.getSeparator());
+        }
+        labels.entrySet()
+              .stream()
+              .filter(entry -> entry.getKey().startsWith(CFG_MAP_LABEL_FSOBJ_NAME_KEY_PREFIX))
+              .forEach(entry -> labelsToBeSorted.put(extractPathElementIndex(entry.getKey()), entry));
+        
+        labelsToBeSorted.entrySet()
+                        .stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .forEach(entry -> pathBuilder.append(fs.getSeparator())
+                                                     .append(extractPathElementStringWithHiddenIndicator(entry.getValue())));
+        return fs.getPath(pathBuilder.toString());
+    }
+    
+    static Float extractPathElementIndex(String pathElement) {
+        return Float.parseFloat(pathElement.substring(CFG_MAP_LABEL_FSOBJ_NAME_KEY_PREFIX.length()));
+    }
+    
+    static String extractPathElementStringWithHiddenIndicator(Map.Entry<String, String> entry) {
+        String pes = entry.getValue();
+        if (entry.getKey().endsWith(K8S_FS_HIDDEN_FILE_INDICATOR.concat(K8S_FS_HIDDEN_FILE_INDICATOR_SUFFIX))) {
+            return K8S_FS_HIDDEN_FILE_INDICATOR.concat(pes);
+        } else {
+            return pes;
+        }
+    }
+
+    public static boolean isRoot(Path path) {
+        return path.getParent() == null;
+    }
+    
+    static boolean isFile(ConfigMap fileCM) {
+        return K8SFileSystemObjectType.FILE.toString()
+                                           .equals(fileCM.getMetadata()
+                                                         .getLabels()
+                                                         .getOrDefault(CFG_MAP_LABEL_FSOBJ_TYPE_KEY, UNKNOWN.toString()));
+    }
+
+    static boolean isDirectory(ConfigMap fileCM) {
+        return K8SFileSystemObjectType.DIR.toString()
+                                          .equals(fileCM.getMetadata()
+                                                        .getLabels()
+                                                        .getOrDefault(CFG_MAP_LABEL_FSOBJ_TYPE_KEY, UNKNOWN.toString()))
+               ||                           
+               K8SFileSystemObjectType.ROOT.toString()
+                .equals(fileCM.getMetadata()
+                              .getLabels()
+                              .getOrDefault(CFG_MAP_LABEL_FSOBJ_TYPE_KEY, UNKNOWN.toString()));
+    }
+
+    @SuppressWarnings("rawtypes")
+    static Optional<Kind> mapActionToKind(Action action) {
+        switch(action) {
+            case ADDED:
+                return Optional.of(StandardWatchEventKind.ENTRY_CREATE);
+            case DELETED:
+                return Optional.of(StandardWatchEventKind.ENTRY_DELETE);
+            case MODIFIED:
+                return Optional.of(StandardWatchEventKind.ENTRY_MODIFY);
+            case ERROR:
+            default:
+                return Optional.empty();
+        }
+    }
+
+    static Instant parseTimestamp(String timestamp) {
+        return Optional.ofNullable(timestamp).map(ts -> ZonedDateTime.parse(ts, DateTimeFormatter.ISO_DATE_TIME)
+                                                                     .toInstant())
+                                             .orElse(Instant.now());
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SWatchKey.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SWatchKey.java
@@ -1,0 +1,164 @@
+package org.uberfire.java.nio.fs.k8s;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.uberfire.java.nio.base.WatchContext;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchEvent.Kind;
+import org.uberfire.java.nio.file.WatchKey;
+import org.uberfire.java.nio.file.Watchable;
+
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_NO_IMPL;
+
+@SuppressWarnings("serial")
+public class K8SWatchKey implements WatchKey {
+    private final transient K8SWatchService service;
+    private final transient Path path;
+    private final AtomicReference<State> state = new AtomicReference<>(State.READY);
+    private final AtomicBoolean valid = new AtomicBoolean(true);
+    private final BlockingQueue<WatchEvent<?>> events = new LinkedBlockingQueue<>();
+    @SuppressWarnings("rawtypes")
+    private final transient Map<Kind, Event> eventKinds = new ConcurrentHashMap<>();
+
+    K8SWatchKey(K8SWatchService service, Path path) {
+        this.service = service;
+        this.path = path;
+    }
+
+    @Override
+    public boolean isValid() {
+        return !service.isClose() && valid.get();
+    }
+
+    @Override
+    public List<WatchEvent<?>> pollEvents() {
+        List<WatchEvent<?>> result = new ArrayList<>(events.size());
+        events.drainTo(result);
+        eventKinds.clear();
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public boolean reset() {
+        if (isValid()) {
+            events.clear();
+            eventKinds.clear();
+            return state.compareAndSet(State.SIGNALLED, State.READY);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void cancel() {
+        valid.set(false);
+    }
+
+    @Override
+    public Watchable watchable() {
+        return this.path;
+    }
+
+    @SuppressWarnings("rawtypes")
+    protected boolean postEvent(WatchEvent.Kind kind) {
+        Event event = eventKinds.computeIfAbsent(kind, k -> {
+            Event e = new Event(kind, new Context(K8SWatchKey.this.path.getFileName()));
+            return events.offer(e) ? e : null;
+        });
+        if (event == null) {
+            return false;
+        } else {
+            event.increaseCount();
+            return true;
+        }
+    }
+
+    protected boolean isQueued() {
+        return state.get() == State.SIGNALLED;
+    }
+
+    protected void signal() {
+        state.compareAndSet(State.READY, State.SIGNALLED);
+    }
+
+    enum State {
+        READY,
+        SIGNALLED
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static final class Event implements WatchEvent<Context> {
+
+        private final AtomicInteger count = new AtomicInteger(0);
+        private final transient Kind kind;
+        private final transient Context context;
+
+        private Event(Kind kind, Context context) {
+            this.kind = kind;
+            this.context = context;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Kind kind() {
+            return this.kind;
+        }
+
+        @Override
+        public int count() {
+            return count.get();
+        }
+
+        @Override
+        public Context context() {
+            return this.context;
+        }
+
+        private int increaseCount() {
+            return count.incrementAndGet();
+        }
+    }
+    
+    private static final class Context implements WatchContext {
+        private final Path path;
+        
+        private Context(Path path) {
+            this.path = path;
+        }
+        
+        @Override
+        public Path getPath() {
+            return this.path;
+        }
+
+        @Override
+        public Path getOldPath() {
+            return this.path;
+        }
+
+        @Override
+        public String getSessionId() {
+            return K8S_FS_NO_IMPL;
+        }
+
+        @Override
+        public String getMessage() {
+            return K8S_FS_NO_IMPL;
+        }
+
+        @Override
+        public String getUser() {
+            return K8S_FS_NO_IMPL;
+        }
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SWatchService.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/K8SWatchService.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.file.ClosedWatchServiceException;
+import org.uberfire.java.nio.file.InterruptedException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.WatchKey;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.fs.cloud.CloudClientFactory;
+
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_LABEL_FSOBJ_APP_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.APP_NAME;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getPathByFsObjCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.mapActionToKind;
+
+public class K8SWatchService implements WatchService {
+
+    private static final Logger logger = LoggerFactory.getLogger(K8SWatchService.class);
+    private final CloudClientFactory ccf;
+    private final K8SFileSystem fs;
+    private final BlockingQueue<WatchKey> buckets = new LinkedBlockingQueue<>();
+    private final Map<Path, WatchKey> registrations = new ConcurrentHashMap<>();
+
+    private final CompletableFuture<Void> closed = new CompletableFuture<>();
+
+    public K8SWatchService(K8SFileSystem fs) {
+        this.fs = fs;
+        this.ccf = (CloudClientFactory) fs.provider();
+        Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("k8sfs-cm-watcher-thread-%d").build()).execute(() -> 
+            ccf.executeCloudFunction(this::triageEvents, KubernetesClient.class));
+    }
+
+    @Override
+    public void close() {
+        logger.info("K8SFileSystem WatchService is closing.");
+        if (closed.complete(null)) {
+            logger.info("K8SFileSystem WatchService closed normally.");
+        } else {
+            logger.info("K8SFileSystem WatchService has been closed already.");
+        }
+        buckets.clear();
+        registrations.clear();
+    }
+
+    @Override
+    public WatchKey poll() {
+        checkOpen();
+        return buckets.poll();
+    }
+
+    @Override
+    public WatchKey poll(long timeout, TimeUnit unit) {
+        WatchKey bucket = null;
+        checkOpen();
+        try {
+            bucket = buckets.poll(timeout, unit);
+        } catch (java.lang.InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new InterruptedException();
+        }
+        return bucket;
+    }
+
+    @Override
+    public WatchKey take() {
+        WatchKey bucket = null;
+        checkOpen();
+        try {
+            bucket = buckets.take();
+        } catch (java.lang.InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new InterruptedException();
+        }
+        return bucket;
+    }
+
+    @Override
+    public boolean isClose() {
+        return closed.isDone();
+    }
+
+    protected final void checkOpen() {
+        if (closed.isDone()) {
+            throw new ClosedWatchServiceException();
+        }
+    }
+
+    private CompletableFuture<Void> triageEvents(KubernetesClient client) {
+        logger.info("K8SFileSystem WatchService is starting to watch K8SFileSystem ConfigMap in namespace: [{}]",
+                    client.getNamespace());
+        try (Watch watchable = client.configMaps()
+                                     .withLabel(CFG_MAP_LABEL_FSOBJ_APP_KEY, APP_NAME)
+                                     .watch(new Watcher<ConfigMap>() {
+            @Override
+            public void eventReceived(Action action, ConfigMap fsObjCM) {
+                logger.debug("Event - Action: {}, {} on ConfigMap ", action, fsObjCM.getMetadata().getLabels());
+                Path path = getPathByFsObjCM(K8SWatchService.this.fs, fsObjCM);
+                
+                K8SWatchKey key = (K8SWatchKey) registrations
+                        .computeIfAbsent(path, p -> new K8SWatchKey(K8SWatchService.this, p));
+                mapActionToKind(action).ifPresent(e -> {
+                    if (key.postEvent(e) && key.isValid() && !key.isQueued() && buckets.offer(key)) {
+                        key.signal();
+                    }
+                });
+            }
+
+            @Override
+            public void onClose(KubernetesClientException cause) {
+                logger.info("K8SFileSystem ConfigMap Watcher closed.");
+                if (cause != null) {
+                    logger.info(cause.getMessage());
+                }
+            }
+        })) {
+            logger.info("K8SFileSystem ConfigMap Watcher thread started.");
+            closed.get();
+            logger.info("K8SFileSystem ConfigMap Watcher thread terminated.");
+        } catch (ExecutionException ee) {
+            logger.error("K8SFileSystem ConfigMap Watcher thread terminated with execution exception.", ee);
+            closed.completeExceptionally(ee);
+        } catch (Exception e) {
+            if (!closed.isDone()) {
+                logger.error("K8SFileSystem ConfigMap Watcher thread terminated with exception.", e);
+                closed.completeExceptionally(e);
+            } 
+        }
+        return closed;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/SeekableInMemoryByteChannel.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/main/java/org/uberfire/java/nio/fs/k8s/SeekableInMemoryByteChannel.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import com.google.common.io.ByteSource;
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.channels.SeekableByteChannel;
+
+public class SeekableInMemoryByteChannel implements SeekableByteChannel {
+
+    private static final String ENCODING = System.getProperty("file.encoding", StandardCharsets.UTF_8.name());
+
+    private int position;
+    private int capacity = Integer.MAX_VALUE;
+    private boolean open;
+    protected byte[] contents;
+
+    public SeekableInMemoryByteChannel(int capacity) {
+        this();
+        this.capacity = capacity;
+    }
+    public SeekableInMemoryByteChannel() {
+        this.open = true;
+        synchronized (this) {
+            this.position = 0;
+            this.contents = new byte[0];
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return this.open;
+    }
+
+    @Override
+    public void close() {
+        this.open = false;
+        this.truncate(0);
+    }
+
+    @Override
+    public int read(final ByteBuffer destination) {
+        this.checkClosed();
+        if (destination == null) {
+            throw new IllegalArgumentException("Destination buffer must be supplied");
+        }
+
+        final int spaceInBuffer = destination.remaining();
+        final int numBytesRemainingInContent;
+        final int numBytesToRead;
+        synchronized (this) {
+            numBytesRemainingInContent = this.contents.length - this.position;
+            if (numBytesRemainingInContent <= 0) {
+                return -1;
+            }
+            numBytesToRead = numBytesRemainingInContent >= spaceInBuffer ? spaceInBuffer : numBytesRemainingInContent;
+            destination.put(this.contents, this.position, numBytesToRead);
+            this.position += numBytesToRead;
+        }
+        return numBytesToRead;
+    }
+
+    @Override
+    public int write(final ByteBuffer source) {
+        this.checkClosed();
+        if (source == null) {
+            throw new IllegalArgumentException("Source buffer must be supplied");
+        }
+        
+        final int totalBytes = source.remaining();
+        if (totalBytes > capacity || this.position + totalBytes > capacity) {
+            throw new IOException("Reached maximum capacity of [" + capacity + "] bytes.");
+        }
+        
+        final byte[] readContents = new byte[totalBytes];
+        source.get(readContents, source.position(), readContents.length);
+
+        synchronized (this) {
+            this.contents = this.concat(this.contents, readContents, this.position);
+            this.position += totalBytes;
+            /**
+             * Channel content will be overwritten by new source completely 
+             * from existing position. Old trailing content will be cleared.
+             */
+            truncate(this.position()); 
+        }
+
+        return totalBytes;
+    }
+
+    @Override
+    public long position() {
+        synchronized (this) {
+            return this.position;
+        }
+    }
+
+    @Override
+    public SeekableByteChannel position(final long newPosition) {
+        if (newPosition > Integer.MAX_VALUE || newPosition < 0) {
+            throw new IllegalArgumentException("Valid position for this channel is between 0 and " + Integer.MAX_VALUE);
+        }
+        synchronized (this) {
+            this.position = (int) newPosition;
+        }
+        return this;
+    }
+
+    @Override
+    public long size() {
+        synchronized (this) {
+            return this.contents.length;
+        }
+    }
+
+    @Override
+    public SeekableByteChannel truncate(final long size) {
+        if (size < 0 || size > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("This implementation permits a size of 0 to " + Integer.MAX_VALUE + " inclusive");
+        }
+        synchronized (this) {
+            final int newSize = (int) size;
+            final int currentSize = (int) this.size();
+            if (this.position > newSize) {
+                this.position = newSize;
+            }
+            if (currentSize > newSize) {
+                final byte[] newContents = new byte[newSize];
+                System.arraycopy(this.contents, 0, newContents, 0, newSize);
+                this.contents = newContents;
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return convert(getContent());
+    }
+
+    public InputStream getContent() {
+        final byte[] copy;
+        synchronized (this) {
+            final int length = this.contents.length;
+            copy = new byte[length];
+            System.arraycopy(this.contents, 0, copy, 0, this.contents.length);
+        }
+        return new ByteArrayInputStream(copy);
+    }
+    
+    private byte[] concat(final byte[] input1, final byte[] input2, final int position) {
+        assert input1 != null : "Input 1 must be specified";
+        assert input2 != null : "Input 2 must be specified";
+        assert position >= 0 : "Position must be 0 or higher";
+        /**
+         * Allocate a new array of enough space (either current size or position + input2.length, 
+         * whichever is greater)
+         */
+        final int newSize = position + input2.length < input1.length ? input1.length : position + input2.length;
+        final byte[] merged = new byte[newSize];
+        System.arraycopy(input1, 0, merged, 0, input1.length);
+        System.arraycopy(input2, 0, merged, position, input2.length);
+        return merged;
+    }
+
+    private void checkClosed() {
+        if (!this.isOpen()) {
+            throw new IOException("Channel closed.");
+        }
+    }
+    
+    private String convert(InputStream is) {
+        try (InputStream bis = is) {
+            return new ByteSource() {
+    
+                @Override
+                public InputStream openStream() throws java.io.IOException {
+                    return bis;
+                }
+            }.asCharSource(Charset.forName(ENCODING)).read();
+        } catch (java.io.IOException e) {
+            throw new IOException(e.getMessage());
+        } 
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/cloud/CloudClientFactoryTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/cloud/CloudClientFactoryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.cloud;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.junit.Test;
+import org.uberfire.java.nio.IOException;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class CloudClientFactoryTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetupConfig() {
+        new CloudClientFactory(){}.setupConfig();
+    }
+    
+    @Test
+    public void testExecuteCloudFunction() {
+        System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, "https://127.0.0.1:8443");
+        System.setProperty(Config.KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY, "dummy");
+        
+        assertThat(new CloudClientFactory() {}.executeCloudFunction(client -> {
+                       return OpenShiftClient.class;
+                   }, OpenShiftClient.class)).containsSame(OpenShiftClient.class);
+
+        assertThat(new CloudClientFactory() {}.executeCloudFunction(client -> {
+            return KubernetesClient.class;
+        }, KubernetesClient.class)).containsSame(KubernetesClient.class);
+        
+        assertThat(new CloudClientFactory() {}.executeCloudFunction(client -> {
+            return null;
+        }, KubernetesClient.class)).isEmpty();
+       
+        assertThat(new CloudClientFactory() {}.executeCloudFunction(client -> {
+            return "";
+        }, KubernetesClient.class)).isNotEmpty();
+        
+        assertThatThrownBy(() -> 
+            new CloudClientFactory() {}.executeCloudFunction(client -> {
+                throw new UnsupportedOperationException();
+            }, KubernetesClient.class)
+        ).isInstanceOf(UnsupportedOperationException.class);
+
+        assertThatThrownBy(() -> 
+            new CloudClientFactory() {}.executeCloudFunction(client -> {
+                throw new IllegalStateException();
+            }, KubernetesClient.class)
+        ).isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> 
+            new CloudClientFactory() {}.executeCloudFunction(client -> {
+                throw new IndexOutOfBoundsException();
+            }, KubernetesClient.class)
+        ).isInstanceOf(IOException.class);
+        
+        System.clearProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY);
+        System.clearProperty(Config.KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/FileSystemProvidersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/FileSystemProvidersTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.net.URI;
+
+import org.junit.Test;
+import org.uberfire.java.nio.file.api.FileSystemProviders;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
+import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileSystemProvidersTest {
+    
+
+    @Test
+    public void generalTests() {
+        assertThat(FileSystemProviders.installedProviders()).hasSize(2);
+        assertThat(FileSystemProviders.getDefaultProvider()).isInstanceOf(SimpleFileSystemProvider.class);
+
+        assertThat(FileSystemProviders.resolveProvider(URI.create("default:///"))).isInstanceOf(SimpleFileSystemProvider.class);
+        assertThat(FileSystemProviders.resolveProvider(URI.create("file:///"))).isInstanceOf(SimpleFileSystemProvider.class);
+        assertThat(FileSystemProviders.resolveProvider(URI.create("k8s:///"))).isInstanceOf(K8SFileSystemProvider.class);
+    }
+    
+    @Test
+    public void k8sFileSystemProivdeAsDefaultTests() {
+        FileSystemUtils.getConfigProps().setProperty(FileSystemUtils.CFG_KIE_CONTROLLER_OCP_ENABLED, "true");
+        assertThat(FileSystemProviders.resolveProvider(URI.create("default:///"))).isInstanceOf(K8SFileSystemProvider.class);
+        assertThat(FileSystemProviders.resolveProvider(URI.create("k8s:///"))).isInstanceOf(K8SFileSystemProvider.class);
+    }
+
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemInitTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemInitTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.google.common.collect.Lists;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.uberfire.java.nio.base.attributes.HiddenAttributes;
+import org.uberfire.java.nio.file.DirectoryStream;
+import org.uberfire.java.nio.file.FileAlreadyExistsException;
+import org.uberfire.java.nio.file.FileStore;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Files;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFileNameString;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjNameElementLabel;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getPathByFsObjCM;
+
+public class K8SFileSystemInitTest {
+
+    @ClassRule
+    public static KubernetesServer SERVER = new KubernetesServer(false, true);
+    // The default namespace for MockKubernetes Server is 'test'
+    protected static String TEST_NAMESPACE = "test";
+    protected static ThreadLocal<KubernetesClient> CLIENT_FACTORY =
+            ThreadLocal.withInitial(() -> SERVER.getClient());
+
+    protected static final FileSystemProvider fsProvider = new K8SFileSystemProvider() {
+
+        @Override
+        public KubernetesClient createKubernetesClient() {
+            return CLIENT_FACTORY.get();
+        }
+
+    };
+    
+    protected static FileStore fstore;
+
+    @BeforeClass
+    public static void setup() {
+        fstore = fsProvider.getFileSystem(URI.create("default:///")).getFileStores().iterator().next();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE).delete();
+        CLIENT_FACTORY.get().close();
+    }
+    
+    @Test
+    public void testRoot() throws URISyntaxException {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = fileSystem.getPath("/");
+        Map<String, String> ne = getFsObjNameElementLabel(root);
+        
+        List<Path> roots = StreamSupport.stream(fileSystem.getRootDirectories().spliterator(), false)
+                                        .collect(Collectors.toList());
+        assertThat(roots).asList().size().isEqualTo(1);
+        assertThat(roots.get(0)).isEqualTo(root);
+
+        /**
+         * Handling this hard coded dependency
+         * https://github.com/kiegroup/appformer/blob/92d05f8620fb775a9fdd96574273de2deda3d215/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/config/ConfigurationServiceImpl.java#L129
+         */
+        assertThat(root.toUri().toString().contains("/master@")).isTrue();
+        assertThat(root).isEqualTo(fileSystem.getPath("/path").getRoot());
+        assertThat(root).isEqualTo(fileSystem.getPath("/path").getParent());
+        assertThat(root.getRoot().equals(root)).isTrue();
+        assertThat(root.toString().equals("/")).isTrue();
+        assertThat(root.toRealPath().toString().equals("/")).isTrue();
+        assertThat(root.getParent()).isNull();
+        assertThat(root.getFileName()).isNull();
+        assertThat(root.getNameCount()).isEqualTo(0);
+        assertThat(root.iterator().hasNext()).isEqualTo(false);
+        assertThat(ne.size()).isEqualTo(0);
+        assertThat(getFileNameString(root).equals("/")).isTrue();
+    }
+
+    @Test
+    public void testInitRoot() {
+        final FileSystem fs = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = fs.getPath("/");
+        final Path testParentDir = fs.getPath("/.testParentDir");
+        final Path testDir = fs.getPath("/.testParentDir/.testInitRoot");
+        final Path rPath = fs.getPath("./../.testInitRoot");
+        
+        assertThat(root.getParent()).isNull();
+        assertThat(root.isAbsolute()).isTrue();
+
+        assertThat(rPath.isAbsolute()).isFalse();
+        assertThat(rPath.getRoot()).isNull();
+        
+        assertThat(testDir.isAbsolute()).isTrue();
+        assertThat(testDir.getParent()).isEqualTo(testParentDir);
+        assertThat(testDir.getRoot()).isEqualTo(root);
+        assertThat(testDir.getFileName()).isEqualTo(rPath.getFileName());
+        
+        Path aPath = ((K8SFileSystemProvider)fsProvider).toAbsoluteRealPath(rPath);
+        assertThat(aPath.getRoot()).isEqualTo(root);
+        assertThat(aPath.getParent()).isNotNull();
+        assertThat(aPath.isAbsolute()).isTrue();
+        assertThat(aPath.getFileName()).isEqualTo(rPath.getFileName());
+                                                  
+        assertThat(testDir.isAbsolute()).isTrue();
+        assertThat(testDir.getParent()).isEqualTo(testParentDir);
+        
+        assertThat(testParentDir.getParent()).isEqualTo(root);
+        assertThat(testParentDir).isEqualTo(((K8SFileSystemProvider)fsProvider).toAbsoluteRealPath(testParentDir));
+        
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemInitTest.class.getResourceAsStream("/test-k8sfs-dir-r-empty-configmap.yml"))
+                                                     .get());
+        assertThat(Files.exists(root)).isTrue();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+            ArrayList<Path> dirContent = Lists.newArrayList(stream);
+            assertThat(dirContent).asList().isEmpty();
+        }
+        
+        CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE).delete();
+        assertThat(Files.exists(root)).isFalse();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+            ArrayList<Path> dirContent = Lists.newArrayList(stream);
+            assertThat(dirContent).asList().isEmpty();
+        }
+        assertThat(Files.exists(root)).isTrue();
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), root).getData()).isNotNull();
+        
+        Files.createDirectory(testDir);
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(testParentDir)) {
+            ArrayList<Path> dirContent = Lists.newArrayList(stream);
+            assertThat(dirContent).asList().containsExactly(testDir);
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAmbiguousCM() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path file = fileSystem.getPath("/testDir/testFile");
+        
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemInitTest.class.getResourceAsStream("/test-k8sfs-file-configmap.yml"))
+                                                     .get());
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemInitTest.class.getResourceAsStream("/test-k8sfs-file-dup-configmap.yml"))
+                                                     .get());        
+        getFsObjCM(CLIENT_FACTORY.get(), file);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidFsObjCM() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final ConfigMap cm = CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemInitTest.class.getResourceAsStream("/test-k8sfs-file-invalid-configmap.yml"))
+                                                     .get();
+        getPathByFsObjCM((K8SFileSystem)fileSystem, cm);
+    }
+    
+    @Test
+    public void testFileStore() {
+        final K8SFileSystem fs = (K8SFileSystem)fsProvider.getFileSystem(URI.create("default:///"));
+        fs.lock();
+        fs.unlock();
+        assertThat(fs).isNotNull();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFileStoreGetTotalSpace() {
+        fstore.getTotalSpace();
+    }
+    
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFileStoreGetUsableSpace() {
+        fstore.getUsableSpace();
+    }
+    
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFileStoreGetUnallocatedSpace() {
+        fstore.getUnallocatedSpace();
+    }
+    
+    @Test(expected = UnsupportedOperationException.class)
+    public void testNewFileChannel() {
+        final FileSystem fs = fsProvider.getFileSystem(URI.create("default:///"));
+        fsProvider.newFileChannel(fs.getPath("/"), null);
+    }
+    
+    @Test
+    public void testGetFileStore() {
+        final FileSystem fs = fsProvider.getFileSystem(URI.create("default:///"));
+        FileStore fstore = fsProvider.getFileStore(fs.getPath("/"));
+        assertThat(K8SFileStore.class.isInstance(fstore)).isTrue();
+    }
+    
+    @Test(expected = FileAlreadyExistsException.class)
+    public void testCheckFileExistsThenThrow() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path dir = fileSystem.getPath("/testDir");
+
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemInitTest.class.getResourceAsStream("/test-k8sfs-dir-0-configmap.yml"))
+                                                     .get());
+        fsProvider.createDirectory(dir);
+    }
+    
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCopyDirShouldFail() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path source = fileSystem.getPath("/testDir");
+        final Path target = fileSystem.getPath("/testDir2");
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemInitTest.class.getResourceAsStream("/test-k8sfs-dir-0-configmap.yml"))
+                                                     .get());
+        fsProvider.copy(source, target);
+    }
+    
+    @Test
+    public void testReadAttributes() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path dir = fileSystem.getPath("/testDir");
+        
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemInitTest.class.getResourceAsStream("/test-k8sfs-dir-0-configmap.yml"))
+                                                     .get());
+        assertThat(fsProvider.readAttributes(dir, HiddenAttributes.class)).isNull();
+        assertThat(fsProvider.readAttributes(dir, BasicFileAttributes.class)).isNotNull();
+        assertThat(fsProvider.readAttributes(dir, BasicFileAttributes.class).isDirectory()).isTrue();
+        assertThat(fsProvider.readAttributes(dir, BasicFileAttributes.class).isRegularFile()).isFalse();
+        assertThat(fsProvider.readAttributes(dir, BasicFileAttributes.class).isSymbolicLink()).isFalse();
+        assertThat(fsProvider.readAttributes(dir, BasicFileAttributes.class).size()).isEqualTo(19);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemTest.java
@@ -1,0 +1,607 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.uberfire.java.nio.file.DirectoryStream;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Files;
+import org.uberfire.java.nio.file.InvalidPathException;
+import org.uberfire.java.nio.file.NoSuchFileException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+import org.uberfire.java.nio.fs.cloud.CloudClientConstants;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_ANNOTATION_FSOBJ_LAST_MODIFIED_TIMESTAMP_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_FSOBJ_CONTENT_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.CFG_MAP_LABEL_FSOBJ_TYPE_KEY;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.createOrReplaceFSCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.createOrReplaceParentDirFSCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getCreationTime;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjContentBytes;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getFsObjNameElementLabel;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getPathByFsObjCM;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getSize;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.isDirectory;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.isFile;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.validateAndBuildPathLabel;
+
+public class K8SFileSystemTest {
+
+    @ClassRule
+    public static KubernetesServer SERVER = new KubernetesServer(false, true);
+    // The default namespace for MockKubernetes Server is 'test'
+    protected static String TEST_NAMESPACE = "test";
+    protected static ThreadLocal<KubernetesClient> CLIENT_FACTORY =
+            ThreadLocal.withInitial(() -> SERVER.getClient());
+
+    protected static final FileSystemProvider fsProvider = new K8SFileSystemProvider() {
+
+            @Override
+            public KubernetesClient createKubernetesClient() {
+                return CLIENT_FACTORY.get();
+            }
+    };
+
+    protected String newFileWithContent(final Path newFile, final String testFileContent) throws IOException {
+        Files.createFile(newFile);
+        try (BufferedWriter writer = Files.newBufferedWriter(newFile, StandardCharsets.UTF_8)) {
+            writer.write(testFileContent, 0, testFileContent.length());
+        }
+        return testFileContent;
+    }
+
+    @BeforeClass
+    public static void setup() {
+        // Load testing KieServerState ConfigMap data into mock server from file
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemTest.class.getResourceAsStream("/test-k8sfs-dir-r-configmap.yml"))
+                                                     .get());
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemTest.class.getResourceAsStream("/test-k8sfs-dir-0-configmap.yml"))
+                                                     .get());
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemTest.class.getResourceAsStream("/test-k8sfs-file-configmap.yml"))
+                                                     .get());
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SFileSystemTest.class.getResourceAsStream("/test-k8sfs-dir-00-configmap.yml"))
+                                                     .get());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE).delete();
+        CLIENT_FACTORY.get().close();
+    }
+    
+    @Test
+    public void testSetup() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = fileSystem.getPath("/");
+        assertThat(root.getFileSystem().provider()).isEqualTo(fsProvider);
+    }
+
+    @Test
+    public void testGetCMByName() {
+        assertThat(CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                                 .withName("dummy").get()).isNull();
+        assertThat(CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                                 .withName("k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff35").get()).isNotNull();
+        assertThat(CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                                 .withName("k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff35").get()).isNotNull();
+    }
+    
+    @Test 
+    public void testCreateOrReplaceFSCM() throws IOException {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testDir = fileSystem.getPath("/testCreateOrReplaceFSCMDir");
+        final Path testFile = fileSystem.getPath("/testCreateOrReplaceFSCMDir/testCreateOrReplaceFSCMFile");
+        
+        // Create a new empty dir under root
+        createOrReplaceFSCM(CLIENT_FACTORY.get(), 
+                            testDir,
+                            createOrReplaceParentDirFSCM(CLIENT_FACTORY.get(), testDir, 0L, false),
+                            Collections.emptyMap(),
+                            true);
+        ConfigMap testDirCM = getFsObjCM(CLIENT_FACTORY.get(), testDir);
+        
+        ConfigMap rootCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff35").get();
+
+        // Check CM data of the empty dir
+        assertThat(testDirCM).isNotNull();
+        assertThat(testDirCM.getMetadata().getLabels().get("k8s.fs.nio.java.uberfire.org/fsobj-name-0"))
+                                                    .isEqualTo("testCreateOrReplaceFSCMDir");
+        assertThat(testDirCM.getMetadata().getLabels().get(CFG_MAP_LABEL_FSOBJ_TYPE_KEY))
+                                                    .isEqualTo(K8SFileSystemObjectType.DIR.toString());
+        assertThat(testDirCM.getMetadata().getAnnotations().get(CFG_MAP_ANNOTATION_FSOBJ_SIZE_KEY))
+                                                    .isEqualTo("0");
+        assertThat(testDirCM.getData().isEmpty()).isTrue();
+        
+        // Check the ref-link to the root CM
+        assertThat(testDirCM.getMetadata().getOwnerReferences().get(0).getKind())
+            .isEqualTo(rootCM.getKind());
+        assertThat(testDirCM.getMetadata().getOwnerReferences().get(0).getName())
+            .isEqualTo(rootCM.getMetadata().getName());
+        
+        // Create new file followed by testing write to and read from the file
+        String testFileContent = "Hello World";
+        newFileWithContent(testFile, testFileContent);
+        
+        ConfigMap newDirCM = getFsObjCM(CLIENT_FACTORY.get(), fileSystem.getPath("/testCreateOrReplaceFSCMDir"));
+        ConfigMap newFileCM = getFsObjCM(CLIENT_FACTORY.get(), testFile);
+        
+        assertThat(newDirCM).isNotNull();
+        assertThat(newFileCM).isNotNull();
+        assertThat(newDirCM.getMetadata().getAnnotations().get(CFG_MAP_ANNOTATION_FSOBJ_LAST_MODIFIED_TIMESTAMP_KEY))
+            .isNotNull();
+        assertThat(newFileCM.getMetadata().getAnnotations().get(CFG_MAP_ANNOTATION_FSOBJ_LAST_MODIFIED_TIMESTAMP_KEY))
+            .isNotNull();
+        assertThat(newFileCM.getData().get(CFG_MAP_FSOBJ_CONTENT_KEY)).isEqualTo(testFileContent);
+        assertThat(Files.size(testFile)).isEqualTo(testFileContent.length());
+    }
+
+    @Test
+    public void testGetFsObjCM() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = fileSystem.getPath("/");
+        final Path dir = fileSystem.getPath("/testDir");
+        final Path file = fileSystem.getPath("/testDir/testFile");
+        
+        ConfigMap rootCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff35").get();
+        ConfigMap dirCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff36").get();
+        ConfigMap fileCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff35").get();
+        
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), root)).isEqualTo(rootCM);
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), dir)).isEqualTo(dirCM);
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), file)).isEqualTo(fileCM);
+    }
+
+    @Test
+    public void testGetFsObjContentBytes() {
+        ConfigMap fileCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff35").get();
+        
+        String fileContent = new String(getFsObjContentBytes(fileCM), 
+                                        Charset.forName(CloudClientConstants.ENCODING));
+        assertThat(fileContent).isEqualTo("This is a test file");
+    }
+    
+    @Test
+    public void testGetFsObjNameElement() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path aFile = fileSystem.getPath("/testDir/../testDir/./testFile");
+        Map<String, String> ne = getFsObjNameElementLabel(((K8SFileSystemProvider)fsProvider).toAbsoluteRealPath(aFile));
+        assertThat(ne.size()).isEqualTo(2);
+        assertThat(ne.containsValue("testDir")).isTrue();
+        assertThat(ne.containsValue("testFile")).isTrue();
+    }
+
+    @Test
+    public void testGetSize() {
+        ConfigMap cfm = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                                      .withName("k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff35").get();
+        assertThat(getSize(cfm)).isEqualTo(19);
+    }
+
+    @Test
+    public void testGetCreationTime() {
+        ConfigMap cfm = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                                      .withName("k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff35").get();
+        assertThat(getCreationTime(cfm)).isEqualTo(0);
+    }
+
+    @Test
+    public void testGetPathByFsObjCM() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path f = kfs.getPath("/testDir/testFile");
+
+        assertThat(f.getRoot()).isNotNull();
+        assertThat(f.getNameCount()).isEqualTo(2);
+        assertThat(f.getParent()).isEqualTo(kfs.getPath("/testDir"));
+        assertThat(f.getName(0).toString()).isEqualTo("testDir");
+        assertThat(f.getName(1).toString()).isEqualTo("testFile");
+        assertThat(f.toUri().toString()).isEqualTo(fsProvider.getScheme() + ":///testDir/testFile");
+        
+        ConfigMap rootCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff35").get();
+        ConfigMap dirCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff36").get();
+        ConfigMap fileCM = CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE)
+                .withName("k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff35").get();
+        
+        assertThat(getPathByFsObjCM(kfs, rootCM)).isEqualTo(kfs.getPath("/"));
+        assertThat(getPathByFsObjCM(kfs, dirCM)).isEqualTo(kfs.getPath("/testDir"));
+        assertThat(getPathByFsObjCM(kfs, fileCM)).isEqualTo(kfs.getPath("/testDir/testFile"));
+    }
+
+    @Test
+    public void testIsFile() {
+        ConfigMap cfm = CLIENT_FACTORY.get()
+                                      .configMaps()
+                                      .load(K8SFileSystemTest.class.getResourceAsStream("/test-k8sfs-file-configmap.yml"))
+                                      .get();
+        assertThat(isFile(cfm)).isTrue();
+        assertThat(isDirectory(cfm)).isFalse();
+    }
+
+    @Test
+    public void testIsDir() {
+        ConfigMap cfm = CLIENT_FACTORY.get()
+                                      .configMaps()
+                                      .load(K8SFileSystemTest.class.getResourceAsStream("/test-k8sfs-dir-0-configmap.yml"))
+                                      .get();
+        assertThat(isFile(cfm)).isFalse();
+        assertThat(isDirectory(cfm)).isTrue();
+    }
+
+    @Test
+    public void testFileMetadata() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path d = kfs.getPath("/testDir");
+        final Path f = kfs.getPath("/testDir/testFile");
+        final Path e = kfs.getPath("/doesNotExist");
+        
+        assertThat(Files.exists(e)).isFalse();
+        assertThat(Files.notExists(e)).isTrue();
+        assertThat(Files.isDirectory(d)).isTrue();
+        assertThat(Files.isRegularFile(d)).isFalse();
+        assertThat(Files.isDirectory(f)).isFalse();
+        assertThat(Files.isRegularFile(f)).isTrue();
+        
+        assertThat(Files.isReadable(f)).isTrue();
+        assertThat(Files.isWritable(f)).isTrue();
+        assertThat(Files.isExecutable(f)).isFalse();
+    }
+    
+    @Test
+    public void testDelete() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path f = kfs.getPath("/testDeleteFile");
+
+        String testFileContent = "Hello World";
+        newFileWithContent(f, testFileContent);
+
+        assertThat(Files.exists(f)).isTrue();
+        Files.delete(f);
+        assertThat(Files.exists(f)).isFalse();
+    }
+
+    @Test(expected = NoSuchFileException.class)
+    public void testDeleteNotExistingFile() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path f = kfs.getPath("/testDeleteNotExistingFile");
+
+        Files.delete(f);
+    }
+
+    @Test
+    public void testDeleteIfExists() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path f = kfs.getPath("/testDeleteIfExists");
+
+        assertThat(Files.deleteIfExists(f)).isFalse();
+
+        String testFileContent = "Hello World";
+        newFileWithContent(f, testFileContent);
+
+        assertThat(Files.exists(f)).isTrue();
+        assertThat(Files.deleteIfExists(f)).isTrue();
+        assertThat(Files.exists(f)).isFalse();
+    }
+
+    @Test
+    public void testCopy() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path src = kfs.getPath("/testCopySrc");
+        final Path target = kfs.getPath("/testCopyTarget");
+        
+        String testFileContent = "Test copy capability";
+        newFileWithContent(src, testFileContent);
+        
+        Files.copy(src, target);
+        
+        assertThat(Files.exists(target)).isTrue();
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), target).getData()
+                   .get(CFG_MAP_FSOBJ_CONTENT_KEY)).isEqualTo(testFileContent);
+    }
+
+    @Test
+    public void testMove() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path src = kfs.getPath("/testMoveSrc");
+        final Path target = kfs.getPath("/testMoveTarget");
+        
+        String testFileContent = "Test move capability";
+        newFileWithContent(src, testFileContent);
+        
+        Files.move(src, target);
+        
+        assertThat(Files.notExists(src)).isTrue();
+        assertThat(Files.exists(target)).isTrue();
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), target).getData()
+                   .get(CFG_MAP_FSOBJ_CONTENT_KEY)).isEqualTo(testFileContent);
+    }
+
+    @Test
+    public void testCreateAndReadDir() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testDir = kfs.getPath("/testDir");
+        final Path testFile = kfs.getPath("/testDir/testFile");
+
+        assertThat(Files.exists(testDir)).isTrue();
+        assertThat(Files.isDirectory(testDir)).isTrue();
+        assertThat(Files.isHidden(testDir)).isFalse();
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(testDir)) {
+            ArrayList<Path> dirContent = Lists.newArrayList(stream);
+            assertThat(dirContent).asList().containsExactly(testFile);
+        }
+    }
+
+    @Test
+    public void testCreateAndReadHiddenDir() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path aDir = kfs.getPath("/.testCreateAndReadDir");
+        final Path root = aDir.getRoot();
+        
+        Files.createDirectory(aDir);
+        
+        assertThat(Files.exists(aDir)).isTrue();
+        assertThat(Files.isDirectory(aDir)).isTrue();
+        assertThat(Files.isHidden(aDir)).isTrue();
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+            ArrayList<Path> dirContent = Lists.newArrayList(stream);
+            assertThat(dirContent).asList().contains(aDir);
+        }
+    }
+
+    @Test
+    public void testCreateDuplicateDirectory() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testDir = kfs.getPath("/testCreateDuplicateDirectory");
+
+        Files.createDirectory(testDir);
+
+        assertThat(Files.exists(testDir)).isTrue();
+        assertThat(Files.isDirectory(testDir)).isTrue();
+
+        assertThat(catchThrowable(() -> Files.createDirectory(testDir)))
+            .isInstanceOf(org.uberfire.java.nio.file.FileAlreadyExistsException.class);
+    }
+
+    @Test
+    public void testOverwriteFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testFile = kfs.getPath("/testOverwriteFile");
+        final String content = "Large content, blah, blah, blah...";
+        final String smallerContent = "Small";
+        
+        newFileWithContent(testFile, content);
+        assertThat(Files.exists(testFile)).isTrue();
+
+        try (BufferedWriter writer = Files.newBufferedWriter(testFile, Charset.forName("UTF-8"))) {
+            writer.write(smallerContent, 0, smallerContent.length());
+        }
+        
+        StringBuffer sb = new StringBuffer();
+        try (BufferedReader reader = Files.newBufferedReader(testFile, Charset.forName("UTF-8"))) {
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        }
+        
+        assertThat(sb.toString()).isEqualTo(smallerContent);
+        
+        try (BufferedWriter writer = Files.newBufferedWriter(testFile, Charset.forName("UTF-8"))) {
+            writer.write(content, 0, content.length());
+        }
+        
+        sb = new StringBuffer();
+        try (BufferedReader reader = Files.newBufferedReader(testFile, Charset.forName("UTF-8"))) {
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        }
+        
+        assertThat(sb.toString()).isEqualTo(content);
+    }
+    
+    @Test 
+    public void testParentDirShouldBeUpdatedAfterDelete() throws IOException {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = fileSystem.getPath("/");
+        final Path testDir = fileSystem.getPath("/testParentDirShouldBeUpdatedAfterDeleteDir");
+        final Path testFile = fileSystem.getPath("/testParentDirShouldBeUpdatedAfterDeleteDir/testParentDirShouldBeUpdatedAfterDeleteFile");
+        
+        newFileWithContent(testFile, "I'm here");
+        assertThat(Files.deleteIfExists(testFile)).isTrue();
+        assertThat(Files.size(testDir)).isEqualTo(0);
+        
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), testDir).getData().isEmpty()).isTrue();
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+            ArrayList<Path> dirContent = Lists.newArrayList(stream);
+            assertThat(dirContent).asList().contains(testDir);
+        }
+        
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(testDir)) {
+            ArrayList<Path> dirContent = Lists.newArrayList(stream);
+            assertThat(dirContent).asList().isEmpty();
+        }
+    }   
+    
+    @Test
+    public void testFileNameValidation() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path invalid = kfs.getPath("/#weirdFileName$@#^&*");
+        final Path hidden = kfs.getPath("/.testFileNameValidation");
+        final Path tooLongFileName = kfs.getPath("/testFileNameValidationForTooLongFileNameWhichIsLongerThanSixtyThreeCharacters");
+        
+        assertThat(catchThrowable(() -> validateAndBuildPathLabel(new HashMap<String, String>(), invalid.getFileName())))
+            .isInstanceOf(InvalidPathException.class);
+        assertThat(catchThrowable(() -> validateAndBuildPathLabel(new HashMap<String, String>(), hidden.getFileName())))
+            .isNull();
+        
+        assertThat(catchThrowable(() -> newFileWithContent(invalid, "blah...")))
+            .isInstanceOf(org.uberfire.java.nio.IOException.class)
+            .hasRootCauseInstanceOf(InvalidPathException.class);
+        assertThat(catchThrowable(() -> newFileWithContent(tooLongFileName, "blah...")))
+            .isInstanceOf(org.uberfire.java.nio.IOException.class)
+            .hasRootCauseInstanceOf(InvalidPathException.class);
+    }
+    
+    @Test
+    public void testCreateHiddenFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path hidden = kfs.getPath("/.testCreateHiddenDir/.testCreateHiddenFile");
+        
+        newFileWithContent(hidden, "blah...");
+        ConfigMap cm = getFsObjCM(CLIENT_FACTORY.get(), hidden);
+        assertThat(Files.exists(hidden)).isTrue();
+        assertThat(Files.isHidden(hidden)).isTrue();
+        assertThat(getPathByFsObjCM(kfs, cm)).isEqualTo(hidden); 
+    }
+
+    @Test
+    public void testCopyHiddenFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path src = kfs.getPath("/.testCopyHiddenFileSrcFile");
+        final Path target = kfs.getPath("/.testCopyHiddenFileTargetFile");
+
+        String testFileContent = "Test copy capability";
+        newFileWithContent(src, testFileContent);
+
+        Files.copy(src, target);
+
+        assertThat(Files.exists(target)).isTrue();
+        assertThat(Files.isHidden(target)).isTrue();
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), target).getData()
+                   .get(CFG_MAP_FSOBJ_CONTENT_KEY)).isEqualTo(testFileContent);
+    }
+
+    @Test
+    public void testMoveHiddenFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path src = kfs.getPath("/.testMoveHiddenFileSrc");
+        final Path targetPublic = kfs.getPath("/testMoveHiddenFileTargetPublic");
+        final Path targetHidden = kfs.getPath("/.testMoveHiddenFileTargetHidden");
+
+        String testFileContent = "Test move capability";
+        newFileWithContent(src, testFileContent);
+
+        Files.move(src, targetPublic);
+
+        assertThat(Files.notExists(src)).isTrue();
+        assertThat(Files.exists(targetPublic)).isTrue();
+        assertThat(Files.isHidden(targetPublic)).isFalse();
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), targetPublic).getData()
+                   .get(CFG_MAP_FSOBJ_CONTENT_KEY)).isEqualTo(testFileContent);
+
+        Files.move(targetPublic, targetHidden);
+
+        assertThat(Files.notExists(targetPublic)).isTrue();
+        assertThat(Files.exists(targetHidden)).isTrue();
+        assertThat(Files.isHidden(targetHidden)).isTrue();
+        assertThat(getFsObjCM(CLIENT_FACTORY.get(), targetHidden).getData()
+                   .get(CFG_MAP_FSOBJ_CONTENT_KEY)).isEqualTo(testFileContent);
+    }
+
+    @Test
+    public void testReadNotExistingFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testFile = kfs.getPath("/testReadNotExistingFile");
+
+        assertThat(catchThrowable(() -> Files.newBufferedReader(testFile, Charset.forName("UTF-8"))))
+            .isInstanceOf(org.uberfire.java.nio.file.NoSuchFileException.class);
+    }
+
+    @Test
+    public void testIsHiddenNotExistingFile() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testFile = kfs.getPath("/testIsHiddenNotExistingFile");
+
+        assertThat(catchThrowable(() -> Files.isHidden(testFile)))
+            .isInstanceOf(org.uberfire.java.nio.IOException.class);
+    }
+
+    @Test
+    public void testIsHiddenManyNestedFolders() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testFolder11 = kfs.getPath("/testIsHiddenManyNestedFolders/1/2/3/4/5/6/7/8/9/10/11");
+        final Path testFolder12 = kfs.getPath("/testIsHiddenManyNestedFolders/1/2/3/4/5/6/7/8/9/10/11/.12");
+
+        Files.createDirectory(testFolder12);
+
+        assertThat(Files.isHidden(testFolder11)).isFalse();
+        assertThat(Files.isHidden(testFolder12)).isTrue();
+    }
+
+    @Test
+    public void testGetDirectoryContentManyNestedFolders() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path testFolder11 = kfs.getPath("/testGetDirectoryContentManyNestedFolders/1/2/3/4/5/6/7/8/9/.10/11");
+        final Path testFolder12 = kfs.getPath("/testGetDirectoryContentManyNestedFolders/1/2/3/4/5/6/7/8/9/.10/11/.12");
+
+        Files.createDirectory(testFolder12);
+
+        Path[] directoryContent = ((K8SFileSystemProvider)fsProvider).getDirectoryContent(testFolder11);
+        assertThat(directoryContent).contains(testFolder12);
+    }
+    
+    
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SWatchServiceTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SWatchServiceTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watcher.Action;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.uberfire.java.nio.base.WatchContext;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Files;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.StandardWatchEventKind;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.uberfire.java.nio.fs.k8s.K8SFileSystemConstants.K8S_FS_NO_IMPL;
+
+public class K8SWatchServiceTest {
+
+    @ClassRule
+    public static KubernetesServer SERVER = new KubernetesServer(false, true);
+    // The default namespace for MockKubernetes Server is 'test'
+    protected static String TEST_NAMESPACE = "test";
+    protected static ThreadLocal<KubernetesClient> CLIENT_FACTORY =
+            ThreadLocal.withInitial(() -> SERVER.getClient());
+
+    protected static final FileSystemProvider fsProvider = new K8SFileSystemProvider() {
+
+        @Override
+        public KubernetesClient createKubernetesClient() {
+            return CLIENT_FACTORY.get();
+        }
+
+    };
+
+    @BeforeClass
+    public static void setup() {
+        // Load testing KieServerState ConfigMap data into mock server from file
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SWatchServiceTest.class.getResourceAsStream("/test-k8sfs-dir-r-configmap.yml"))
+                                                     .get());
+        CLIENT_FACTORY.get()
+                      .configMaps()
+                      .inNamespace(TEST_NAMESPACE)
+                      .createOrReplace(CLIENT_FACTORY.get().configMaps()
+                                                     .load(K8SWatchServiceTest.class.getResourceAsStream("/test-k8sfs-dir-0-configmap.yml"))
+                                                     .get());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE).delete();
+        CLIENT_FACTORY.get().close();
+    }
+    
+    @Test
+    public void testSetup() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = fileSystem.getPath("/");
+        final Path dir = fileSystem.getPath("/testDir");
+        
+        assertThat(root.getFileSystem().provider()).isEqualTo(fsProvider);
+        assertThat(Files.exists(root)).isTrue();
+        assertThat(Files.exists(dir)).isTrue();
+        assertThat(Files.isDirectory(root)).isTrue();
+        assertThat(Files.isDirectory(root)).isTrue();
+    }
+
+    @Test
+    public void testWatchServiceOpenAndClose() throws URISyntaxException {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        final WatchService ws = fileSystem.newWatchService();
+        // MockWebServer does not support websocket; as a result, WatchService will shutdown itself.
+        assertThat(ws.isClose()).isFalse();
+        await().until(ws::isClose);
+        ws.close();
+        assertThat(ws.isClose()).isTrue();
+    }
+    
+    @Test
+    public void testMapActionToKind() {
+        assertThat(K8SFileSystemUtils.mapActionToKind(Action.ERROR).isPresent()).isFalse();
+        assertThat(K8SFileSystemUtils.mapActionToKind(Action.ADDED).get())
+            .isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+        assertThat(K8SFileSystemUtils.mapActionToKind(Action.MODIFIED).get())
+            .isEqualTo(StandardWatchEventKind.ENTRY_MODIFY);
+        assertThat(K8SFileSystemUtils.mapActionToKind(Action.DELETED).get())
+            .isEqualTo(StandardWatchEventKind.ENTRY_DELETE);
+    }
+    
+    @Test
+    public void testWatchKey() {
+        final K8SFileSystem fileSystem = (K8SFileSystem)fsProvider.getFileSystem(URI.create("default:///"));
+        final Path dir = fileSystem.getPath("/testDir");
+        
+        boolean isWSClosed = false;
+        K8SWatchKey wk = new K8SWatchKey(new K8SWatchService(fileSystem) {
+
+            @Override
+            public boolean isClose() {
+                return isWSClosed;
+            }
+        }, dir);
+        
+        assertThat(wk.isValid()).isTrue();
+        assertThat(wk.pollEvents()).asList().isEmpty();
+        assertThat(wk.watchable()).isEqualTo(dir);
+        assertThat(wk.postEvent(StandardWatchEventKind.ENTRY_CREATE)).isTrue();
+        assertThat(wk.isQueued()).isFalse();
+        
+        wk.signal();
+        assertThat(wk.isQueued()).isTrue();
+        assertThat(wk.reset()).isTrue();
+        assertThat(wk.pollEvents()).asList().isEmpty();
+        assertThat(wk.isQueued()).isFalse();
+        
+        assertThat(wk.postEvent(StandardWatchEventKind.ENTRY_DELETE)).isTrue();
+        wk.signal();
+        assertThat(wk.isQueued()).isTrue();
+        
+        List<WatchEvent<?>> eventList = wk.pollEvents();
+        assertThat(eventList.size()).isEqualTo(1);
+        
+        WatchEvent<?> event = eventList.get(0);
+        assertThat(event.kind()).isEqualTo(StandardWatchEventKind.ENTRY_DELETE);
+        assertThat(event.count()).isEqualTo(1);
+        WatchContext wc = (WatchContext) event.context();
+        assertThat(wc.getPath()).isEqualTo(dir.getFileName());
+        assertThat(wc.getOldPath()).isEqualTo(dir.getFileName());
+        assertThat(wc.getSessionId()).isEqualTo(K8S_FS_NO_IMPL);
+        assertThat(wc.getMessage()).isEqualTo(K8S_FS_NO_IMPL);
+        assertThat(wc.getUser()).isEqualTo(K8S_FS_NO_IMPL);
+        
+        wk.cancel();
+        assertThat(wk.isValid()).isFalse();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/SeekableInMemoryByteChannelTestCase.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/SeekableInMemoryByteChannelTestCase.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.java.nio.IOException;
+
+
+public class SeekableInMemoryByteChannelTestCase {
+
+    @SuppressWarnings("unused")
+    private static final Logger log = Logger.getLogger(SeekableInMemoryByteChannelTestCase.class.getName());
+
+    private static final String CONTENTS_SMALLER_BUFFER = "Small";
+    private static final String CONTENTS_BIGGER_BUFFER = "Large............";
+
+    private static final String UTF8 = "UTF-8";
+
+    private SeekableInMemoryByteChannel channel;
+
+    private ByteBuffer smallerBuffer;
+    private ByteBuffer biggerBuffer;
+
+    @Before
+    public void init() throws UnsupportedEncodingException {
+        this.channel = new SeekableInMemoryByteChannel();
+        smallerBuffer = ByteBuffer.wrap(CONTENTS_SMALLER_BUFFER.getBytes(UTF8));
+        biggerBuffer = ByteBuffer.wrap(CONTENTS_BIGGER_BUFFER.getBytes(UTF8));
+    }
+
+    @After
+    public void closeChannel() throws IOException {
+        if (this.channel.isOpen()) {
+            this.channel.close();
+        }
+    }
+
+    @Test(expected = org.uberfire.java.nio.IOException.class)
+    public void readAfterCloseThrowsException() throws IOException {
+        this.channel.close();
+        this.channel.read(ByteBuffer.wrap(new byte[] {}));
+    }
+
+    @Test(expected = org.uberfire.java.nio.IOException.class)
+    public void writeAfterCloseThrowsException() throws IOException {
+        this.channel.close();
+        this.channel.write(ByteBuffer.wrap(new byte[] {}));
+    }
+
+    @Test
+    public void isOpenTrue() throws IOException {
+        Assert.assertTrue("Channel should report open before it's closed", this.channel.isOpen());
+    }
+
+    @Test
+    public void isOpenFalseAfterClose() throws IOException {
+        this.channel.close();
+        Assert.assertFalse("Channel should report not open after close", this.channel.isOpen());
+    }
+
+    @Test
+    public void positionInit0() throws IOException {
+        Assert.assertEquals("Channel should init to position 0", 0, this.channel.position());
+    }
+
+    @Test
+    public void sizeInit0() throws IOException {
+        Assert.assertEquals("Channel should init to size 0", 0, this.channel.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void readRequiresBuffer() throws IOException {
+        this.channel.read(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void writeRequiresBuffer() throws IOException {
+        this.channel.write(null);
+    }
+
+    @Test
+    public void read() throws IOException, java.io.IOException {
+        this.channel.write(smallerBuffer);
+        final int newPosition = 2;
+        final byte[] contents = new byte[2];
+        // Read 2 bytes from the new position
+        final int numBytesRead = this.channel.position(newPosition).read(ByteBuffer.wrap(contents));
+        final String expected = "al";
+        final String contentsRead = new String(contents, UTF8);
+        Assert.assertEquals("Read should report correct number of bytes read", contents.length, numBytesRead);
+        Assert.assertEquals("Channel should respect explicit position during reads", expected, contentsRead);
+    }
+
+    @Test
+    public void getContent() throws IOException, java.io.IOException {
+        this.channel.write(smallerBuffer);
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(this.channel.getContent()));
+        final String contents = reader.readLine();
+        Assert.assertEquals("Contents read were not as expected", CONTENTS_SMALLER_BUFFER, contents);
+    }
+
+    @Test
+    public void readDestinationBiggerThanChannel() throws IOException, java.io.IOException {
+        this.channel.write(smallerBuffer);
+        final ByteBuffer destination = biggerBuffer;
+        Assert.assertTrue("Test setup incorrect, should be trying to read into a buffer greater than our size",
+            destination.remaining() > this.channel.size());
+        // Read more bytes than we currently have size
+        final int numBytesRead = this.channel.position(0).read(destination);
+        Assert.assertEquals("Read to a buffer greater than our size should read only up to our size",
+            this.channel.size(), numBytesRead);
+    }
+
+    @Test
+    public void nothingToRead() throws IOException, java.io.IOException {
+        this.channel.write(smallerBuffer);
+        // Read a byte from a position past the size
+        final int numBytesRead = this.channel.position(this.channel.size() + 3).read(ByteBuffer.wrap(new byte[1]));
+        Assert.assertEquals("Read on position > size should return -1", -1, numBytesRead);
+    }
+
+    @Test
+    public void write() throws IOException, java.io.IOException {
+        this.channel.write(smallerBuffer);
+        final int newPosition = 2;
+        final int numBytesWritten = this.channel.position(newPosition).write(ByteBuffer.wrap("DR".getBytes(UTF8)));
+        // Read 2 bytes from the new position
+        final byte[] contents = new byte[2];
+        this.channel.position(newPosition).read(ByteBuffer.wrap(contents));
+        final String expected = "DR";
+        final String read = new String(contents, UTF8);
+        Assert.assertEquals("Write should report correct number of bytes written", 2, numBytesWritten);
+        Assert.assertEquals("Channel should respect explicit position during writes", expected, read);
+    }
+
+    @Test
+    public void writeWithPositionPastSize() throws IOException, java.io.IOException {
+        this.channel.write(smallerBuffer);
+        smallerBuffer.clear();
+        final int gap = 5;
+        // Write again, after a gap past the current size
+        this.channel.position(this.channel.size() + gap).write(smallerBuffer);
+        smallerBuffer.clear();
+        Assert.assertEquals("Channel size should be equal to the size of the writes we put in, plus "
+            + "the gap when we set the position tpo be greater than the size", smallerBuffer.remaining() * 2 + gap,
+            this.channel.size());
+    }
+
+    @Test
+    public void positionSetPastSize() throws IOException {
+        final int newPosition = 30;
+        this.channel.position(newPosition);
+        Assert.assertEquals("Channel should be able to be set past size", newPosition, this.channel.position());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativePositionProhibited() throws IOException {
+        this.channel.position(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void exceedMaxIntegerPositionProhibited() throws IOException {
+        final long newPosition = Integer.MAX_VALUE + 1L;
+        Assert.assertTrue("Didn't set up new position to be out of int bounds", newPosition > Integer.MAX_VALUE);
+        this.channel.position(newPosition); // Exception expected
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeTruncateProhibited() throws IOException {
+        this.channel.truncate(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void exceedMaxIntegerTruncateProhibited() throws IOException {
+        final long truncateValue = Integer.MAX_VALUE + 1L;
+        Assert.assertTrue("Didn't set up new truncate to be out of int bounds", truncateValue > Integer.MAX_VALUE);
+        this.channel.truncate(truncateValue); // Exception expected
+    }
+
+    @Test
+    public void size() throws IOException {
+        this.channel.write(smallerBuffer);
+        Assert.assertEquals("Channel should report correct size", this.smallerBuffer.clear().remaining(),
+            this.channel.size());
+    }
+
+    @Test
+    public void truncate() throws IOException {
+        this.channel.write(smallerBuffer);
+        final int newSize = (int) this.channel.size() - 3;
+        this.channel.truncate(newSize);
+        // Correct size?
+        Assert.assertEquals("Channel should report correct size after truncate", newSize, this.channel.size());
+        // Correct position?
+        Assert.assertEquals("Channel should report adjusted position after truncate", newSize, this.channel.position());
+    }
+
+    @Test
+    public void truncateLargerThanSizeRepositions() throws IOException {
+        this.channel.write(smallerBuffer);
+        final int oldSize = (int) this.channel.size();
+        final int newSize = oldSize + 3;
+        this.channel.truncate(newSize);
+        // Size unchanged?
+        Assert.assertEquals("Channel should report unchanged size after truncate to bigger value", oldSize,
+            this.channel.size());
+        // Correct position, beyond size?
+        Assert.assertEquals("Channel should report unchanged position after truncate to bigger value", oldSize,
+            this.channel.position());
+    }
+
+    @Test(expected = IOException.class)
+    public void exceedMaxCapacityProhibited() throws IOException {
+        this.channel = new SeekableInMemoryByteChannel(5);
+        this.channel.write(biggerBuffer); // Exception expected
+    }
+    
+    @Test
+    public void emptyContentAfterClose() {
+        this.channel.write(smallerBuffer);
+        Assert.assertTrue(this.channel.toString().length() > 0);
+        this.channel.close();
+        Assert.assertTrue(this.channel.toString().length() == 0);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void readFromNullDestination() {
+        this.channel.read(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void writeToNullSource() {
+        this.channel.write(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidPosition() {
+        this.channel.position(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidTruncate() {
+        this.channel.truncate(-1);
+    }
+
+    @Test(expected = IOException.class)
+    public void writeAfterClose() {
+        this.channel.close();
+        this.channel.write(ByteBuffer.wrap(new byte[0]));
+    }
+
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/integrationtests/K8SFileSystemProviderIntegrationTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/integrationtests/K8SFileSystemProviderIntegrationTest.java
@@ -1,0 +1,508 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.k8s.integrationtests;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.commons.io.IOUtils;
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.uberfire.java.nio.base.WatchContext;
+import org.uberfire.java.nio.file.FileAlreadyExistsException;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Files;
+import org.uberfire.java.nio.file.NoSuchFileException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.StandardWatchEventKind;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchKey;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+import org.uberfire.java.nio.fs.k8s.K8SFileSystem;
+import org.uberfire.java.nio.fs.k8s.K8SFileSystemProvider;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class K8SFileSystemProviderIntegrationTest {
+
+    private static final String KUBERNETES_MASTER_API_URL = System.getProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY);
+    private static final String KUBERNETES_MASTER_API_TOKEN = System.getProperty(Config.KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY);
+    private static final String TEST_NAMESPACE = "k8sfsp-test";
+    private static KubernetesClient client;
+
+    protected static final FileSystemProvider fsProvider = new K8SFileSystemProvider();
+
+    @BeforeClass
+    public static void setup() {
+        System.setProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY, TEST_NAMESPACE);
+
+        Config config = new ConfigBuilder()
+                .withMasterUrl(KUBERNETES_MASTER_API_URL)
+                .withOauthToken(KUBERNETES_MASTER_API_TOKEN)
+                .withTrustCerts(true)
+                .withNamespace(TEST_NAMESPACE)
+                .build();
+        client = new DefaultKubernetesClient(config);
+        client.namespaces().createOrReplaceWithNew().withNewMetadata()
+                                                    .withName(TEST_NAMESPACE)
+                                                    .endMetadata()
+                                                    .done();
+    }
+
+    @After
+    public void cleanNamespace() {
+        client.configMaps().inNamespace(TEST_NAMESPACE).delete();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        client.namespaces().withName(TEST_NAMESPACE).delete();
+        client.close();
+        System.clearProperty(Config.KUBERNETES_NAMESPACE_SYSTEM_PROPERTY);
+    }
+
+    @Test
+    public void simpleRootFolderCreateDeleteTest() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        Path folderInRootFolder = fileSystem.getPath("/test");
+
+        assertThat(Files.exists(folderInRootFolder)).isFalse();
+        assertThat(Files.deleteIfExists(folderInRootFolder)).isFalse();
+        Files.createDirectory(folderInRootFolder);
+        assertThat(Files.deleteIfExists(folderInRootFolder)).isTrue();
+    }
+
+    @Test
+    public void simpleRootFileCreateDeleteTest() throws IOException {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        Path fileInRootFolder = fileSystem.getPath("/test.txt");
+
+        assertThat(Files.exists(fileInRootFolder)).isFalse();
+        assertThat(Files.deleteIfExists(fileInRootFolder)).isFalse();
+
+        createOrEditFile(fileInRootFolder, "Hello");
+        assertThat(Files.deleteIfExists(fileInRootFolder)).isTrue();
+    }
+
+    @Test
+    public void testDeleteRoot() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("k8s:///"));
+        final Path testDir = kfs.getPath("/.testDeleRootDir");
+        final Path testFile = kfs.getPath("/.testDeleRootDir/.testDeleRootDirFile");
+        final Path root = testFile.getRoot();
+
+        String testFileContent = "Hello World";
+        createOrEditFile(testFile, testFileContent);
+
+        assertThat(Files.exists(testDir)).isTrue();
+        Files.delete(root);
+        assertThat(Files.exists(testDir)).isFalse();
+        assertThat(Files.exists(testFile)).isFalse();
+    }
+    
+    @Test
+    public void testDeleteFolderWithFiles() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("k8s:///"));
+        final Path testDir = kfs.getPath("/testDir");
+        final Path testFirstFile = kfs.getPath("/testDir/testFirstFile");
+        final Path testSecondFile = kfs.getPath("/testDir/testSecondFile");
+
+        String testFileContent = "Hello World";
+        createOrEditFile(testFirstFile, testFileContent);
+        createOrEditFile(testSecondFile, testFileContent);
+
+        assertThat(Files.exists(testDir)).isTrue();
+        Files.delete(testDir);
+        assertThat(Files.exists(testDir)).isFalse();
+        assertThat(Files.exists(testFirstFile)).isFalse();
+        assertThat(Files.exists(testSecondFile)).isFalse();
+    }
+
+    @Test(expected = FileAlreadyExistsException.class)
+    public void simpleRootFolderCreateDuplicateFolderTest() {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        Path folderInRootFolder = fileSystem.getPath("/test");
+
+        Files.createDirectory(folderInRootFolder);
+        Files.createDirectory(folderInRootFolder);
+    }
+
+    @Test
+    public void simpleRootFileEditFileTest() throws IOException {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        Path fileInRootFolder = fileSystem.getPath("/test.txt");
+
+        createOrEditFile(fileInRootFolder, "Hello");
+        assertThat(readFile(fileInRootFolder)).isEqualTo("Hello");
+        createOrEditFile(fileInRootFolder, "Welcome");
+        assertThat(readFile(fileInRootFolder)).isEqualTo("Welcome");
+        createOrEditFile(fileInRootFolder, "Hi");
+        assertThat(readFile(fileInRootFolder)).isEqualTo("Hi");
+    }
+
+    @Test(expected = NoSuchFileException.class)
+    public void inputStreamFromNotExistingFileTest() throws IOException {
+        final FileSystem fileSystem = fsProvider.getFileSystem(URI.create("default:///"));
+        Path fileInRootFolder = fileSystem.getPath("/test.txt");
+
+        readFile(fileInRootFolder);
+    }
+
+    @Test
+    public void testWatchCreateDirectory() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path watchDir = kfs.getPath("/watchDir");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            watchDir.register(watcher);
+
+            // Check directory creation events, root is created first
+            Files.createDirectory(watchDir);
+            WatchKey createRootKey = watcher.poll(30, TimeUnit.SECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+
+            List<WatchEvent<?>> rootEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 1));
+            assertThat(rootEvents).asList().hasSize(1);
+
+            WatchEvent<?> firstEvent = rootEvents.get(0);
+            assertThat(firstEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstEvent.context()).getPath()).isNull();
+
+            // Watched directory is created then
+            WatchKey createWatchDirKey = watcher.poll();
+            assertThat(createWatchDirKey.isValid()).isTrue();
+            assertThat(createWatchDirKey.watchable()).isEqualTo(watchDir);
+
+            List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 1));
+            assertThat(watchDirEvents).asList().hasSize(1);
+
+            WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);
+            assertThat(firstWatchDirEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstWatchDirEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstWatchDirEvent.context()).getPath()).isEqualTo(watchDir.getFileName());
+
+            // No more events
+            assertThat(watcher.poll()).isNull();
+        }
+    }
+
+    @Test
+    public void testWatchCreateFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path fileInRootFolder = kfs.getPath("/.test.txt");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            fileInRootFolder.register(watcher);
+
+            // Check file creation events, root is created first
+            createOrEditFile(fileInRootFolder, "Hi");
+            WatchKey createRootKey = watcher.poll(30, TimeUnit.SECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+
+            List<WatchEvent<?>> rootEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 1));
+            assertThat(rootEvents).asList().hasSize(1);
+
+            WatchEvent<?> firstEvent = rootEvents.get(0);
+            assertThat(firstEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstEvent.context()).getPath()).isNull();
+
+            // Watched file is created then
+            WatchKey createWatchDirKey = watcher.poll();
+            assertThat(createWatchDirKey.isValid()).isTrue();
+            assertThat(createWatchDirKey.watchable()).isEqualTo(fileInRootFolder);
+
+            List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 1));
+            assertThat(watchDirEvents).asList().hasSize(1);
+
+            WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);
+            assertThat(firstWatchDirEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstWatchDirEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstWatchDirEvent.context()).getPath()).isEqualTo(fileInRootFolder.getFileName());
+
+            // No more events
+            assertThat(watcher.poll()).isNull();
+        }
+    }
+
+    @Test
+    public void testWatchEditFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path fileInRootFolder = kfs.getPath("/test.txt");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            fileInRootFolder.register(watcher);
+
+            // Check file creation events, root is created first, also it is modified as folder tracks size of its content
+            createOrEditFile(fileInRootFolder, "Hi");
+            createOrEditFile(fileInRootFolder, "Welcome");
+            createOrEditFile(fileInRootFolder, "Hello");
+            WatchKey createRootKey = watcher.poll(30, TimeUnit.SECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+
+            List<WatchEvent<?>> rootEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 2));
+            assertThat(rootEvents).asList().hasSize(2);
+
+            WatchEvent<?> firstEvent = rootEvents.get(0);
+            assertThat(firstEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstEvent.context()).getPath()).isNull();
+
+            WatchEvent<?> secondEvent = rootEvents.get(1);
+            assertThat(secondEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_MODIFY);
+            assertThat(secondEvent.count()).isEqualTo(2);
+            assertThat(((WatchContext)secondEvent.context()).getPath()).isNull();
+
+            // Watched file is created and modified then
+            WatchKey createWatchDirKey = watcher.poll();
+            assertThat(createWatchDirKey.isValid()).isTrue();
+            assertThat(createWatchDirKey.watchable()).isEqualTo(fileInRootFolder);
+
+            List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 2));
+            assertThat(watchDirEvents).asList().hasSize(2);
+
+            WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);
+            assertThat(firstWatchDirEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstWatchDirEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstWatchDirEvent.context()).getPath()).isEqualTo(fileInRootFolder.getFileName());
+
+            WatchEvent<?> secondWatchDirEvent = watchDirEvents.get(1);
+            assertThat(secondWatchDirEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_MODIFY);
+            assertThat(secondWatchDirEvent.count()).isEqualTo(2);
+            assertThat(((WatchContext)secondWatchDirEvent.context()).getPath()).isEqualTo(fileInRootFolder.getFileName());
+
+            // No more events
+            assertThat(watcher.poll()).isNull();
+        }
+    }
+
+    @Test
+    public void testWatchDeleteFile() throws IOException {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path fileInRootFolder = kfs.getPath("/test.txt");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            fileInRootFolder.register(watcher);
+
+            // Check file creation events, root is created first, also it is modified as folder tracks size of its content
+            createOrEditFile(fileInRootFolder, "Hi");
+            assertThat(Files.deleteIfExists(fileInRootFolder)).isTrue();
+
+            WatchKey createRootKey = watcher.poll(30, TimeUnit.SECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+
+            List<WatchEvent<?>> rootEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 2));
+            assertThat(rootEvents).asList().hasSize(2);
+
+            WatchEvent<?> firstEvent = rootEvents.get(0);
+            assertThat(firstEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstEvent.context()).getPath()).isNull();
+
+            WatchEvent<?> secondEvent = rootEvents.get(1);
+            assertThat(secondEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_MODIFY);
+            assertThat(secondEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)secondEvent.context()).getPath()).isNull();
+
+            // Watched file is created and deleted then
+            WatchKey createWatchDirKey = watcher.poll();
+            assertThat(createWatchDirKey.isValid()).isTrue();
+            assertThat(createWatchDirKey.watchable()).isEqualTo(fileInRootFolder);
+
+            List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
+            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 2));
+            assertThat(watchDirEvents).asList().hasSize(2);
+
+            WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);
+            assertThat(firstWatchDirEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_CREATE);
+            assertThat(firstWatchDirEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)firstWatchDirEvent.context()).getPath()).isEqualTo(fileInRootFolder.getFileName());
+
+            WatchEvent<?> thirdWatchDirEvent = watchDirEvents.get(1);
+            assertThat(thirdWatchDirEvent.kind()).isEqualTo(StandardWatchEventKind.ENTRY_DELETE);
+            assertThat(thirdWatchDirEvent.count()).isEqualTo(1);
+            assertThat(((WatchContext)thirdWatchDirEvent.context()).getPath()).isEqualTo(fileInRootFolder.getFileName());
+
+            // No more events
+            assertThat(watcher.poll()).isNull();
+        }
+    }
+
+    @Test
+    public void testCancelWatchKey() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path watchDir = kfs.getPath("/watchDir");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            watchDir.register(watcher);
+
+            Files.createDirectory(watchDir);
+            WatchKey createRootKey = watcher.poll(30, TimeUnit.SECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+
+            createRootKey.cancel();
+
+            assertThat(createRootKey.isValid()).isFalse();
+        }
+    }
+
+    @Test
+    public void testResetWatchKey() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path watchDir = kfs.getPath("/watchDir");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            watchDir.register(watcher);
+
+            Files.createDirectory(watchDir);
+            WatchKey createRootKey = watcher.poll(30, TimeUnit.SECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+
+            // Reset the key
+            assertThat(createRootKey.reset()).isTrue();
+
+            // The creation event has been removed from poll events
+            assertThat(createRootKey.pollEvents()).asList().isEmpty();
+        }
+    }
+
+    @Test
+    public void testResetCancelledWatchKey() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path watchDir = kfs.getPath("/watchDir");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            watchDir.register(watcher);
+
+            Files.createDirectory(watchDir);
+            WatchKey createRootKey = watcher.poll(30, TimeUnit.SECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+
+            createRootKey.cancel();
+            assertThat(createRootKey.reset()).isFalse();
+        }
+    }
+
+    @Test
+    public void testPollWatchKeyWithTimeout() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path watchDir = kfs.getPath("/watchDir");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            watchDir.register(watcher);
+
+            Files.createDirectory(watchDir);
+            WatchKey createRootKey = watcher.poll(1, TimeUnit.MILLISECONDS);
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+        }
+    }
+
+    @Test(timeout = 30_000L)
+    public void testTakeWatchKey() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        final Path root = kfs.getPath("/");
+        final Path watchDir = kfs.getPath("/watchDir");
+
+        try (WatchService watcher = kfs.newWatchService()){
+            watchDir.register(watcher);
+
+            Runnable createDirectory = () -> Files.createDirectory(watchDir);
+            Thread createDirectoryThread = new Thread(createDirectory);
+            createDirectoryThread.start();
+
+            WatchKey createRootKey = watcher.take();
+            assertThat(createRootKey.isValid()).isTrue();
+            assertThat(createRootKey.watchable()).isEqualTo(root);
+        }
+    }
+
+    @Test
+    public void testCloseAlreadyClosedWatchService() {
+        final K8SFileSystem kfs = (K8SFileSystem) fsProvider.getFileSystem(URI.create("default:///"));
+        WatchService watcher = kfs.newWatchService();
+        watcher.close();
+        assertThat(watcher.isClose()).isTrue();
+        watcher.close();
+        assertThat(watcher.isClose()).isTrue();
+    }
+
+    private void createOrEditFile(Path file, String fileContent) throws IOException {
+        try (OutputStream fileStream = Files.newOutputStream(file)) {
+            fileStream.write(fileContent.getBytes());
+            fileStream.flush();
+        }
+    }
+
+    private String readFile(Path file) throws IOException {
+        try (InputStream fileStream = Files.newInputStream(file)) {
+            return IOUtils.toString(fileStream, StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private Callable<Boolean> fetchWatchEvents(WatchKey watchKey, List<WatchEvent<?>> foundEvents, int numberOfEventsExpected) {
+        return new Callable<Boolean>() {
+            public Boolean call() {
+                foundEvents.addAll(watchKey.pollEvents());
+
+                if (foundEvents.size() >= numberOfEventsExpected) {
+                    return Boolean.TRUE;
+                }
+                return Boolean.FALSE;
+            }
+        };
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,18 @@
+#
+# Copyright 2019 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider # file system provider, also default (1st)
+org.uberfire.java.nio.fs.k8s.K8SFileSystemProvider     # can be set as default at runtime by system property: org.kie.workbench.controller.openshift.enabled

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/logback-test.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.uberfire.java.nio.fs.k8s" level="DEBUG" /> 
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-0-configmap.yml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-0-configmap.yml
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff36
+  labels:
+    k8s.fs.nio.java.uberfire.org/fsobj-name-0: testDir
+    k8s.fs.nio.java.uberfire.org/fsobj-type: fsobj-directory
+    k8s.fs.nio.java.uberfire.org/fsobj-app: unknown
+  annotations:
+    k8s.fs.nio.java.uberfire.org/fsobj-size: 19
+  creationTimestamp: 1970-01-01T00:00:00Z  
+  uid: e6bb5ba5-527f-11e9-8a93-8c16458eff36
+data:
+  testFile: 19
+ownerReferences:
+- apiVersion: apps.openshift.io/v1
+  kind: ConfigMap
+  name: k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff35
+  uid: e6bb5ba5-527f-11e9-8a93-8c16458eff35
+  

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-00-configmap.yml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-00-configmap.yml
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff37
+  labels:
+    k8s.fs.nio.java.uberfire.org/fsobj-name-0: testDir
+    k8s.fs.nio.java.uberfire.org/fsobj-type: fsobj-directory
+    k8s.fs.nio.java.uberfire.org/fsobj-app: other
+  annotations:
+    k8s.fs.nio.java.uberfire.org/fsobj-size: 0
+  creationTimestamp: 1970-01-01T00:00:00Z  
+  uid: e6bb5ba5-527f-11e9-8a93-8c16458eff36
+data:
+ 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-r-configmap.yml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-r-configmap.yml
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff35
+  labels:
+    k8s.fs.nio.java.uberfire.org/fsobj-type: fsobj-root-directory
+    k8s.fs.nio.java.uberfire.org/fsobj-app: unknown
+  annotations:
+    k8s.fs.nio.java.uberfire.org/fsobj-size: 19
+    k8s.fs.nio.java.uberfire.org/fsobj-test: must-have 
+  creationTimestamp: 1970-01-01T00:00:00Z  
+  uid: e6bb5ba5-527f-11e9-8a93-8c16458eff35
+data:
+  testDir: 19
+  

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-r-empty-configmap.yml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-dir-r-empty-configmap.yml
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    k8s.fs.nio.java.uberfire.org/fsobj-lastModifiedTimestamp: '2019-09-09T17:40:19.217Z'
+    k8s.fs.nio.java.uberfire.org/fsobj-size: '0'
+  creationTimestamp: '2019-09-09T17:40:19Z'
+  labels:
+    k8s.fs.nio.java.uberfire.org/fsobj-app: unknown
+    k8s.fs.nio.java.uberfire.org/fsobj-type: fsobj-root-directory
+  name: k8s-fsobj-2bad6abd-6d85-48ff-b62b-210dcfc9ffdc
+  resourceVersion: '4117848'
+  uid: e46c4e73-d328-11e9-ad7a-8c16458eff35
+  
+
+  

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-file-configmap.yml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-file-configmap.yml
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff35
+  labels:
+    k8s.fs.nio.java.uberfire.org/fsobj-name-0: testDir
+    k8s.fs.nio.java.uberfire.org/fsobj-name-1: testFile
+    k8s.fs.nio.java.uberfire.org/fsobj-type: fsobj-regular-file
+    k8s.fs.nio.java.uberfire.org/fsobj-app: unknown
+  annotations:
+    k8s.fs.nio.java.uberfire.org/fsobj-size: 19
+  creationTimestamp: 1970-01-01T00:00:00Z  
+data:
+  fsobj-content: This is a test file
+ownerReferences:
+- apiVersion: apps.openshift.io/v1
+  kind: ConfigMap
+  name: k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff36
+  uid: e6bb5ba5-527f-11e9-8a93-8c16458eff36
+
+  

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-file-dup-configmap.yml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-file-dup-configmap.yml
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff36
+  labels:
+    k8s.fs.nio.java.uberfire.org/fsobj-name-0: testDir
+    k8s.fs.nio.java.uberfire.org/fsobj-name-1: testFile
+    k8s.fs.nio.java.uberfire.org/fsobj-type: fsobj-regular-file
+    k8s.fs.nio.java.uberfire.org/fsobj-app: unknown
+  annotations:
+    k8s.fs.nio.java.uberfire.org/fsobj-size: 19
+  creationTimestamp: 1970-01-01T00:00:00Z  
+data:
+  fsobj-content: This is a test file
+ownerReferences:
+- apiVersion: apps.openshift.io/v1
+  kind: ConfigMap
+  name: k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff36
+  uid: e6bb5ba5-527f-11e9-8a93-8c16458eff36
+
+  

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-file-invalid-configmap.yml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/resources/test-k8sfs-file-invalid-configmap.yml
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2019 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-fsobj-86403b0c-78b7-11e9-ad76-8c16458eff37
+  labels:
+    k8s.fs.nio.java.uberfire.org/fsobj-name-0: testDir
+    k8s.fs.nio.java.uberfire.org/fsobj-name-1: testFile
+    k8s.fs.nio.java.uberfire.org/fsobj-app: unknown
+  annotations:
+    k8s.fs.nio.java.uberfire.org/fsobj-size: 19
+  creationTimestamp: 1970-01-01T00:00:00Z  
+data:
+  fsobj-content: This is a test file
+ownerReferences:
+- apiVersion: apps.openshift.io/v1
+  kind: ConfigMap
+  name: k8s-fsobj-e6bb5ba5-527f-11e9-8a93-8c16458eff36
+  uid: e6bb5ba5-527f-11e9-8a93-8c16458eff36
+
+  

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/GeneralPathImpl.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/GeneralPathImpl.java
@@ -42,7 +42,7 @@ public class GeneralPathImpl
                             boolean isNormalized) {
         super(fs,
               path,
-              "",
+              isRoot ? "master@localhost" : "",
               isRoot,
               isRealPath,
               isNormalized);


### PR DESCRIPTION
Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Prerequisite PRs:
  https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1064
  https://github.com/kiegroup/kie-wb-common/pull/2916

Provide shared state support through existing uberfire java nio2 API backed by ocp/k8s API Server service
Provide state change event support through existing uberfire java nio2 WatchService API backed by ocp/k8s API Server service