### PR TITLE
DROOLS-4689/DROOLS-4690/DROOLS-4691/DROOLS-4692: [DMN Designer] Code Completion - Enable code completion for Literal Expressions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <version.org.webjars.bower.moment>2.14.1</version.org.webjars.bower.moment>
     <version.org.webjars.bower.moment-timezone>0.5.17</version.org.webjars.bower.moment-timezone>
     <version.org.webjars.bower.bluebird>3.1.1</version.org.webjars.bower.bluebird>
+    <version.org.webjars.npm.monaco-editor>0.18.1</version.org.webjars.npm.monaco-editor>
     <version.org.webjars.npm.react>16.6.0</version.org.webjars.npm.react>
     <version.org.webjars.npm.react-dom>16.6.0</version.org.webjars.npm.react-dom>
     <version.org.webjars.bower.bootstrap-daterangepicker>2.1.25</version.org.webjars.bower.bootstrap-daterangepicker>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -345,6 +345,27 @@
               <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
+          <execution>
+            <id>unpack-monaco-editor</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.webjars.npm</groupId>
+                  <artifactId>monaco-editor</artifactId>
+                  <version>${version.org.webjars.npm.monaco-editor}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/monaco-editor</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -476,6 +497,24 @@
                   <directory>${project.build.directory}/d3/META-INF/resources/webjars/d3/${version.org.webjars.bower.d3js}/</directory>
                   <includes>
                     <include>d3.min.js</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-monaco-editor</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/monaco-editor</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/monaco-editor/META-INF/resources/webjars/monaco-editor/${version.org.webjars.npm.monaco-editor}/</directory>
+                  <includes>
+                    <include>**</include>
                   </includes>
                 </resource>
               </resources>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/MonacoEditorInitializer.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/MonacoEditorInitializer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco;
