### PR TITLE
[7.5.1] [AF-2214] User confirmation when closing the workbench with unsaved stuff

### DIFF
--- a/uberfire-backend/uberfire-backend-server/pom.xml
+++ b/uberfire-backend/uberfire-backend-server/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>uberfire-ssh-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-server</artifactId>
+    </dependency>
+
     <!-- Formatting -->
     <dependency>
       <groupId>org.ocpsoft.prettytime</groupId>

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/VFSLockServiceImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/VFSLockServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -236,21 +237,24 @@ public class VFSLockServiceImpl implements VFSLockService {
     private void updateSession(final LockInfo lockInfo,
                                boolean remove) {
         final HttpSession session = RpcContext.getHttpSession();
-        @SuppressWarnings("unchecked")
-        Set<LockInfo> locks = (Set<LockInfo>) session.getAttribute(LOCK_SESSION_ATTRIBUTE_NAME);
 
-        if (remove) {
-            if (locks != null) {
-                locks.remove(lockInfo);
-            }
-        } else {
-            if (locks == null) {
-                locks = new HashSet<LockInfo>();
-            }
+        if (session != null) {
+            @SuppressWarnings("unchecked")
+            Set<LockInfo> locks = (Set<LockInfo>) session.getAttribute(LOCK_SESSION_ATTRIBUTE_NAME);
 
-            locks.add(lockInfo);
-            session.setAttribute(LOCK_SESSION_ATTRIBUTE_NAME,
-                                 locks);
+            if (remove) {
+                if (locks != null) {
+                    locks.remove(lockInfo);
+                }
+            } else {
+                if (locks == null) {
+                    locks = new HashSet<LockInfo>();
+                }
+
+                locks.add(lockInfo);
+                session.setAttribute(LOCK_SESSION_ATTRIBUTE_NAME,
+                                     locks);
+            }
         }
     }
 

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServlet.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServlet.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.servlet;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.VFSLockServiceImpl;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.server.BaseFilteredServlet;
+
+@WebServlet(name = "ReleaseUserLocksServlet", urlPatterns = "/releaseUserLocksServlet")
+public class ReleaseUserLocksServlet extends BaseFilteredServlet {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReleaseUserLocksServlet.class);
+
+    @Inject
+    private VFSLockService vfsLockService;
+
+    @Override
+    protected void doGet(final HttpServletRequest request,
+                         final HttpServletResponse response) {
+        final HttpSession session = request.getSession();
+
+        if (session != null && session.getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME) != null) {
+            final Set<LockInfo> locks =
+                    (Set<LockInfo>) session.getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME);
+
+            try {
+                locks.forEach(lockInfo -> vfsLockService.releaseLock(lockInfo.getFile()));
+                locks.clear();
+            } catch (Exception e) {
+                logger.error("Error when releasing locks.", e);
+            }
+        }
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServletTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServletTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.servlet;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.server.VFSLockServiceImpl;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReleaseUserLocksServletTest {
+
+    @Mock
+    private VFSLockService vfsLockService;
+
+    @InjectMocks
+    private ReleaseUserLocksServlet releaseUserLocksServlet;
+
+    @Test
+    public void releaseUserLocksWhenInvalidSessionTest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        doReturn(null).when(request).getSession();
+
+        releaseUserLocksServlet.doGet(request,
+                                      response);
+
+        verify(vfsLockService, never()).releaseLock(any(Path.class));
+    }
+
+    @Test
+    public void releaseUserLocksWhenNoLockAttributeTest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+
+        doReturn(session).when(request).getSession();
+        doReturn(null).when(session).getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME);
+
+        releaseUserLocksServlet.doGet(request,
+                                      response);
+
+        verify(vfsLockService, never()).releaseLock(any(Path.class));
+    }
+
+    @Test
+    public void releaseUserLocksSuccessTest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+
+        Set<LockInfo> locks = new HashSet<>();
+        locks.add(mock(LockInfo.class));
+
+        doReturn(session).when(request).getSession();
+        doReturn(locks).when(session).getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME);
+
+        releaseUserLocksServlet.doGet(request,
+                                      response);
+
+        verify(vfsLockService).releaseLock(any(Path.class));
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
@@ -176,6 +176,11 @@ public class MockPlaceManager implements PlaceManager {
     }
 
     @Override
