### PR TITLE
BXMSPROD-507: upgrade netty to 4.1.42.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
     <version.org.jboss.errai.wildfly.sdm>14.0.1.Final</version.org.jboss.errai.wildfly.sdm>
 
     <version.org.apache.activemq.artemis>2.3.0</version.org.apache.activemq.artemis>
-    <version.io.netty>4.1.16.Final</version.io.netty>
     <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
     <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
 
@@ -102,7 +101,6 @@
     <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
     <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
 
-    <version.io.netty.old>3.10.6.Final</version.io.netty.old>
     <version.org.elasticsearch>5.6.1</version.org.elasticsearch>
     <version.org.infinispan.protostream>4.2.2.Final</version.org.infinispan.protostream>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/BXMSPROD-507

Parent PR kiegroup/droolsjbpm-build-bootstrap/pull/1095
merge together with this #821 and kie-soup PR kiegroup/kie-soup/pull/117