+
+import java.util.function.Consumer;
+
+import com.google.gwt.core.client.JsArrayString;
+import org.uberfire.client.views.pfly.monaco.jsinterop.Monaco;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoLoader;
+
+import static com.google.gwt.core.client.JavaScriptObject.createArray;
+
+/**
+ * {@link MonacoEditorInitializer} initializes Monaco modules by temporarily switching the functions
+ * '__MONACO_AMD_LOADER__.define' and '__MONACO_AMD_LOADER__.require' from Monaco namespace to the global scope.
+ * The global scope already has other libraries occupying namespaces that Monaco cannot override, so this class
+ * temporarily uses the global scope and gives it back to the legacy libraries, when Monaco finishes its work.
+ */
+public class MonacoEditorInitializer {
+
+    static final String VS_EDITOR_EDITOR_MAIN_MODULE = "vs/editor/editor.main";
+
+    public void require(final Consumer<Monaco> monacoConsumer) {
+
+        switchAMDLoaderFromDefaultToMonaco();
+
+        require(monacoModule(), monaco -> {
+            monacoConsumer.accept(monaco);
+            switchAMDLoaderFromMonacoToDefault();
+        });
+    }
+
+    void require(final JsArrayString modules,
+                 final MonacoLoader.CallbackFunction callback) {
+        MonacoLoader.require(modules, callback);
+    }
+
+    void switchAMDLoaderFromDefaultToMonaco() {
+        nativeSwitchAMDLoaderFromDefaultToMonaco();
+    }
+
+    void switchAMDLoaderFromMonacoToDefault() {
+        nativeSwitchAMDLoaderFromMonacoToDefault();
+    }
+
+    JsArrayString monacoModule() {
+        final JsArrayString modules = makeJsArrayString();
+        modules.push(VS_EDITOR_EDITOR_MAIN_MODULE);
+        return modules;
+    }
+
+    JsArrayString makeJsArrayString() {
+        return (JsArrayString) createArray();
+    }
+
+    private native void nativeSwitchAMDLoaderFromDefaultToMonaco() /*-{
+
+        // Store current definition of 'define' and 'require'
+        $wnd.__GLOBAL_DEFINE__ = $wnd.define;
+        $wnd.__GLOBAL_REQUIRE__ = $wnd.require;
+
+        // Set Monaco AMD Loader definition of 'define' and 'require'
+        $wnd.define = $wnd.__MONACO_AMD_LOADER__.define;
+        $wnd.require = $wnd.__MONACO_AMD_LOADER__.require;
+    }-*/;
+
+    private native void nativeSwitchAMDLoaderFromMonacoToDefault() /*-{
+        // Reset the definition of 'define' and 'require'
+        $wnd.define = $wnd.__GLOBAL_DEFINE__;
+        $wnd.require = $wnd.__GLOBAL_REQUIRE__;
+    }-*/;
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/Monaco.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/Monaco.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco.jsinterop;
+
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true)
+public class Monaco {
+
+    public MonacoLanguages languages;
+
+    public MonacoEditor editor;
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoEditor.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoEditor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco.jsinterop;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import elemental2.dom.Element;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true)
+public class MonacoEditor {
+
+    public native void defineTheme(final String themeId,
+                                   final JavaScriptObject themeData);
+
+    public native MonacoStandaloneCodeEditor create(final Element themeId,
+                                                    final JavaScriptObject options);
+
+    public native void setTheme(final String feelThemeId);
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoLanguages.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoLanguages.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco.jsinterop;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true)
+public class MonacoLanguages {
+
+    public native void register(final JavaScriptObject language);
+
+    public native void setMonarchTokensProvider(final String languageId,
+                                                final JavaScriptObject languageDefinition);
+
+    public native void registerCompletionItemProvider(final String languageId,
+                                                      final JavaScriptObject completionItemProvider);
+
+    @JsFunction
+    public interface ProvideCompletionItemsFunction {
+
+        JavaScriptObject call();
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoLoader.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoLoader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco.jsinterop;
+
+import com.google.gwt.core.client.JsArrayString;
+import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsType;
+
+import static jsinterop.annotations.JsPackage.GLOBAL;
+
+@JsType(isNative = true)
+public class MonacoLoader {
+
+    @JsMethod(namespace = GLOBAL, name = "require")
+    public static native void require(final JsArrayString modules,
+                                      final CallbackFunction callback);
+
+    @JsFunction
+    public interface CallbackFunction {
+
+        void call(final Monaco monacoEditor);
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoStandaloneCodeEditor.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoStandaloneCodeEditor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco.jsinterop;
+
+import com.google.gwt.dom.client.NativeEvent;
+import elemental2.core.JsObject;
+import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true)
+public class MonacoStandaloneCodeEditor {
+
+    public JsObject _contentWidgets;
+
+    public native void focus();
+
+    public native void dispose();
+
+    public native String getValue();
+
+    public native void trigger(final String source,
+                               final String handlerId);
+
+    public native void setValue(final String value);
+
+    public native void onKeyDown(final CallbackFunction callback);
+
+    @JsOverlay
+    public final boolean isSuggestWidgetVisible() {
+        return MonacoStandaloneCodeEditorHelper.isSuggestWidgetVisible(this);
+    }
+
+    @JsFunction
+    public interface CallbackFunction {
+
+        void call(final NativeEvent event);
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoStandaloneCodeEditorHelper.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/monaco/jsinterop/MonacoStandaloneCodeEditorHelper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco.jsinterop;
+
+/**
+ * This is class is a helper for {@link MonacoStandaloneCodeEditor}.
+ * {@link MonacoStandaloneCodeEditor} is a native class, thus it cannot contain JSNI code.
+ */
+public class MonacoStandaloneCodeEditorHelper {
+
+    public static native boolean isSuggestWidgetVisible(final MonacoStandaloneCodeEditor codeEditor) /*-{
+        return codeEditor._contentWidgets['editor.widget.suggestWidget'].widget.state === 3;
+    }-*/;
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyBootstrapper.java
@@ -16,8 +16,10 @@
 
 package org.uberfire.client.views.pfly.sys;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.ScriptInjector;
 import org.gwtbootstrap3.client.GwtBootstrap3ClientBundle;
+import org.uberfire.client.views.pfly.monaco.MonacoEditorInitializer;
 
 import static org.uberfire.client.views.pfly.sys.MomentUtils.setMomentLocale;
 
@@ -25,6 +27,8 @@ import static org.uberfire.client.views.pfly.sys.MomentUtils.setMomentLocale;
  * Utilities for ensuring the PatternFly/BS3 system is working early enough that the app can start correctly.
  */
 public class PatternFlyBootstrapper {
+
+    private static final String MONACO_EDITOR_BASE_PATH = "monaco-editor/dev";
 
     private static boolean isPrettifyLoaded = false;
 
@@ -41,6 +45,8 @@ public class PatternFlyBootstrapper {
     private static boolean isD3Loaded = false;
 
     private static boolean isJQueryUILoaded = false;
+
+    private static boolean isMonacoEditorLoaderLoaded = false;
 
     /**
      * Uses GWT's ScriptInjector to put jQuery in the page if it isn't already. All Errai IOC beans that rely on
@@ -130,12 +136,39 @@ public class PatternFlyBootstrapper {
         }
     }
 
+    public static void ensureMonacoEditorLoaderIsAvailable() {
+        if (!isMonacoEditorLoaderLoaded) {
+
+            final String monacoAbsolutePath = GWT.getModuleBaseURL() + MONACO_EDITOR_BASE_PATH;
+            final String amdLoaderScript = PatternFlyClientBundle.INSTANCE.monacoAMDLoader().getText();
+
+            ScriptInjector.fromString(enclosureByMonacoAMDLoaderNamespace(monacoAbsolutePath, amdLoaderScript))
+                    .setWindow(ScriptInjector.TOP_WINDOW)
+                    .inject();
+
+            isMonacoEditorLoaderLoaded = true;
+        }
+    }
+
+    /**
+     * The global scope already has other libraries occupying namespaces that Monaco cannot override.
+     * Thus, this method encloses Monaco loader functions into the '__MONACO_AMD_LOADER__' namespace, and
+     * the {@link MonacoEditorInitializer} uses '__MONACO_AMD_LOADER__' to correctly initialize Monaco modules.
+     */
+    private static String enclosureByMonacoAMDLoaderNamespace(final String baseUrlPath,
+                                                              final String script) {
+
+        return "(new function() { this.require = { baseUrl: '" + baseUrlPath + "' }; "
+                + script
+                + " window.__MONACO_AMD_LOADER__ = _amdLoaderGlobal });";
+    }
+
     /**
      * Checks to see if jQuery is already present.
+     *
      * @return true is jQuery is loaded, false otherwise.
      */
     private static native boolean isjQueryLoaded() /*-{
         return (typeof $wnd['jQuery'] !== 'undefined');
     }-*/;
 }
-

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyClientBundle.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/sys/PatternFlyClientBundle.java
@@ -47,4 +47,7 @@ public interface PatternFlyClientBundle extends ClientBundle {
 
     @Source("org/uberfire/client/views/static/jquery-ui/jquery-ui.min.js")
     TextResource jQueryUI();
+
+    @Source("org/uberfire/client/views/static/monaco-editor/dev/vs/loader.js")
+    TextResource monacoAMDLoader();
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/PatternFly.gwt.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/PatternFly.gwt.xml
@@ -30,4 +30,5 @@
   <stylesheet src="bootstrap-select/css/bootstrap-select.min.css"/>
   <stylesheet src="prettify/bin/prettify.min.css"/>
   <stylesheet src="uberfire-patternfly.css" />
+  <stylesheet src="monaco-editor/min/vs/editor/editor.main.css"/>
 </module>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/monaco/MonacoEditorInitializerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/monaco/MonacoEditorInitializerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.views.pfly.monaco;
+
+import java.util.function.Consumer;
+
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.uberfire.client.views.pfly.monaco.jsinterop.Monaco;
+import org.uberfire.client.views.pfly.monaco.jsinterop.MonacoLoader;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.uberfire.client.views.pfly.monaco.MonacoEditorInitializer.VS_EDITOR_EDITOR_MAIN_MODULE;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class MonacoEditorInitializerTest {
+
+    @Mock
+    private JsArrayString monacoModule;
+
+    @Mock
+    private Monaco monaco;
+
+    @Captor
+    private ArgumentCaptor<MonacoLoader.CallbackFunction> callbackFunctionCaptor;
+
+    private MonacoEditorInitializer initializer;
+
+    @Before
+    public void setup() {
+        initializer = spy(new MonacoEditorInitializer());
+    }
+
+    @Test
+    public void testRequire() {
+
+        final int[] monacoConsumerCalls = new int[1];
+        final Consumer<Monaco> monacoConsumer = (e) -> monacoConsumerCalls[0]++;
+
+        doNothing().when(initializer).require(any(), any());
+        doReturn(monacoModule).when(initializer).monacoModule();
+
+        initializer.require(monacoConsumer);
+
+        final InOrder inOrder = inOrder(initializer);
+
+        inOrder.verify(initializer).switchAMDLoaderFromDefaultToMonaco();
+        inOrder.verify(initializer).require(eq(monacoModule), callbackFunctionCaptor.capture());
+        callbackFunctionCaptor.getValue().call(monaco);
+        assertEquals(1, monacoConsumerCalls[0]);
+        inOrder.verify(initializer).switchAMDLoaderFromMonacoToDefault();
+    }
+
+    @Test
+    public void testMonacoModule() {
+
+        final JsArrayString expectedModules = mock(JsArrayString.class);
+
+        doReturn(expectedModules).when(initializer).makeJsArrayString();
+
+        final JsArrayString actualModules = initializer.monacoModule();
+
+        verify(expectedModules).push(VS_EDITOR_EDITOR_MAIN_MODULE);
+        assertEquals(expectedModules, actualModules);
+    }
+}


### PR DESCRIPTION
See:
- [DROOLS-4689](https://issues.jboss.org/browse/DROOLS-4689): [DMN Designer] Code Completion - Setup Monaco (loader)
- [DROOLS-4690](https://issues.jboss.org/browse/DROOLS-4690): [DMN Designer] Code Completion - Add Monaco support for 'TextAreaSingletonDOMElementFactory'
- [DROOLS-4691](https://issues.jboss.org/browse/DROOLS-4691): [DMN Designer] Code Completion - Enable code completion for only Literal Expressions
- [DROOLS-4692](https://issues.jboss.org/browse/DROOLS-4692): [DMN Designer] Code Completion - UI adjusts for Monaco component into DMN Boxed Expression component

---

![2019-11-07 14 31 45](https://user-images.githubusercontent.com/1079279/68412704-74bea100-016b-11ea-80b8-c421d9c337c7.gif)

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/836
- https://github.com/kiegroup/kie-wb-common/pull/3000