+    public boolean canCloseAllPlaces() {
+        throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
     public List<PlaceRequest> getUncloseablePlaces() {
         throw new UnsupportedOperationException("Not implemented.");
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
@@ -18,6 +18,7 @@ package org.uberfire.client.mvp;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -29,8 +30,6 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.EventListener;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.Window.ClosingEvent;
-import com.google.gwt.user.client.Window.ClosingHandler;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
@@ -226,13 +225,25 @@ public class LockManagerImpl implements LockManager {
     }
 
     private void releaseLockOnClose() {
-        closeHandler = Window.addWindowClosingHandler(new ClosingHandler() {
-            @Override
-            public void onWindowClosing(ClosingEvent event) {
-                releaseLock();
-            }
-        });
+        closeHandler = Window.addCloseHandler(event -> requestReleaseLock());
     }
+
+    private native void requestReleaseLock()/*-{
+        var pathArray = window.location.pathname.split('/');
+
+        var url = "";
+        for (var i = 0; i < pathArray.length - 1; i++) {
+            if (pathArray[i] !== "") {
+                url += "/" + pathArray[i];
+            }
+        }
+
+        url += "/releaseUserLocksServlet";
+
+        var request = new XMLHttpRequest();
+        request.open('GET', url, false);
+        request.send();
+    }-*/;
 
     private void handleLockFailure(final LockInfo lockInfo) {
 

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
@@ -182,6 +182,8 @@ public interface PlaceManager {
 
     boolean canClosePlace(PlaceRequest place);
 
+    boolean canCloseAllPlaces();
+
     /**
      * @return All opened PlaceRequests that cannot be closed (@onMayClose method returns false).
      */

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -1182,6 +1182,11 @@ public class PlaceManagerImpl implements PlaceManager {
         return false;
     }
 
+    @Override
+    public boolean canCloseAllPlaces() {
+        return getUncloseablePlaces().isEmpty();
+    }
+
     @SuppressWarnings("unused")
     private void onWorkbenchPartOnFocus(@Observes PlaceGainFocusEvent event) {
         final PlaceRequest place = event.getPlace();

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PluginPlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PluginPlaceManagerImpl.java
@@ -225,6 +225,12 @@ public class PluginPlaceManagerImpl implements PlaceManager {
     }
 
     @Override
+    public boolean canCloseAllPlaces() {
+        fail();
+        return false;
+    }
+
+    @Override
     public List<PlaceRequest> getUncloseablePlaces() {
         fail();
         return null;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/WorkbenchConstants.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/WorkbenchConstants.java
@@ -55,4 +55,6 @@ public interface WorkbenchConstants
     String switchToDefaultView();
 
     String switchToCompactView();
+
+    String closingWindowMessage();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -46,6 +47,7 @@ import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.resources.WorkbenchResources;
+import org.uberfire.client.resources.i18n.WorkbenchConstants;
 import org.uberfire.client.workbench.events.ApplicationReadyEvent;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
@@ -232,7 +234,18 @@ public class Workbench {
         }
 
         // Ensure orderly shutdown when Window is closed (eg. saves workbench state)
-        Window.addWindowClosingHandler(event -> workbenchCloseHandler.onWindowClose(workbenchCloseCommand));
+        Window.addCloseHandler(event -> workbenchCloseHandler.onWindowClose(workbenchCloseCommand));
+
+        Window.addWindowClosingHandler(event -> {
+            if (!placeManager.canCloseAllPlaces()) {
+                // Setting a non-null message will make the browser to present a confirmation dialog that asks the user
+                // whether or not they wish to navigate away from the page. The message in the dialog, however,
+                // is not customizable anymore mainly due to scammers using such a message to trick people.
+                // Thus, each browser shows its own message. If the user has an outdated browser, then our custom
+                // message might be shown.
+                event.setMessage(WorkbenchConstants.INSTANCE.closingWindowMessage());
+            }
+        });
 
         // Resizing the Window should resize everything
         Window.addResizeHandler(event -> layout.resizeTo(event.getWidth(),

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchCloseHandlerImplFallback.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchCloseHandlerImplFallback.java
@@ -20,9 +20,9 @@ import com.google.gwt.user.client.Command;
 /**
  * Generic WindowCloseHandler
  */
-public class WorkbenchCloseHandlerImplIE10 implements WorkbenchCloseHandler {
+public class WorkbenchCloseHandlerImplFallback implements WorkbenchCloseHandler {
 
     public void onWindowClose(final Command command) {
-        //Do nothing, as WindowCloseEvents are raised when we don't need them by IE10
+        //Do nothing, as WindowCloseEvents are raised when we don't need them by IE10 and Firefox
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/UberfireWorkbench.gwt.xml
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/UberfireWorkbench.gwt.xml
@@ -53,9 +53,13 @@
   <replace-with class="org.uberfire.client.workbench.WorkbenchCloseHandlerImpl">
     <when-type-is class="org.uberfire.client.workbench.WorkbenchCloseHandler"/>
   </replace-with>
-  <replace-with class="org.uberfire.client.workbench.WorkbenchCloseHandlerImplIE10">
+  <replace-with class="org.uberfire.client.workbench.WorkbenchCloseHandlerImplFallback">
     <when-type-is class="org.uberfire.client.workbench.WorkbenchCloseHandler"/>
     <when-property-is name="user.agent" value="ie9"/>
+  </replace-with>
+  <replace-with class="org.uberfire.client.workbench.WorkbenchCloseHandlerImplFallback">
+    <when-type-is class="org.uberfire.client.workbench.WorkbenchCloseHandler"/>
+    <when-property-is name="user.agent" value="gecko1_8"/>
   </replace-with>
 
 </module>

--- a/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/i18n/WorkbenchConstants.properties
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/i18n/WorkbenchConstants.properties
@@ -28,3 +28,4 @@ lockedMessage=This asset is currently being edited by {0}. Once they commit thei
 splashScreenNoneAvailable=-- None --
 switchToDefaultView=Switch to Default View
 switchToCompactView=Switch to Compact View
+closingWindowMessage=You have unsaved changes in the Workbench, and they will be lost if you proceed. This action cannot be undone. Do you want to proceed anyway?


### PR DESCRIPTION
Same code: https://github.com/kiegroup/appformer/pull/796

JIRA task: [AF-2214](https://issues.jboss.org/browse/AF-2214)

If the user has unsaved changes and closes the browser, then they lost all changes without being warned about. Thus, as a last resort, in this PR the browser will ask the user for confirmation when closing the tab, closing the browser or refreshing the page.

**DEMO**
![AF-2214-2019-09-10](https://user-images.githubusercontent.com/638737/65062814-41257e80-d953-11e9-8502-f4b1c53fbbb8.gif)