### PR TITLE
Fix unmet-peer-dependency errors in appformer-js

### DIFF
--- a/appformer-js/package.json
+++ b/appformer-js/package.json
@@ -54,6 +54,7 @@
     "typescript": "2.9.2",
     "watch": "1.0.2",
     "webpack": "4.15.1",
-    "webpack-cli": "3.0.8"
+    "webpack-cli": "3.0.8",
+    "babel-jest": "23.0.0"
   }
 }


### PR DESCRIPTION
Adds babel-jst to devDependencies.
Version is 23.0.0 as version 24.0.0 is not compatible.

@tiagobento Please take a look :) 