### PR TITLE
DROOLS-4563 javax.validation-api version 1.0.0.GA managed 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <version.org.elasticsearch>5.6.1</version.org.elasticsearch>
     <version.org.infinispan.protostream>4.2.2.Final</version.org.infinispan.protostream>
 
-    <!-- Newer version in ip-bom causes ServiceLoader error -->
+    <!-- Newer version in kie-parent causes ServiceLoader error -->
     <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
     <version.jnuit.docker.rule>0.3</version.jnuit.docker.rule>
     <version.com.spotify.docker>5.0.2</version.com.spotify.docker>
@@ -132,6 +132,8 @@
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
 
     <version.org.jboss.marshalling.api>1.2.3.GA</version.org.jboss.marshalling.api>
+    <!-- Version 2.0.1.Final which is coming from kie-parent is not compatible with dashbuilder-validator module -->
+    <version.javax.validation>1.0.0.GA</version.javax.validation>
   </properties>
 
   <repositories>
@@ -940,6 +942,12 @@
             <artifactId>javax.interceptor-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>${version.javax.validation}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -945,12 +945,6 @@
       </dependency>
 
       <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>${version.javax.validation}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit</artifactId>
         <version>${version.org.eclipse.jgit}</version>


### PR DESCRIPTION
https://issues.jboss.org/browse/DROOLS-4563

Parent PR:
- kiegroup/droolsjbpm-build-bootstrap#1075

Dependent PRs:

-    kiegroup/appformer#814
-    kiegroup/kie-wb-common#2934
-    kiegroup/drools-wb#1238
