### PR TITLE
[AF-2305] Keeping asset locks if the user decides to stay on the page

### DIFF
--- a/uberfire-backend/uberfire-backend-server/pom.xml
+++ b/uberfire-backend/uberfire-backend-server/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>uberfire-ssh-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-server</artifactId>
+    </dependency>
+
     <!-- Formatting -->
     <dependency>
       <groupId>org.ocpsoft.prettytime</groupId>

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/VFSLockServiceImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/VFSLockServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -236,21 +237,23 @@ public class VFSLockServiceImpl implements VFSLockService {
     private void updateSession(final LockInfo lockInfo,
                                boolean remove) {
         final HttpSession session = RpcContext.getHttpSession();
-        @SuppressWarnings("unchecked")
-        Set<LockInfo> locks = (Set<LockInfo>) session.getAttribute(LOCK_SESSION_ATTRIBUTE_NAME);
+        if (session != null) {
+            @SuppressWarnings("unchecked")
+            Set<LockInfo> locks = (Set<LockInfo>) session.getAttribute(LOCK_SESSION_ATTRIBUTE_NAME);
 
-        if (remove) {
-            if (locks != null) {
-                locks.remove(lockInfo);
-            }
-        } else {
-            if (locks == null) {
-                locks = new HashSet<LockInfo>();
-            }
+            if (remove) {
+                if (locks != null) {
+                    locks.remove(lockInfo);
+                }
+            } else {
+                if (locks == null) {
+                    locks = new HashSet<LockInfo>();
+                }
 
-            locks.add(lockInfo);
-            session.setAttribute(LOCK_SESSION_ATTRIBUTE_NAME,
-                                 locks);
+                locks.add(lockInfo);
+                session.setAttribute(LOCK_SESSION_ATTRIBUTE_NAME,
+                                     locks);
+            }
         }
     }
 

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServlet.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServlet.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.servlet;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.VFSLockServiceImpl;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.server.BaseFilteredServlet;
+
+@WebServlet(name = "ReleaseUserLocksServlet", urlPatterns = "/releaseUserLocksServlet")
+public class ReleaseUserLocksServlet extends BaseFilteredServlet {
+
+    private static final Logger logger = LoggerFactory.getLogger(ReleaseUserLocksServlet.class);
+
+    @Inject
+    private VFSLockService vfsLockService;
+
+    @Override
+    protected void doGet(final HttpServletRequest request,
+                         final HttpServletResponse response) {
+        final HttpSession session = request.getSession();
+
+        if (session != null && session.getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME) != null) {
+            final Set<LockInfo> locks =
+                    (Set<LockInfo>) session.getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME);
+
+            try {
+                locks.forEach(lockInfo -> vfsLockService.releaseLock(lockInfo.getFile()));
+                locks.clear();
+            } catch (Exception e) {
+                logger.error("Error when releasing locks.", e);
+            }
+        }
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServletTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/servlet/ReleaseUserLocksServletTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.servlet;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.server.VFSLockServiceImpl;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.VFSLockService;
+import org.uberfire.backend.vfs.impl.LockInfo;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReleaseUserLocksServletTest {
+
+    @Mock
+    private VFSLockService vfsLockService;
+
+    @InjectMocks
+    private ReleaseUserLocksServlet releaseUserLocksServlet;
+
+    @Test
+    public void releaseUserLocksWhenInvalidSessionTest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        doReturn(null).when(request).getSession();
+
+        releaseUserLocksServlet.doGet(request,
+                                      response);
+
+        verify(vfsLockService, never()).releaseLock(any(Path.class));
+    }
+
+    @Test
+    public void releaseUserLocksWhenNoLockAttributeTest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+
+        doReturn(session).when(request).getSession();
+        doReturn(null).when(session).getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME);
+
+        releaseUserLocksServlet.doGet(request,
+                                      response);
+
+        verify(vfsLockService, never()).releaseLock(any(Path.class));
+    }
+
+    @Test
+    public void releaseUserLocksSuccessTest() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        HttpSession session = mock(HttpSession.class);
+
+        Set<LockInfo> locks = new HashSet<>();
+        locks.add(mock(LockInfo.class));
+
+        doReturn(session).when(request).getSession();
+        doReturn(locks).when(session).getAttribute(VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME);
+
+        releaseUserLocksServlet.doGet(request,
+                                      response);
+
+        verify(vfsLockService).releaseLock(any(Path.class));
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/UserAgent.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/UserAgent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.util;
+
+import com.google.gwt.user.client.Window;
+
+public class UserAgent {
+
+    private UserAgent() {
+
+    }
+
+    public static boolean isChrome() {
+        final String userAgent = Window.Navigator.getUserAgent().toLowerCase();
+        return userAgent.contains("chrome");
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
@@ -48,6 +48,7 @@ import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.resources.WorkbenchResources;
 import org.uberfire.client.resources.i18n.WorkbenchConstants;
+import org.uberfire.client.util.UserAgent;
 import org.uberfire.client.workbench.events.ApplicationReadyEvent;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
@@ -233,19 +234,7 @@ public class Workbench {
             handleStandaloneMode(Window.Location.getParameterMap());
         }
 
-        // Ensure orderly shutdown when Window is closed (eg. saves workbench state)
-        Window.addCloseHandler(event -> workbenchCloseHandler.onWindowClose(workbenchCloseCommand));
-
-        Window.addWindowClosingHandler(event -> {
-            if (!placeManager.canCloseAllPlaces()) {
-                // Setting a non-null message will make the browser to present a confirmation dialog that asks the user
-                // whether or not they wish to navigate away from the page. The message in the dialog, however,
-                // is not customizable anymore mainly due to scammers using such a message to trick people.
-                // Thus, each browser shows its own message. If the user has an outdated browser, then our custom
-                // message might be shown.
-                event.setMessage(WorkbenchConstants.INSTANCE.closingWindowMessage());
-            }
-        });
+        addCloseHandler();
 
         // Resizing the Window should resize everything
         Window.addResizeHandler(event -> layout.resizeTo(event.getWidth(),
@@ -255,6 +244,25 @@ public class Workbench {
         Scheduler.get().scheduleDeferred(() -> layout.onResize());
 
         notifyJSReady();
+    }
+
+    private void addCloseHandler() {
+        if (UserAgent.isChrome()) {
+            Window.addCloseHandler(event -> workbenchCloseHandler.onWindowClose(workbenchCloseCommand));
+
+            Window.addWindowClosingHandler(event -> {
+                if (!placeManager.canCloseAllPlaces()) {
+                    // Setting a non-null message will make the browser to present a confirmation dialog that asks the user
+                    // whether or not they wish to navigate away from the page. The message in the dialog, however,
+                    // is not customizable anymore mainly due to scammers using such a message to trick people.
+                    // Thus, each browser shows its own message. If the user has an outdated browser, then our custom
+                    // message might be shown.
+                    event.setMessage(WorkbenchConstants.INSTANCE.closingWindowMessage());
+                }
+            });
+        } else {
+            Window.addWindowClosingHandler(event -> workbenchCloseHandler.onWindowClose(workbenchCloseCommand));
+        }
     }
 
     private native void notifyJSReady() /*-{


### PR DESCRIPTION
**Task**: [AF-2305](https://issues.jboss.org/browse/AF-2305)

**Cause**:

The root cause of this bug is that `LockManager` also has a `WindowClosingHandler`, responsible for releasing asset locks when users close the browser.
Due to [AF-2214](https://issues.jboss.org/browse/AF-2214), `WindowClosingHandler` does not guarantee anymore that users have actually closed the browser.
Thus, users lose the lock when they decide to stay on the page.

As in [AF-2214](https://issues.jboss.org/browse/AF-2214), `WindowClosingHandler` can be replaced by the `ClosedHandler`.
Then, the lock is released only when the user actually decides to close the browser.
However, there is one limitation:
In Firefox and MS Edge, the event is fired when a _tab_ is closed, but it is **not** fired when the _browser_ is closed.

**Countermeasure**:

 [AF-2214](https://issues.jboss.org/browse/AF-2214) will be applied only for chrome browsers.

**Expectation**:

Chrome browsers:
The browser will ask the user for confirmation when closing the tab, closing the browser or refreshing the page when there are unsaved changes.
The asset lock is kept if the user decides to stay on the page.
The asset lock is released if the user decides to close the browser.

DEMO
![AF-2305-chrome](https://user-images.githubusercontent.com/638737/68022068-fb621280-fc81-11e9-967b-303663a0146a.gif)

Other browsers:
Basically, the behavior before [AF-2214](https://issues.jboss.org/browse/AF-2214) has been restored.
There will be no warning for users when closing the browser even if they have unsaved changes.
The asset lock is released when the browser is closed.

DEMO
![AF-2305-ff](https://user-images.githubusercontent.com/638737/68022077-ff8e3000-fc81-11e9-842c-50f952272b74.gif)