### PR TITLE
javax.validation-api needs to keep older version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <version.org.elasticsearch>5.6.1</version.org.elasticsearch>
     <version.org.infinispan.protostream>4.2.2.Final</version.org.infinispan.protostream>
 
-    <!-- Newer version in ip-bom causes ServiceLoader error -->
+    <!-- Newer version in kie-parent causes ServiceLoader error -->
     <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
     <version.jnuit.docker.rule>0.3</version.jnuit.docker.rule>
     <version.com.spotify.docker>5.0.2</version.com.spotify.docker>
@@ -133,6 +133,8 @@
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
 
     <version.org.jboss.marshalling.api>1.2.3.GA</version.org.jboss.marshalling.api>
+    <!-- Version 2.0.1.Final which is coming from kie-parent is not compatible with dashbuilder-validator module -->
+    <version.javax.validation>1.0.0.GA</version.javax.validation>
   </properties>
 
   <repositories>
@@ -941,6 +943,12 @@
             <artifactId>javax.interceptor-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>${version.javax.validation}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
this is dependent PR for https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1055 