### PR TITLE
DROOLS-4735: [DMN Designer] Grid performance is dire

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -44,6 +44,12 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>testing</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>testing</scope>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridCell.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/model/impl/BaseGridCell.java
@@ -41,7 +41,7 @@ public class BaseGridCell<T> implements GridCell<T> {
     }
 
     //This is not part of the GridCell interface as we don't want to expose this for general use
-    void setValue(final GridCellValue<T> value) {
+    protected void setValue(final GridCellValue<T> value) {
         this.value = value;
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilities.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilities.java
@@ -50,7 +50,7 @@ public class CellContextUtilities {
         final double clipMinY = getClipMinY(gridWidget);
 
         final double blockCellWidth = column.getWidth();
-        final double blockCellHeight = gridRow.getHeight();
+        final double blockCellHeight = ri.getAllRowHeights().get(uiRowIndex);
 
         return new GridBodyCellEditContext(cellX,
                                            cellY,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/Logging.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/Logging.java
@@ -20,6 +20,10 @@ import java.util.logging.Logger;
 
 public class Logging {
 
+    private Logging() {
+        //Sonar rule: Utility classes should not have public constructors
+    }
+
     /**
      * Logs a message at {@see Level.FINEST}
      * @param logger Logger to record the entry.

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/Logging.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/Logging.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.wires.core.grids.client.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class Logging {
+
+    /**
+     * Logs a message at {@see Level.FINEST}
+     * @param logger Logger to record the entry.
+     * @param message Message to log.
+     * @return Returns the current (system) time in milliseconds.
+     */
+    public static long log(final Logger logger,
+                           final String message) {
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.log(Level.FINEST, message);
+        }
+        return System.currentTimeMillis();
+    }
+
+    /**
+     * Logs a message at {@see Level.FINEST} including the elapsed time between the
+     * previousTimeMillis and the current (system) time in milliseconds.
+     * @param logger Logger to record the entry.
+     * @param message Message to log.
+     * @param previousTimeMillis Previous time in milliseconds.
+     * @return Returns the current (system) time in milliseconds.
+     */
+    public static long log(final Logger logger,
+                           final String message,
+                           final long previousTimeMillis) {
+        final long currentTimeMillis = System.currentTimeMillis();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.log(Level.FINEST, message + " - " + (currentTimeMillis - previousTimeMillis) + "ms");
+        }
+        return currentTimeMillis;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandler.java
@@ -158,11 +158,13 @@ public class GridWidgetDnDMouseDownHandler implements NodeMouseDownHandler {
 
         final Bounds bounds = renderingInformation.getBounds();
         final GridRow row = activeGridRows.get(0);
-        final double rowOffsetY = rendererHelper.getRowOffset(row) + view.getRenderer().getHeaderHeight();
+        final int rowIndex = view.getModel().getRows().indexOf(row);
+        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
+        final double rowOffsetY = rendererHelper.getRowOffset(rowIndex, allRowHeights) + view.getRenderer().getHeaderHeight();
 
         final double highlightWidth = Math.min(bounds.getX() + bounds.getWidth() - view.getComputedLocation().getX(),
                                                view.getWidth());
-        final double highlightHeight = row.getHeight();
+        final double highlightHeight = allRowHeights.get(rowIndex);
 
         state.getEventColumnHighlight().setWidth(highlightWidth)
                 .setHeight(highlightHeight)

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandler.java
@@ -124,10 +124,11 @@ public class GridWidgetDnDMouseDownHandler implements NodeMouseDownHandler {
                                                           view,
                                                           headerMinY);
 
-        state.getEventColumnHighlight().setWidth(highlightWidth)
-                .setHeight(highlightHeight)
-                .setX(view.getComputedLocation().getX() + activeColumnX)
-                .setY(view.getComputedLocation().getY() + headerMinY);
+        final GridWidgetDnDProxy highlight = state.getEventColumnHighlight();
+        highlight.setWidth(highlightWidth);
+        highlight.setHeight(highlightHeight);
+        highlight.setX(view.getComputedLocation().getX() + activeColumnX);
+        highlight.setY(view.getComputedLocation().getY() + headerMinY);
         layer.add(state.getEventColumnHighlight());
         layer.getLayer().batch();
     }
@@ -166,10 +167,11 @@ public class GridWidgetDnDMouseDownHandler implements NodeMouseDownHandler {
                                                view.getWidth());
         final double highlightHeight = allRowHeights.get(rowIndex);
 
-        state.getEventColumnHighlight().setWidth(highlightWidth)
-                .setHeight(highlightHeight)
-                .setX(view.getComputedLocation().getX())
-                .setY(view.getComputedLocation().getY() + rowOffsetY);
+        final GridWidgetDnDProxy highlight = state.getEventColumnHighlight();
+        highlight.setWidth(highlightWidth);
+        highlight.setHeight(highlightHeight);
+        highlight.setX(view.getComputedLocation().getX());
+        highlight.setY(view.getComputedLocation().getY() + rowOffsetY);
         layer.add(state.getEventColumnHighlight());
         layer.getLayer().batch();
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
@@ -597,9 +597,7 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
         final List<GridColumn<?>> allGridColumns = activeGridModel.getColumns();
 
         final BaseGridRendererHelper rendererHelper = activeGridWidget.getRendererHelper();
-        final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
         final GridRenderer renderer = activeGridWidget.getRenderer();
-        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
         final double headerHeight = renderer.getHeaderHeight();
 
         final GridRow leadRow = activeGridRows.get(0);
@@ -614,11 +612,11 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
         }
 
         //Find new row index
-        double rowHeight;
+        GridRow row;
         int uiRowIndex = 0;
         double offsetY = cy - headerHeight;
-        while ((rowHeight = allRowHeights.get(uiRowIndex)) < offsetY) {
-            offsetY = offsetY - rowHeight;
+        while ((row = activeGridModel.getRow(uiRowIndex)).getHeight() < offsetY) {
+            offsetY = offsetY - row.getHeight();
             uiRowIndex++;
         }
         if (uiRowIndex < 0 || uiRowIndex > activeGridModel.getRowCount() - 1) {
@@ -630,12 +628,12 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
             return;
         } else if (uiRowIndex < activeGridModel.getRows().indexOf(leadRow)) {
             //Don't move up if the pointer is in the bottom half of the target row.
-            if (offsetY > allRowHeights.get(uiRowIndex) / 2) {
+            if (offsetY > activeGridModel.getRow(uiRowIndex).getHeight() / 2) {
                 return;
             }
         } else if (uiRowIndex > activeGridModel.getRows().indexOf(leadRow)) {
             //Don't move down if the pointer is in the top half of the target row.
-            if (offsetY < allRowHeights.get(uiRowIndex) / 2) {
+            if (offsetY < activeGridModel.getRow(uiRowIndex).getHeight() / 2) {
                 return;
             }
         }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
@@ -331,8 +331,7 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
                                    final BaseGridRendererHelper.RenderingInformation renderingInformation,
                                    final double cx,
                                    final double cy) {
-        if (!isOverRowDragHandleColumn(view,
-                                       renderingInformation,
+        if (!isOverRowDragHandleColumn(renderingInformation,
                                        cx)) {
             return;
         }
@@ -373,8 +372,7 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
         setCursor(Style.Cursor.MOVE);
     }
 
-    private boolean isOverRowDragHandleColumn(final GridWidget view,
-                                              final BaseGridRendererHelper.RenderingInformation renderingInformation,
+    private boolean isOverRowDragHandleColumn(final BaseGridRendererHelper.RenderingInformation renderingInformation,
                                               final double cx) {
         //Gather information on columns
         if (renderingInformation == null) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -59,6 +58,8 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.selections.impl.Base
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
+
+import static org.uberfire.ext.wires.core.grids.client.util.Logging.log;
 
 /**
  * The base of all GridWidgets.
@@ -301,28 +302,28 @@ public class BaseGridWidget extends Group implements GridWidget {
         //Clear existing content
         this.removeAll();
 
-        long currentTimeMillis = 0;
+        long currentTimeMillis;
         if (!isSelectionLayer) {
             //If there's no RenderingInformation the GridWidget is not visible
-            currentTimeMillis = log(" - Pre- prepare()");
+            currentTimeMillis = log(LOGGER, " - Pre- prepare()");
             this.renderingInformation = prepare();
-            log(" - Post- prepare() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+            log(LOGGER, " - Post- prepare()", currentTimeMillis);
             if (renderingInformation == null) {
                 destroyDOMElementResources();
                 return;
             }
-            currentTimeMillis = log(" - Pre- makeRenderingCommands()");
+            currentTimeMillis = log(LOGGER, " - Pre- makeRenderingCommands()");
             makeRenderingCommands();
-            log(" - Post- makeRenderingCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+            log(LOGGER, " - Post- makeRenderingCommands()", currentTimeMillis);
         }
 
-        currentTimeMillis = log(" - Pre- layerRenderGroups()");
+        currentTimeMillis = log(LOGGER, " - Pre- layerRenderGroups()");
         layerRenderGroups();
-        log(" - Post- layerRenderGroups() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        log(LOGGER, " - Post- layerRenderGroups()", currentTimeMillis);
 
-        currentTimeMillis = log(" - Pre- executeRenderQueueCommands()");
+        currentTimeMillis = log(LOGGER, " - Pre- executeRenderQueueCommands()");
         executeRenderQueueCommands(isSelectionLayer);
-        log(" - Post- executeRenderQueueCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        log(LOGGER, " - Post- executeRenderQueueCommands()", currentTimeMillis);
 
         //Signal columns to free any unused resources
         if (!isSelectionLayer) {
@@ -334,11 +335,11 @@ public class BaseGridWidget extends Group implements GridWidget {
         }
 
         //Then render to the canvas
-        currentTimeMillis = log(" - Pre- super.drawWithoutTransforms()");
+        currentTimeMillis = log(LOGGER, " - Pre- super.drawWithoutTransforms()");
         super.drawWithoutTransforms(context,
                                     alpha,
                                     bb);
-        log(" - Post- super.drawWithoutTransforms() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        log(LOGGER, " - Post- super.drawWithoutTransforms()", currentTimeMillis);
     }
 
     private BaseGridRendererHelper.RenderingInformation prepare() {
@@ -358,9 +359,9 @@ public class BaseGridWidget extends Group implements GridWidget {
         this.renderQueue.clear();
 
         //If there's no RenderingInformation the GridWidget is not visible
-        long currentTimeMillis = log(" - Pre- getRenderingInformation()");
+        long currentTimeMillis = log(LOGGER, " - Pre- getRenderingInformation()");
         final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
-        log(" - Post- getRenderingInformation() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        log(LOGGER, " - Post- getRenderingInformation()", currentTimeMillis);
         if (renderingInformation == null) {
             return null;
         }
@@ -863,12 +864,5 @@ public class BaseGridWidget extends Group implements GridWidget {
                                           final int uiColumnIndex) {
         // no operation by default
         return false;
-    }
-
-    private static long log(final String message) {
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, message);
-        }
-        return System.currentTimeMillis();
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
@@ -250,7 +250,9 @@ public class BaseGridWidget extends Group implements GridWidget {
 
     private double getHeight(final BaseGridRendererHelper.RenderingInformation renderingInformation) {
         double height = renderer.getHeaderHeight();
-        height = height + renderingInformation.getAllRowHeights().stream().reduce(0d, Double::sum);
+        for (double h : renderingInformation.getAllRowHeights()) {
+            height = height + h;
+        }
         return height;
     }
 
@@ -283,8 +285,6 @@ public class BaseGridWidget extends Group implements GridWidget {
     protected void drawWithoutTransforms(Context2D context,
                                          double alpha,
                                          BoundingBox bb) {
-        long currentTimeMillis = 0;
-
         final boolean isSelectionLayer = context.isSelection();
         if (isSelectionLayer && (false == isListening())) {
             return;
@@ -301,47 +301,28 @@ public class BaseGridWidget extends Group implements GridWidget {
         //Clear existing content
         this.removeAll();
 
+        long currentTimeMillis = 0;
         if (!isSelectionLayer) {
             //If there's no RenderingInformation the GridWidget is not visible
-            if (LOGGER.isLoggable(Level.FINEST)) {
-                currentTimeMillis = System.currentTimeMillis();
-                LOGGER.log(Level.FINEST, " - Pre- prepare()");
-            }
+            currentTimeMillis = log(" - Pre- prepare()");
             this.renderingInformation = prepare();
-            if (LOGGER.isLoggable(Level.FINEST)) {
-                LOGGER.log(Level.FINEST, " - Post- prepare() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-            }
+            log(" - Post- prepare() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
             if (renderingInformation == null) {
                 destroyDOMElementResources();
                 return;
             }
-            if (LOGGER.isLoggable(Level.FINEST)) {
-                currentTimeMillis = System.currentTimeMillis();
-                LOGGER.log(Level.FINEST, " - Pre- makeRenderingCommands()");
-            }
+            currentTimeMillis = log(" - Pre- makeRenderingCommands()");
             makeRenderingCommands();
-            if (LOGGER.isLoggable(Level.FINEST)) {
-                LOGGER.log(Level.FINEST, " - Post- makeRenderingCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-            }
+            log(" - Post- makeRenderingCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
         }
 
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- layerRenderGroups()");
-        }
+        currentTimeMillis = log(" - Pre- layerRenderGroups()");
         layerRenderGroups();
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- layerRenderGroups() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(" - Post- layerRenderGroups() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
 
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- executeRenderQueueCommands()");
-        }
+        currentTimeMillis = log(" - Pre- executeRenderQueueCommands()");
         executeRenderQueueCommands(isSelectionLayer);
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- executeRenderQueueCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(" - Post- executeRenderQueueCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
 
         //Signal columns to free any unused resources
         if (!isSelectionLayer) {
@@ -353,16 +334,11 @@ public class BaseGridWidget extends Group implements GridWidget {
         }
 
         //Then render to the canvas
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- super.drawWithoutTransforms()");
-        }
+        currentTimeMillis = log(" - Pre- super.drawWithoutTransforms()");
         super.drawWithoutTransforms(context,
                                     alpha,
                                     bb);
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- super.drawWithoutTransforms() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(" - Post- super.drawWithoutTransforms() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
     }
 
     private BaseGridRendererHelper.RenderingInformation prepare() {
@@ -382,15 +358,9 @@ public class BaseGridWidget extends Group implements GridWidget {
         this.renderQueue.clear();
 
         //If there's no RenderingInformation the GridWidget is not visible
-        long currentTimeMillis = 0;
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- getRenderingInformation()");
-        }
+        long currentTimeMillis = log(" - Pre- getRenderingInformation()");
         final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- getRenderingInformation() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(" - Post- getRenderingInformation() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
         if (renderingInformation == null) {
             return null;
         }
@@ -893,5 +863,12 @@ public class BaseGridWidget extends Group implements GridWidget {
                                           final int uiColumnIndex) {
         // no operation by default
         return false;
+    }
+
+    private static long log(final String message) {
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, message);
+        }
+        return System.currentTimeMillis();
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidget.java
@@ -283,7 +283,7 @@ public class BaseGridWidget extends Group implements GridWidget {
     protected void drawWithoutTransforms(Context2D context,
                                          double alpha,
                                          BoundingBox bb) {
-        long currentTimeMillis;
+        long currentTimeMillis = 0;
 
         final boolean isSelectionLayer = context.isSelection();
         if (isSelectionLayer && (false == isListening())) {
@@ -303,29 +303,45 @@ public class BaseGridWidget extends Group implements GridWidget {
 
         if (!isSelectionLayer) {
             //If there's no RenderingInformation the GridWidget is not visible
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- prepare()");
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                currentTimeMillis = System.currentTimeMillis();
+                LOGGER.log(Level.FINEST, " - Pre- prepare()");
+            }
             this.renderingInformation = prepare();
-            LOGGER.log(Level.FINEST, " - Post- prepare() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, " - Post- prepare() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+            }
             if (renderingInformation == null) {
                 destroyDOMElementResources();
                 return;
             }
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- makeRenderingCommands()");
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                currentTimeMillis = System.currentTimeMillis();
+                LOGGER.log(Level.FINEST, " - Pre- makeRenderingCommands()");
+            }
             makeRenderingCommands();
-            LOGGER.log(Level.FINEST, " - Post- makeRenderingCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST, " - Post- makeRenderingCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+            }
         }
 
-        currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- layerRenderGroups()");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- layerRenderGroups()");
+        }
         layerRenderGroups();
-        LOGGER.log(Level.FINEST, " - Post- layerRenderGroups() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- layerRenderGroups() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
 
-        currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- executeRenderQueueCommands()");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- executeRenderQueueCommands()");
+        }
         executeRenderQueueCommands(isSelectionLayer);
-        LOGGER.log(Level.FINEST, " - Post- executeRenderQueueCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- executeRenderQueueCommands() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
 
         //Signal columns to free any unused resources
         if (!isSelectionLayer) {
@@ -337,12 +353,16 @@ public class BaseGridWidget extends Group implements GridWidget {
         }
 
         //Then render to the canvas
-        currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- super.drawWithoutTransforms()");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- super.drawWithoutTransforms()");
+        }
         super.drawWithoutTransforms(context,
                                     alpha,
                                     bb);
-        LOGGER.log(Level.FINEST, " - Post- super.drawWithoutTransforms() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- super.drawWithoutTransforms() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
     }
 
     private BaseGridRendererHelper.RenderingInformation prepare() {
@@ -362,10 +382,15 @@ public class BaseGridWidget extends Group implements GridWidget {
         this.renderQueue.clear();
 
         //If there's no RenderingInformation the GridWidget is not visible
-        long currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- getRenderingInformation()");
+        long currentTimeMillis = 0;
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- getRenderingInformation()");
+        }
         final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
-        LOGGER.log(Level.FINEST, " - Post- getRenderingInformation() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- getRenderingInformation() - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
         if (renderingInformation == null) {
             return null;
         }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyFlattened.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyFlattened.java
@@ -27,7 +27,6 @@ import com.google.gwt.core.client.GWT;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
-import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyColumnRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
@@ -49,6 +48,7 @@ public class ColumnRenderingStrategyFlattened {
         final double clipMinX = context.getClipMinX();
         final int minVisibleRowIndex = context.getMinVisibleRowIndex();
         final int maxVisibleRowIndex = context.getMaxVisibleRowIndex();
+        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
         final List<Double> visibleRowOffsets = renderingInformation.getVisibleRowOffsets();
         final boolean isFloating = context.isFloating();
         final GridData model = context.getModel();
@@ -56,7 +56,7 @@ public class ColumnRenderingStrategyFlattened {
         final GridRenderer renderer = context.getRenderer();
         final GridRendererTheme theme = renderer.getTheme();
         final double columnWidth = column.getWidth();
-        final double columnHeight = visibleRowOffsets.get(maxVisibleRowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0) + model.getRow(maxVisibleRowIndex).getHeight();
+        final double columnHeight = visibleRowOffsets.get(maxVisibleRowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0) + allRowHeights.get(maxVisibleRowIndex);
 
         final List<GridRenderer.RendererCommand> commands = new ArrayList<>();
 
@@ -93,8 +93,7 @@ public class ColumnRenderingStrategyFlattened {
                 final int columnIndex = model.getColumns().indexOf(column);
                 for (int rowIndex = minVisibleRowIndex; rowIndex <= maxVisibleRowIndex; rowIndex++) {
                     final double y = visibleRowOffsets.get(rowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0);
-                    final GridRow row = model.getRow(rowIndex);
-                    final double rowHeight = row.getHeight();
+                    final double rowHeight = allRowHeights.get(rowIndex);
                     final GridBodyCellRenderContext cellContext = new GridBodyCellRenderContext(absoluteColumnX,
                                                                                                 absoluteGridY + renderer.getHeaderHeight() + visibleRowOffsets.get(rowIndex - minVisibleRowIndex),
                                                                                                 columnWidth,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
@@ -57,6 +57,7 @@ public class ColumnRenderingStrategyMerged {
         final double clipMinX = context.getClipMinX();
         final int minVisibleRowIndex = context.getMinVisibleRowIndex();
         final int maxVisibleRowIndex = context.getMaxVisibleRowIndex();
+        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
         final List<Double> visibleRowOffsets = renderingInformation.getVisibleRowOffsets();
         final boolean isFloating = context.isFloating();
         final GridData model = context.getModel();
@@ -64,7 +65,7 @@ public class ColumnRenderingStrategyMerged {
         final GridRenderer renderer = context.getRenderer();
         final GridRendererTheme theme = renderer.getTheme();
         final double columnWidth = column.getWidth();
-        final double columnHeight = visibleRowOffsets.get(maxVisibleRowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0) + model.getRow(maxVisibleRowIndex).getHeight();
+        final double columnHeight = visibleRowOffsets.get(maxVisibleRowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0) + allRowHeights.get(maxVisibleRowIndex);
         final int columnIndex = model.getColumns().indexOf(column);
 
         final List<GridRenderer.RendererCommand> commands = new ArrayList<>();
@@ -146,7 +147,7 @@ public class ColumnRenderingStrategyMerged {
 
                     if (isCollapsedCellMixedValue) {
                         final Group mixedValueGroup = renderMergedCellMixedValueHighlight(columnWidth,
-                                                                                          row.getHeight());
+                                                                                          allRowHeights.get(rowIndex));
                         mixedValueGroup.setX(0).setY(y).setListening(true);
                         columnGroup.add(mixedValueGroup);
                     }
@@ -162,7 +163,7 @@ public class ColumnRenderingStrategyMerged {
                                                                       columnIndex);
                         if (nextRowCell != null) {
                             final Group gt = renderGroupedCellToggle(columnWidth,
-                                                                     row.getHeight(),
+                                                                     allRowHeights.get(rowIndex),
                                                                      nextRowCell.isCollapsed());
                             gt.setX(0).setY(y);
                             columnGroup.add(gt);
@@ -172,7 +173,7 @@ public class ColumnRenderingStrategyMerged {
                     if (cell.getMergedCellCount() > 0) {
                         //If cell is "lead" i.e. top of a merged block centralize content in cell
                         final double cellHeight = getCellHeight(rowIndex,
-                                                                model,
+                                                                allRowHeights,
                                                                 cell);
                         final GridBodyCellRenderContext cellContext = new GridBodyCellRenderContext(absoluteColumnX,
                                                                                                     absoluteGridY + renderer.getHeaderHeight() + visibleRowOffsets.get(rowIndex - minVisibleRowIndex),
@@ -201,14 +202,14 @@ public class ColumnRenderingStrategyMerged {
                         GridCell<?> _cell = cell;
                         while (_cell.getMergedCellCount() == 0) {
                             _rowIndex--;
-                            _y = _y - model.getRow(_rowIndex).getHeight();
+                            _y = _y - allRowHeights.get(_rowIndex);
                             _cell = model.getCell(_rowIndex,
                                                   columnIndex);
                         }
 
                         final double cellHeight = getCellHeight(_rowIndex,
-                                                                model,
-                                                                _cell);
+                                                                allRowHeights,
+                                                                cell);
                         final GridBodyCellRenderContext cellContext = new GridBodyCellRenderContext(absoluteColumnX,
                                                                                                     absoluteGridY + renderer.getHeaderHeight() + rendererHelper.getRowOffset(_rowIndex),
                                                                                                     columnWidth,
@@ -305,10 +306,10 @@ public class ColumnRenderingStrategyMerged {
     }
 
     protected static double getCellHeight(final int rowIndex,
-                                          final GridData model,
+                                          final List<Double> allRowHeights,
                                           final GridCell<?> cell) {
         return IntStream.range(rowIndex, rowIndex + cell.getMergedCellCount())
-                .mapToDouble(index -> model.getRow(index).getHeight())
+                .mapToDouble(allRowHeights::get)
                 .sum();
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
@@ -22,14 +22,13 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.IntStream;
 
-import com.ait.lienzo.client.core.shape.BoundingBoxPathClipper;
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPathClipper;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Rectangle;
-import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Transform;
 import com.ait.lienzo.shared.core.types.ColorName;
+import com.google.gwt.core.client.GWT;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
@@ -116,7 +115,8 @@ public class ColumnRenderingStrategyMerged {
         //Column content
         commands.add((GridRenderer.RenderBodyGridContentCommand) (rc) -> {
             if (columnRenderingConstraint.apply(rc.isSelectionLayer(), column)) {
-                final Group columnGroup = new Group().setX(x);
+                final Group columnGroup = GWT.create(Group.class);
+                columnGroup.setX(x);
                 int iterations = 0;
                 for (int rowIndex = minVisibleRowIndex; rowIndex <= maxVisibleRowIndex; rowIndex++) {
 
@@ -235,11 +235,11 @@ public class ColumnRenderingStrategyMerged {
 
                 //Clip Column Group
                 final double gridLinesStrokeWidth = theme.getBodyGridLine().getStrokeWidth();
-                final BoundingBox bb = new BoundingBox(gridLinesStrokeWidth,
-                                                       0,
-                                                       columnWidth - gridLinesStrokeWidth,
-                                                       columnHeight);
-                final IPathClipper clipper = new BoundingBoxPathClipper(bb);
+                final BoundingBoxPathClipperFactory boundingBoxPathClipperFactory = GWT.create(BoundingBoxPathClipperFactory.class);
+                final IPathClipper clipper = boundingBoxPathClipperFactory.newClipper(gridLinesStrokeWidth,
+                                                                                      0,
+                                                                                      columnWidth - gridLinesStrokeWidth,
+                                                                                      columnHeight);
                 columnGroup.setPathClipper(clipper);
                 clipper.setActive(true);
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMerged.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
-import java.util.stream.IntStream;
 
 import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.IPathClipper;
@@ -308,9 +307,11 @@ public class ColumnRenderingStrategyMerged {
     protected static double getCellHeight(final int rowIndex,
                                           final List<Double> allRowHeights,
                                           final GridCell<?> cell) {
-        return IntStream.range(rowIndex, rowIndex + cell.getMergedCellCount())
-                .mapToDouble(allRowHeights::get)
-                .sum();
+        double height = 0.0;
+        for (int iRowIndex = rowIndex; iRowIndex < rowIndex + cell.getMergedCellCount(); iRowIndex++) {
+            height = height + allRowHeights.get(iRowIndex);
+        }
+        return height;
     }
 
     private static Group renderGroupedCellToggle(final double cellWidth,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
@@ -349,9 +349,10 @@ public class BaseGridRenderer implements GridRenderer {
         final GridRenderer renderer = context.getRenderer();
 
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
+        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
         final List<Double> visibleRowOffsets = renderingInformation.getVisibleRowOffsets();
 
-        final double columnHeight = visibleRowOffsets.get(maxVisibleRowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0) + model.getRow(maxVisibleRowIndex).getHeight();
+        final double columnHeight = visibleRowOffsets.get(maxVisibleRowIndex - minVisibleRowIndex) - visibleRowOffsets.get(0) + allRowHeights.get(maxVisibleRowIndex);
 
         //Column backgrounds
         double cx = 0;
@@ -487,7 +488,12 @@ public class BaseGridRenderer implements GridRenderer {
 
         final int visibleRowIndex = getHighlightCellRowIndex() - renderingInformation.getMinVisibleRowIndex();
 
-        final RendererCommand renderCommand = getRendererCommand(model, context, rendererHelper, column, visibleRowIndex);
+        final RendererCommand renderCommand = getRendererCommand(model,
+                                                                 context,
+                                                                 rendererHelper,
+                                                                 renderingInformation,
+                                                                 column,
+                                                                 visibleRowIndex);
 
         return renderCommand;
     }
@@ -495,6 +501,7 @@ public class BaseGridRenderer implements GridRenderer {
     RendererCommand getRendererCommand(final GridData model,
                                        final GridBodyRenderContext context,
                                        final BaseGridRendererHelper rendererHelper,
+                                       final BaseGridRendererHelper.RenderingInformation renderingInformation,
                                        final GridColumn<?> column,
                                        final int visibleRowIndex) {
         return (rc) -> {
@@ -505,6 +512,7 @@ public class BaseGridRenderer implements GridRenderer {
                                                         visibleRowIndex,
                                                         model,
                                                         rendererHelper,
+                                                        renderingInformation,
                                                         column,
                                                         context));
                 }
@@ -516,13 +524,14 @@ public class BaseGridRenderer implements GridRenderer {
                                 final int visibleRowIndex,
                                 final GridData model,
                                 final BaseGridRendererHelper rendererHelper,
+                                final BaseGridRendererHelper.RenderingInformation renderingInformation,
                                 final GridColumn<?> column,
                                 final GridBodyRenderContext context) {
 
         final Rectangle r = getTheme().getHighlightedCellBackground().setListening(false);
         setCellHighlightX(r, context, rendererHelper);
         setCellHighlightY(r, rendererHelper, visibleRowIndex, model);
-        setCellHighlightSize(r, model, column, rowIndex);
+        setCellHighlightSize(r, model, column, renderingInformation.getAllRowHeights(), rowIndex);
         return r;
     }
 
@@ -565,16 +574,18 @@ public class BaseGridRenderer implements GridRenderer {
     void setCellHighlightSize(final Rectangle rectangle,
                               final GridData model,
                               final GridColumn<?> column,
+                              final List<Double> allRowHeights,
                               final int rowIndex) {
 
         final double width = column.getWidth();
         rectangle.setWidth(width);
 
         final int mergedCellsCount = getMergedCellsCount(model, rowIndex);
-        rectangle.setHeight(model.getRow(rowIndex).getHeight() * mergedCellsCount);
+        rectangle.setHeight(allRowHeights.get(rowIndex) * mergedCellsCount);
     }
 
-    int getMergedCellsCount(final GridData model, final int rowIndex) {
+    int getMergedCellsCount(final GridData model,
+                            final int rowIndex) {
 
         int currentIndex = rowIndex;
         GridCell<?> cell = model.getCell(rowIndex, getHighlightCellColumnIndex());

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
@@ -488,14 +488,12 @@ public class BaseGridRenderer implements GridRenderer {
 
         final int visibleRowIndex = getHighlightCellRowIndex() - renderingInformation.getMinVisibleRowIndex();
 
-        final RendererCommand renderCommand = getRendererCommand(model,
-                                                                 context,
-                                                                 rendererHelper,
-                                                                 renderingInformation,
-                                                                 column,
-                                                                 visibleRowIndex);
-
-        return renderCommand;
+        return getRendererCommand(model,
+                                  context,
+                                  rendererHelper,
+                                  renderingInformation,
+                                  column,
+                                  visibleRowIndex);
     }
 
     RendererCommand getRendererCommand(final GridData model,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
@@ -212,9 +212,11 @@ public class BaseGridRendererHelper {
         }
 
         //Identify rows to render
-        long currentTimeMillis;
-        currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- identify rows to render");
+        long currentTimeMillis = 0;
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- identify rows to render");
+        }
 
         int minVisibleRowIndex = 0;
         if (model.getRowCount() > 0) {
@@ -233,11 +235,15 @@ public class BaseGridRendererHelper {
                 maxVisibleRowIndex++;
             }
         }
-        LOGGER.log(Level.FINEST, " - Post- identify rows to render - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- identify rows to render - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
 
         //Identify columns to render
-        currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- identify columns to render");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- identify columns to render");
+        }
 
         double x = 0;
         for (GridColumn<?> column : model.getColumns()) {
@@ -281,7 +287,9 @@ public class BaseGridRendererHelper {
                 }
             }
         }
-        LOGGER.log(Level.FINEST, " - Post- identify columns to render - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- identify columns to render - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
 
         //Construct details of Floating and Body blocks
         double visibleRowOffset = getRowOffset(minVisibleRowIndex, rowHeights);
@@ -304,8 +312,10 @@ public class BaseGridRendererHelper {
         // The minVisibleRowIndex corresponds to index zero and maxVisibleRowIndex corresponds to visibleRowOffsets.size() - 1.
         // This is useful to calculate the Y co-ordinate of each Row's top. It is calculated once and passed to
         // each column as an optimisation to prevent each column from recalculating the same values.
-        currentTimeMillis = System.currentTimeMillis();
-        LOGGER.log(Level.FINEST, " - Pre- calculate row offsets");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            currentTimeMillis = System.currentTimeMillis();
+            LOGGER.log(Level.FINEST, " - Pre- calculate row offsets");
+        }
 
         final List<Double> visibleRowOffsets = new ArrayList<>();
         if (model.getRowCount() > 0) {
@@ -314,7 +324,9 @@ public class BaseGridRendererHelper {
                 visibleRowOffset = visibleRowOffset + rowHeights.get(rowIndex);
             }
         }
-        LOGGER.log(Level.FINEST, " - Post- calculate row offsets - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, " - Post- calculate row offsets - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
+        }
 
         final int headerRowCount = model.getHeaderRowCount();
         final double headerHeight = renderer.getHeaderHeight();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.uberfire.ext.wires.core.grids.client.model.Bounds;
@@ -29,6 +28,8 @@ import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static org.uberfire.ext.wires.core.grids.client.util.Logging.log;
 
 /**
  * Helper for rendering a grid.
@@ -212,11 +213,7 @@ public class BaseGridRendererHelper {
         }
 
         //Identify rows to render
-        long currentTimeMillis = 0;
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- identify rows to render");
-        }
+        long currentTimeMillis = log(LOGGER, " - Pre- identify rows to render");
 
         int minVisibleRowIndex = 0;
         if (model.getRowCount() > 0) {
@@ -235,15 +232,10 @@ public class BaseGridRendererHelper {
                 maxVisibleRowIndex++;
             }
         }
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- identify rows to render - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(LOGGER, " - Post- identify rows to render", currentTimeMillis);
 
         //Identify columns to render
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- identify columns to render");
-        }
+        currentTimeMillis = log(LOGGER, " - Pre- identify columns to render");
 
         double x = 0;
         for (GridColumn<?> column : model.getColumns()) {
@@ -287,9 +279,7 @@ public class BaseGridRendererHelper {
                 }
             }
         }
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- identify columns to render - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(LOGGER, " - Post- identify columns to render", currentTimeMillis);
 
         //Construct details of Floating and Body blocks
         double visibleRowOffset = getRowOffset(minVisibleRowIndex, rowHeights);
@@ -312,10 +302,7 @@ public class BaseGridRendererHelper {
         // The minVisibleRowIndex corresponds to index zero and maxVisibleRowIndex corresponds to visibleRowOffsets.size() - 1.
         // This is useful to calculate the Y co-ordinate of each Row's top. It is calculated once and passed to
         // each column as an optimisation to prevent each column from recalculating the same values.
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            currentTimeMillis = System.currentTimeMillis();
-            LOGGER.log(Level.FINEST, " - Pre- calculate row offsets");
-        }
+        currentTimeMillis = log(LOGGER, " - Pre- calculate row offsets");
 
         final List<Double> visibleRowOffsets = new ArrayList<>();
         if (model.getRowCount() > 0) {
@@ -324,9 +311,7 @@ public class BaseGridRendererHelper {
                 visibleRowOffset = visibleRowOffset + rowHeights.get(rowIndex);
             }
         }
-        if (LOGGER.isLoggable(Level.FINEST)) {
-            LOGGER.log(Level.FINEST, " - Post- calculate row offsets - " + (System.currentTimeMillis() - currentTimeMillis) + "ms");
-        }
+        log(LOGGER, " - Post- calculate row offsets", currentTimeMillis);
 
         final int headerRowCount = model.getHeaderRowCount();
         final double headerHeight = renderer.getHeaderHeight();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelper.java
@@ -158,9 +158,9 @@ public class BaseGridRendererHelper {
     public RenderingInformation getRenderingInformation() {
         final GridData model = view.getModel();
         final Bounds bounds = getVisibleBounds();
-        final List<GridColumn<?>> allColumns = new ArrayList<GridColumn<?>>();
-        final List<GridColumn<?>> bodyColumns = new ArrayList<GridColumn<?>>();
-        final List<GridColumn<?>> floatingColumns = new ArrayList<GridColumn<?>>();
+        final List<GridColumn<?>> allColumns = new ArrayList<>();
+        final List<GridColumn<?>> bodyColumns = new ArrayList<>();
+        final List<GridColumn<?>> floatingColumns = new ArrayList<>();
 
         double viewHeight = 0;
         final int rowCount = model.getRowCount();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/selections/impl/BaseCellSelectionManager.java
@@ -465,7 +465,8 @@ public class BaseCellSelectionManager implements CellSelectionManager {
                                                                                                            uiColumnIndex,
                                                                                                            rendererHelper);
         final double cellHeight = getCellHeight(uiRowIndex,
-                                                uiColumnIndex);
+                                                uiColumnIndex,
+                                                renderingInformation);
 
         final Group header = gridWidget.getHeader();
         final double clipMinX = gridWidgetComputedLocation.getX() + floatingX + floatingWidth;
@@ -514,38 +515,43 @@ public class BaseCellSelectionManager implements CellSelectionManager {
     }
 
     private double getCellHeight(final int uiRowIndex,
-                                 final int uiColumnIndex) {
-        final GridCell<?> cell = gridModel.getCell(uiRowIndex,
-                                                   uiColumnIndex);
+                                 final int uiColumnIndex,
+                                 final BaseGridRendererHelper.RenderingInformation renderingInformation) {
+        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
+        final GridCell<?> cell = gridModel.getCell(uiRowIndex, uiColumnIndex);
         if (cell == null) {
-            return gridModel.getRow(uiRowIndex).getHeight();
+            return allRowHeights.get(uiRowIndex);
         }
         if (cell.getMergedCellCount() == 1) {
-            return gridModel.getRow(uiRowIndex).getHeight();
+            return allRowHeights.get(uiRowIndex);
         } else if (cell.getMergedCellCount() > 1) {
             return getMergedCellHeight(uiRowIndex,
-                                       uiColumnIndex);
+                                       uiColumnIndex,
+                                       renderingInformation);
         } else {
             return getClippedMergedCellHeight(uiRowIndex,
-                                              uiColumnIndex);
+                                              uiColumnIndex,
+                                              renderingInformation);
         }
     }
 
     private double getMergedCellHeight(final int uiRowIndex,
-                                       final int uiColumnIndex) {
+                                       final int uiColumnIndex,
+                                       final BaseGridRendererHelper.RenderingInformation renderingInformation) {
         double height = 0;
-        final GridCell<?> cell = gridModel.getCell(uiRowIndex,
-                                                   uiColumnIndex);
+        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
+        final GridCell<?> cell = gridModel.getCell(uiRowIndex, uiColumnIndex);
         for (int i = uiRowIndex; i < uiRowIndex + cell.getMergedCellCount(); i++) {
-            height = height + gridModel.getRow(i).getHeight();
+            height = height + allRowHeights.get(i);
         }
         return height;
     }
 
     private double getClippedMergedCellHeight(final int uiRowIndex,
-                                              final int uiColumnIndex) {
-        final GridCell<?> cell = gridModel.getCell(uiRowIndex,
-                                                   uiColumnIndex);
+                                              final int uiColumnIndex,
+                                              final BaseGridRendererHelper.RenderingInformation renderingInformation) {
+        final List<Double> allRowHeights = renderingInformation.getAllRowHeights();
+        final GridCell<?> cell = gridModel.getCell(uiRowIndex, uiColumnIndex);
         GridCell<?> _cell = cell;
         int _uiRowIndex = uiRowIndex;
         while (_cell.getMergedCellCount() == 0) {
@@ -555,7 +561,7 @@ public class BaseCellSelectionManager implements CellSelectionManager {
         }
         double height = 0;
         for (int i = _uiRowIndex; i < _uiRowIndex + _cell.getMergedCellCount(); i++) {
-            height = height + gridModel.getRow(i).getHeight();
+            height = height + allRowHeights.get(i);
         }
         return height;
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanel.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanel.java
@@ -83,9 +83,53 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
                         height);
     }
 
+    public GridLienzoPanel(final DefaultGridLayer defaultGridLayer) {
+        this(new LienzoPanel() {
+                 @Override
+                 public void onResize() {
+                     // Do nothing. Resize is handled by AttachHandler. LienzoPanel calls onResize() in
+                     // it's onAttach() method which causes the Canvas to be redrawn. However when LienzoPanel
+                     // is adopted by another Widget LienzoPanel's onAttach() is called before its children
+                     // have been attached. Should redraw require children to be attached errors arise.
+                 }
+             },
+             defaultGridLayer);
+    }
+
+    public GridLienzoPanel(final int width,
+                           final int height,
+                           final DefaultGridLayer defaultGridLayer) {
+        this(new LienzoPanel(width,
+                             height) {
+                 @Override
+                 public void onResize() {
+                     // Do nothing. Resize is handled by AttachHandler. LienzoPanel calls onResize() in
+                     // it's onAttach() method which causes the Canvas to be redrawn. However when LienzoPanel
+                     // is adopted by another Widget LienzoPanel's onAttach() is called before its children
+                     // have been attached. Should redraw require children to be attached errors arise.
+                 }
+             },
+             defaultGridLayer);
+
+        updatePanelSize(width,
+                        height);
+    }
+
     private GridLienzoPanel(final LienzoPanel lienzoPanel) {
         this.lienzoPanel = lienzoPanel;
         this.gridLienzoScrollHandler = new GridLienzoScrollHandler(this);
+
+        setupPanels();
+        setupScrollHandlers();
+        setupDefaultHandlers();
+    }
+
+    private GridLienzoPanel(final LienzoPanel lienzoPanel,
+                            final DefaultGridLayer defaultGridLayer) {
+        this.lienzoPanel = lienzoPanel;
+        this.gridLienzoScrollHandler = new GridLienzoScrollHandler(this);
+
+        add(defaultGridLayer);
 
         setupPanels();
         setupScrollHandlers();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanel.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanel.java
@@ -115,7 +115,7 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
                         height);
     }
 
-    private GridLienzoPanel(final LienzoPanel lienzoPanel) {
+    protected GridLienzoPanel(final LienzoPanel lienzoPanel) {
         this.lienzoPanel = lienzoPanel;
         this.gridLienzoScrollHandler = new GridLienzoScrollHandler(this);
 
@@ -124,8 +124,8 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         setupDefaultHandlers();
     }
 
-    private GridLienzoPanel(final LienzoPanel lienzoPanel,
-                            final DefaultGridLayer defaultGridLayer) {
+    protected GridLienzoPanel(final LienzoPanel lienzoPanel,
+                              final DefaultGridLayer defaultGridLayer) {
         this.lienzoPanel = lienzoPanel;
         this.gridLienzoScrollHandler = new GridLienzoScrollHandler(this);
 
@@ -136,7 +136,7 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         setupDefaultHandlers();
     }
 
-    void setupPanels() {
+    protected void setupPanels() {
         setupScrollPanel();
         setupDomElementContainer();
         setupRootPanel();
@@ -145,29 +145,29 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         getElement().getStyle().setOutlineStyle(Style.OutlineStyle.NONE);
     }
 
-    void setupScrollPanel() {
+    protected void setupScrollPanel() {
         getScrollPanel().add(getInternalScrollPanel());
     }
 
-    void setupDomElementContainer() {
+    protected void setupDomElementContainer() {
         getDomElementContainer().add(getLienzoPanel());
     }
 
-    void setupRootPanel() {
+    protected void setupRootPanel() {
         getRootPanel().add(getDomElementContainer());
         getRootPanel().add(getScrollPanel());
     }
 
-    void setupScrollHandlers() {
+    protected void setupScrollHandlers() {
         getGridLienzoScrollHandler().init();
         addMouseUpHandler();
     }
 
-    void addMouseUpHandler() {
+    protected void addMouseUpHandler() {
         addMouseUpHandler((e) -> refreshScrollPosition());
     }
 
-    void setupDefaultHandlers() {
+    protected void setupDefaultHandlers() {
         //Prevent DOMElements scrolling into view when they receive the focus
         domElementContainer.addDomHandler(new ScrollHandler() {
 
@@ -197,7 +197,7 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         });
     }
 
-    void scheduleDeferred(final Scheduler.ScheduledCommand scheduledCommand) {
+    protected void scheduleDeferred(final Scheduler.ScheduledCommand scheduledCommand) {
         Scheduler.get().scheduleDeferred(scheduledCommand);
     }
 
@@ -222,8 +222,8 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
                                   height);
     }
 
-    private void updateInternalPanelsSizes(final int width,
-                                           final int height) {
+    protected void updateInternalPanelsSizes(final int width,
+                                             final int height) {
         final Integer scrollbarWidth = getGridLienzoScrollHandler().scrollbarWidth();
         final Integer scrollbarHeight = getGridLienzoScrollHandler().scrollbarHeight();
 
@@ -238,8 +238,8 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         propagateNewPanelSize(visibleWidth, visibleHeight);
     }
 
-    private void updateScrollPanelSize(final int width,
-                                       final int height) {
+    protected void updateScrollPanelSize(final int width,
+                                         final int height) {
         getScrollPanel().setPixelSize(width,
                                       height);
     }
@@ -278,7 +278,7 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         return lienzoPanel;
     }
 
-    private DefaultGridLayer setupDefaultGridLayer(final DefaultGridLayer layer) {
+    protected DefaultGridLayer setupDefaultGridLayer(final DefaultGridLayer layer) {
         layer.addOnEnterPinnedModeCommand(this::refreshScrollPosition);
         layer.addOnExitPinnedModeCommand(this::refreshScrollPosition);
 
@@ -309,11 +309,11 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         return defaultGridLayer;
     }
 
-    AbsolutePanel getRootPanel() {
+    protected AbsolutePanel getRootPanel() {
         return rootPanel;
     }
 
-    GridLienzoScrollHandler getGridLienzoScrollHandler() {
+    protected GridLienzoScrollHandler getGridLienzoScrollHandler() {
         return gridLienzoScrollHandler;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanel.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanel.java
@@ -167,7 +167,7 @@ public class GridLienzoPanel extends FocusPanel implements RequiresResize,
         addMouseUpHandler((e) -> refreshScrollPosition());
     }
 
-    private void setupDefaultHandlers() {
+    void setupDefaultHandlers() {
         //Prevent DOMElements scrolling into view when they receive the focus
         domElementContainer.addDomHandler(new ScrollHandler() {
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
@@ -16,7 +16,7 @@
 
 package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
 
-import java.util.Optional;
+import java.util.Objects;
 
 import com.ait.lienzo.client.core.event.NodeMouseMoveEvent;
 import com.ait.lienzo.client.core.shape.Viewport;
@@ -224,7 +224,9 @@ public class GridLienzoScrollHandler {
     }
 
     DefaultGridLayer getDefaultGridLayer() {
-        return Optional.ofNullable(panel.getDefaultGridLayer()).orElse(emptyLayer());
+        //Do not use Optional.ofNullable(..).orElse(..) as the _else_ expression is *always* invoked
+        final DefaultGridLayer defaultGridLayer = panel.getDefaultGridLayer();
+        return Objects.nonNull(defaultGridLayer) ? defaultGridLayer : emptyLayer();
     }
 
     Viewport getViewport() {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
@@ -39,9 +39,15 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.Restri
 
 public class GridLienzoScrollHandler {
 
-    private final GridLienzoPanel panel;
+    private final DefaultGridLayer EMPTY = new DefaultGridLayer();
 
-    private final GridLienzoScrollBounds gridLienzoScrollBounds;
+    private final GridLienzoScrollBars SCROLL_BARS = new GridLienzoScrollBars(this);
+
+    private final GridLienzoScrollPosition SCROLL_POSITION = new GridLienzoScrollPosition(this);
+
+    private final GridLienzoScrollBounds SCROLL_BOUNDS = new GridLienzoScrollBounds(this);
+
+    private final GridLienzoPanel panel;
 
     static final int DEFAULT_INTERNAL_SCROLL_HEIGHT = 1;
 
@@ -51,7 +57,6 @@ public class GridLienzoScrollHandler {
 
     public GridLienzoScrollHandler(final GridLienzoPanel panel) {
         this.panel = panel;
-        this.gridLienzoScrollBounds = new GridLienzoScrollBounds(this);
     }
 
     public void init() {
@@ -234,19 +239,19 @@ public class GridLienzoScrollHandler {
     }
 
     DefaultGridLayer emptyLayer() {
-        return new DefaultGridLayer();
+        return EMPTY;
     }
 
     GridLienzoScrollBars scrollBars() {
-        return new GridLienzoScrollBars(this);
+        return SCROLL_BARS;
     }
 
     GridLienzoScrollPosition scrollPosition() {
-        return new GridLienzoScrollPosition(this);
+        return SCROLL_POSITION;
     }
 
     GridLienzoScrollBounds scrollBounds() {
-        return gridLienzoScrollBounds;
+        return SCROLL_BOUNDS;
     }
 
     public void setBounds(final Bounds bounds) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
@@ -43,8 +43,6 @@ public class GridLienzoScrollHandler {
 
     static final int DEFAULT_INTERNAL_SCROLL_WIDTH = 1;
 
-    private final DefaultGridLayer emptyLayer = new DefaultGridLayer();
-
     private final GridLienzoScrollBars scrollBars = new GridLienzoScrollBars(this);
 
     private final GridLienzoScrollPosition scrollPosition = new GridLienzoScrollPosition(this);
@@ -52,6 +50,8 @@ public class GridLienzoScrollHandler {
     private final GridLienzoScrollBounds scrollBounds = new GridLienzoScrollBounds(this);
 
     private final GridLienzoPanel panel;
+
+    private DefaultGridLayer emptyLayer;
 
     private RestrictedMousePanMediator mousePanMediator;
 
@@ -239,6 +239,9 @@ public class GridLienzoScrollHandler {
     }
 
     DefaultGridLayer emptyLayer() {
+        if (Objects.isNull(emptyLayer)) {
+            emptyLayer = new DefaultGridLayer();
+        }
         return emptyLayer;
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
@@ -39,19 +39,19 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.Restri
 
 public class GridLienzoScrollHandler {
 
-    private final DefaultGridLayer EMPTY = new DefaultGridLayer();
-
-    private final GridLienzoScrollBars SCROLL_BARS = new GridLienzoScrollBars(this);
-
-    private final GridLienzoScrollPosition SCROLL_POSITION = new GridLienzoScrollPosition(this);
-
-    private final GridLienzoScrollBounds SCROLL_BOUNDS = new GridLienzoScrollBounds(this);
-
-    private final GridLienzoPanel panel;
-
     static final int DEFAULT_INTERNAL_SCROLL_HEIGHT = 1;
 
     static final int DEFAULT_INTERNAL_SCROLL_WIDTH = 1;
+
+    private final DefaultGridLayer emptyLayer = new DefaultGridLayer();
+
+    private final GridLienzoScrollBars scrollBars = new GridLienzoScrollBars(this);
+
+    private final GridLienzoScrollPosition scrollPosition = new GridLienzoScrollPosition(this);
+
+    private final GridLienzoScrollBounds scrollBounds = new GridLienzoScrollBounds(this);
+
+    private final GridLienzoPanel panel;
 
     private RestrictedMousePanMediator mousePanMediator;
 
@@ -239,19 +239,19 @@ public class GridLienzoScrollHandler {
     }
 
     DefaultGridLayer emptyLayer() {
-        return EMPTY;
+        return emptyLayer;
     }
 
     GridLienzoScrollBars scrollBars() {
-        return SCROLL_BARS;
+        return scrollBars;
     }
 
     GridLienzoScrollPosition scrollPosition() {
-        return SCROLL_POSITION;
+        return scrollPosition;
     }
 
     GridLienzoScrollBounds scrollBounds() {
-        return SCROLL_BOUNDS;
+        return scrollBounds;
     }
 
     public void setBounds(final Bounds bounds) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
@@ -142,6 +142,7 @@ public class CellContextUtilitiesTest {
         final double headerRowsHeight = 100.0;
         final BaseGridRow row = new BaseGridRow();
         final List<GridColumn<?>> allColumns = new ArrayList<>();
+        final List<Double> allRowHeights = new ArrayList<>(Collections.singletonList(row.getHeight()));
         final GridColumn<?> uiColumn1 = mockGridColumn(25.0);
         final GridColumn<?> uiColumn2 = mockGridColumn(60.0);
         final GridColumn<?> uiColumn3 = mockGridColumn(100.0);
@@ -152,6 +153,7 @@ public class CellContextUtilitiesTest {
 
         doReturn(allColumns).when(ri).getAllColumns();
         doReturn(headerRowsHeight).when(ri).getHeaderRowsHeight();
+        doReturn(allRowHeights).when(ri).getAllRowHeights();
         doReturn(uiColumn2).when(ci).getColumn();
         doReturn(25.0).when(ci).getOffsetX();
         doReturn(1).when(ci).getUiColumnIndex();
@@ -178,18 +180,21 @@ public class CellContextUtilitiesTest {
         final BaseGridRow row2 = new BaseGridRow();
         final BaseGridRow row3 = new BaseGridRow();
         final List<GridColumn<?>> allColumns = new ArrayList<>();
+        final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(3, row1.getHeight()));
         final GridColumn<?> uiColumn1 = mockGridColumn(25.0);
         final GridColumn<?> uiColumn2 = mockGridColumn(60.0);
         final GridColumn<?> uiColumn3 = mockGridColumn(100.0);
         allColumns.add(uiColumn1);
         allColumns.add(uiColumn2);
         allColumns.add(uiColumn3);
+
         gridWidget.getModel().appendRow(row1);
         gridWidget.getModel().appendRow(row2);
         gridWidget.getModel().appendRow(row3);
 
         doReturn(allColumns).when(ri).getAllColumns();
         doReturn(headerRowsHeight).when(ri).getHeaderRowsHeight();
+        doReturn(allRowHeights).when(ri).getAllRowHeights();
         doReturn(uiColumn3).when(ci).getColumn();
         doReturn(25.0).when(ci).getOffsetX();
         doReturn(3).when(ci).getUiColumnIndex();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
@@ -180,7 +180,7 @@ public class CellContextUtilitiesTest {
         final BaseGridRow row2 = new BaseGridRow();
         final BaseGridRow row3 = new BaseGridRow();
         final List<GridColumn<?>> allColumns = new ArrayList<>();
-        final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(3, row1.getHeight()));
+        final List<Double> allRowHeights = Collections.nCopies(3, row1.getHeight());
         final GridColumn<?> uiColumn1 = mockGridColumn(25.0);
         final GridColumn<?> uiColumn2 = mockGridColumn(60.0);
         final GridColumn<?> uiColumn3 = mockGridColumn(100.0);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
@@ -142,7 +142,7 @@ public class CellContextUtilitiesTest {
         final double headerRowsHeight = 100.0;
         final BaseGridRow row = new BaseGridRow();
         final List<GridColumn<?>> allColumns = new ArrayList<>();
-        final List<Double> allRowHeights = new ArrayList<>(Collections.singletonList(row.getHeight()));
+        final List<Double> allRowHeights = Collections.singletonList(row.getHeight());
         final GridColumn<?> uiColumn1 = mockGridColumn(25.0);
         final GridColumn<?> uiColumn2 = mockGridColumn(60.0);
         final GridColumn<?> uiColumn3 = mockGridColumn(100.0);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/LoggingTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/LoggingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.wires.core.grids.client.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoggingTest {
+
+    private static final String MESSAGE = "message";
+
+    private static final long PREVIOUS_TIME_MILLIS = 100;
+
+    @Mock
+    private Logger logger;
+
+    @Test
+    public void testLogEnabled() {
+        when(logger.isLoggable(Level.FINEST)).thenReturn(true);
+
+        assertThat(Logging.log(logger, MESSAGE)).isGreaterThan(0);
+
+        verify(logger).log(eq(Level.FINEST), eq(MESSAGE));
+    }
+
+    @Test
+    public void testLogWithPreviousTimeTimeMillisEnabled() {
+        when(logger.isLoggable(Level.FINEST)).thenReturn(true);
+
+        // There's no guarantee that the method takes >0 ms to complete
+        // so compare the result is at least the same as the previous time
+        assertThat(Logging.log(logger, MESSAGE, PREVIOUS_TIME_MILLIS)).isGreaterThanOrEqualTo(PREVIOUS_TIME_MILLIS);
+
+        verify(logger).log(eq(Level.FINEST), contains(MESSAGE));
+    }
+
+    @Test
+    public void testLogDisabled() {
+        when(logger.isLoggable(Level.FINEST)).thenReturn(false);
+
+        assertThat(Logging.log(logger, MESSAGE)).isGreaterThan(0);
+
+        verify(logger, never()).log(any(Level.class), anyString());
+    }
+
+    @Test
+    public void testLogWithPreviousTimeTimeMillisDisabled() {
+        when(logger.isLoggable(Level.FINEST)).thenReturn(false);
+
+        // There's no guarantee that the method takes >0 ms to complete
+        // so compare the result is at least the same as the previous time
+        assertThat(Logging.log(logger, MESSAGE, PREVIOUS_TIME_MILLIS)).isGreaterThanOrEqualTo(PREVIOUS_TIME_MILLIS);
+
+        verify(logger, never()).log(any(Level.class), anyString());
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
@@ -17,9 +17,12 @@
 package org.uberfire.ext.wires.core.grids.client.widget.dnd;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.ait.lienzo.client.core.event.NodeMouseDownEvent;
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
@@ -31,17 +34,25 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
 import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState.GridWidgetHandlersOperation;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -51,8 +62,25 @@ import static org.mockito.Mockito.when;
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridWidgetDnDMouseDownHandlerTest {
 
+    private static final double GRID_X = 10.0;
+
+    private static final double GRID_Y = 20.0;
+
+    private static final double GRID_WIDTH = 100.0;
+
+    private static final double GRID_HEIGHT = 200.0;
+
+    private static final double COLUMN_WIDTH = 25.0;
+
+    private static final double HEADER_HEIGHT = 25.0;/**/
+
+    private static final double ROW_HEIGHT = 32.0;
+
     @Mock
-    private GridLayer layer;
+    private GridLayer gridLayer;
+
+    @Mock
+    private Layer layer;
 
     @Mock
     private Viewport viewport;
@@ -67,7 +95,16 @@ public class GridWidgetDnDMouseDownHandlerTest {
     private GridWidget gridWidget;
 
     @Mock
-    private BaseGridRendererHelper helper;
+    private Group gridWidgetHeader;
+
+    @Mock
+    private GridRenderer gridRenderer;
+
+    @Mock
+    private BaseGridRendererHelper rendererHelper;
+
+    @Mock
+    private BaseGridRendererHelper.RenderingInformation renderingInformation;
 
     @Mock
     private GridColumn<String> uiColumn;
@@ -90,18 +127,20 @@ public class GridWidgetDnDMouseDownHandlerTest {
 
     @Before
     public void setup() {
-        when(layer.getViewport()).thenReturn(viewport);
+        when(gridLayer.getLayer()).thenReturn(layer);
+        when(gridLayer.getViewport()).thenReturn(viewport);
         when(viewport.getElement()).thenReturn(element);
         when(element.getStyle()).thenReturn(style);
         when(gridWidget.getViewport()).thenReturn(viewport);
-        when(gridWidget.getRendererHelper()).thenReturn(helper);
-        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(100,
-                                                                      100));
+        when(gridWidget.getRenderer()).thenReturn(gridRenderer);
+        when(gridWidget.getRendererHelper()).thenReturn(rendererHelper);
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(GRID_X, GRID_Y));
+        when(gridRenderer.getHeaderHeight()).thenReturn(HEADER_HEIGHT);
 
         final GridWidgetDnDHandlersState wrappedState = new GridWidgetDnDHandlersState();
         this.state = spy(wrappedState);
 
-        final GridWidgetDnDMouseDownHandler wrapped = new GridWidgetDnDMouseDownHandler(layer,
+        final GridWidgetDnDMouseDownHandler wrapped = new GridWidgetDnDMouseDownHandler(gridLayer,
                                                                                         state);
         this.handler = spy(wrapped);
     }
@@ -135,6 +174,17 @@ public class GridWidgetDnDMouseDownHandlerTest {
     }
 
     @Test
+    public void stateColumnResizePendingWithNoActiveColumn() {
+        when(state.getActiveGridWidget()).thenReturn(gridWidget);
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_RESIZE_PENDING);
+        when(state.getActiveGridColumns()).thenReturn(Collections.emptyList());
+
+        handler.onNodeMouseDown(event);
+
+        verify(state, never()).setOperation(any(GridWidgetHandlersOperation.class));
+    }
+
+    @Test
     public void stateColumnMovePendingMovesToColumnMove() {
         when(state.getActiveGridWidget()).thenReturn(gridWidget);
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_MOVE_PENDING);
@@ -155,6 +205,19 @@ public class GridWidgetDnDMouseDownHandlerTest {
         assertEquals(1,
                      uiColumns.size());
         assertTrue(uiColumns.contains(uiColumn));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void stateColumnMovePendingWithNoActiveColumns() {
+        when(state.getActiveGridWidget()).thenReturn(gridWidget);
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_MOVE_PENDING);
+        when(state.getActiveGridColumns()).thenReturn(Collections.emptyList());
+
+        handler.onNodeMouseDown(event);
+
+        verify(handler, never()).showColumnHighlight(any(GridWidget.class),
+                                                     any(List.class));
     }
 
     @Test
@@ -181,6 +244,19 @@ public class GridWidgetDnDMouseDownHandlerTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void stateRowMovePendingWithNoActiveRows() {
+        when(state.getActiveGridWidget()).thenReturn(gridWidget);
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.ROW_MOVE_PENDING);
+        when(state.getActiveGridRows()).thenReturn(Collections.emptyList());
+
+        handler.onNodeMouseDown(event);
+
+        verify(handler, never()).showRowHighlight(any(GridWidget.class),
+                                                  any(List.class));
+    }
+
+    @Test
     public void stateGridMovePendingMovesToGridMove() {
         when(state.getActiveGridWidget()).thenReturn(gridWidget);
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.GRID_MOVE_PENDING);
@@ -191,5 +267,65 @@ public class GridWidgetDnDMouseDownHandlerTest {
                times(1)).setOperation(GridWidgetHandlersOperation.GRID_MOVE);
         verify(gridWidget,
                times(1)).setDraggable(eq(true));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testColumnHighlight() {
+        final GridWidgetDnDProxy highlight = mock(GridWidgetDnDProxy.class);
+        final Bounds bounds = new BaseBounds(GRID_X, GRID_Y, GRID_WIDTH, GRID_HEIGHT);
+
+        when(state.getEventColumnHighlight()).thenReturn(highlight);
+        when(state.getActiveGridWidget()).thenReturn(gridWidget);
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_MOVE_PENDING);
+        when(state.getActiveGridColumns()).thenReturn(new ArrayList<GridColumn<?>>() {{
+            add(uiColumn);
+        }});
+
+        when(rendererHelper.getRenderingInformation()).thenReturn(renderingInformation);
+        when(rendererHelper.getRowOffset(anyInt(), any(List.class))).thenCallRealMethod();
+        when(renderingInformation.getBounds()).thenReturn(bounds);
+        when(gridWidget.getHeader()).thenReturn(gridWidgetHeader);
+        when(gridWidget.getHeight()).thenReturn(GRID_HEIGHT);
+        when(uiColumn.getWidth()).thenReturn(COLUMN_WIDTH);
+
+        handler.onNodeMouseDown(event);
+
+        verify(highlight).setWidth(COLUMN_WIDTH);
+        verify(highlight).setHeight(GRID_HEIGHT);
+        verify(highlight).setX(GRID_X);
+        verify(highlight).setY(GRID_Y);
+        verify(layer).batch();
+    }
+
+    @Test
+    public void testRowHighlight() {
+        final GridWidgetDnDProxy highlight = mock(GridWidgetDnDProxy.class);
+        final Bounds bounds = new BaseBounds(GRID_X, GRID_Y, GRID_WIDTH, GRID_HEIGHT);
+        final GridData gridData = new BaseGridData();
+        gridData.appendRow(uiRow);
+
+        when(state.getEventColumnHighlight()).thenReturn(highlight);
+        when(state.getActiveGridWidget()).thenReturn(gridWidget);
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.ROW_MOVE_PENDING);
+        when(state.getActiveGridRows()).thenReturn(new ArrayList<GridRow>() {{
+            add(uiRow);
+        }});
+
+        when(rendererHelper.getRenderingInformation()).thenReturn(renderingInformation);
+        when(renderingInformation.getBounds()).thenReturn(bounds);
+        when(renderingInformation.getAllRowHeights()).thenReturn(Collections.singletonList(ROW_HEIGHT));
+        when(gridWidget.getModel()).thenReturn(gridData);
+        when(gridWidget.getHeader()).thenReturn(gridWidgetHeader);
+        when(gridWidget.getWidth()).thenReturn(GRID_WIDTH);
+        when(uiRow.getHeight()).thenReturn(ROW_HEIGHT);
+
+        handler.onNodeMouseDown(event);
+
+        verify(highlight).setWidth(GRID_WIDTH);
+        verify(highlight).setHeight(ROW_HEIGHT);
+        verify(highlight).setX(GRID_X);
+        verify(highlight).setY(GRID_Y + HEADER_HEIGHT);
+        verify(layer).batch();
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
@@ -72,7 +72,7 @@ public class GridWidgetDnDMouseDownHandlerTest {
 
     private static final double COLUMN_WIDTH = 25.0;
 
-    private static final double HEADER_HEIGHT = 25.0;/**/
+    private static final double HEADER_HEIGHT = 25.0;
 
     private static final double ROW_HEIGHT = 32.0;
 
@@ -278,9 +278,7 @@ public class GridWidgetDnDMouseDownHandlerTest {
         when(state.getEventColumnHighlight()).thenReturn(highlight);
         when(state.getActiveGridWidget()).thenReturn(gridWidget);
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_MOVE_PENDING);
-        when(state.getActiveGridColumns()).thenReturn(new ArrayList<GridColumn<?>>() {{
-            add(uiColumn);
-        }});
+        when(state.getActiveGridColumns()).thenReturn(Collections.singletonList(uiColumn));
 
         when(rendererHelper.getRenderingInformation()).thenReturn(renderingInformation);
         when(rendererHelper.getRowOffset(anyInt(), any(List.class))).thenCallRealMethod();
@@ -308,9 +306,7 @@ public class GridWidgetDnDMouseDownHandlerTest {
         when(state.getEventColumnHighlight()).thenReturn(highlight);
         when(state.getActiveGridWidget()).thenReturn(gridWidget);
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.ROW_MOVE_PENDING);
-        when(state.getActiveGridRows()).thenReturn(new ArrayList<GridRow>() {{
-            add(uiRow);
-        }});
+        when(state.getActiveGridRows()).thenReturn(Collections.singletonList(uiRow));
 
         when(rendererHelper.getRenderingInformation()).thenReturn(renderingInformation);
         when(renderingInformation.getBounds()).thenReturn(bounds);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
@@ -168,6 +168,11 @@ public class GridWidgetDnDMouseMoveHandlerTest {
                                                                                                                2,
                                                                                                                new ArrayList<Double>() {{
                                                                                                                    add(20.0);
+                                                                                                                   add(20.0);
+                                                                                                                   add(20.0);
+                                                                                                               }},
+                                                                                                               new ArrayList<Double>() {{
+                                                                                                                   add(20.0);
                                                                                                                    add(40.0);
                                                                                                                    add(60.0);
                                                                                                                }},
@@ -201,16 +206,19 @@ public class GridWidgetDnDMouseMoveHandlerTest {
 
         verify(handler,
                never()).findMovableColumns(any(GridWidget.class),
+                                           any(BaseGridRendererHelper.RenderingInformation.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class));
         verify(handler,
                never()).findMovableRows(any(GridWidget.class),
+                                        any(BaseGridRendererHelper.RenderingInformation.class),
                                         any(Double.class),
                                         any(Double.class));
         verify(handler,
                never()).findResizableColumn(any(GridWidget.class),
+                                            any(BaseGridRendererHelper.RenderingInformation.class),
                                             any(Double.class));
     }
 
@@ -229,16 +237,19 @@ public class GridWidgetDnDMouseMoveHandlerTest {
 
         verify(handler,
                never()).findMovableColumns(any(GridWidget.class),
+                                           any(BaseGridRendererHelper.RenderingInformation.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class));
         verify(handler,
                never()).findMovableRows(any(GridWidget.class),
+                                        any(BaseGridRendererHelper.RenderingInformation.class),
                                         any(Double.class),
                                         any(Double.class));
         verify(handler,
                never()).findResizableColumn(any(GridWidget.class),
+                                            any(BaseGridRendererHelper.RenderingInformation.class),
                                             any(Double.class));
     }
 
@@ -261,16 +272,19 @@ public class GridWidgetDnDMouseMoveHandlerTest {
 
         verify(handler,
                times(1)).findMovableColumns(any(GridWidget.class),
+                                            any(BaseGridRendererHelper.RenderingInformation.class),
                                             any(Double.class),
                                             any(Double.class),
                                             any(Double.class),
                                             any(Double.class));
         verify(handler,
                never()).findMovableRows(any(GridWidget.class),
+                                        any(BaseGridRendererHelper.RenderingInformation.class),
                                         any(Double.class),
                                         any(Double.class));
         verify(handler,
                never()).findResizableColumn(any(GridWidget.class),
+                                            any(BaseGridRendererHelper.RenderingInformation.class),
                                             any(Double.class));
 
         verify(state,
@@ -370,16 +384,19 @@ public class GridWidgetDnDMouseMoveHandlerTest {
 
         verify(handler,
                times(1)).findMovableColumns(any(GridWidget.class),
+                                            any(BaseGridRendererHelper.RenderingInformation.class),
                                             any(Double.class),
                                             any(Double.class),
                                             any(Double.class),
                                             any(Double.class));
         verify(handler,
                never()).findMovableRows(any(GridWidget.class),
+                                        any(BaseGridRendererHelper.RenderingInformation.class),
                                         any(Double.class),
                                         any(Double.class));
         verify(handler,
                never()).findResizableColumn(any(GridWidget.class),
+                                            any(BaseGridRendererHelper.RenderingInformation.class),
                                             any(Double.class));
 
         verify(state,
@@ -414,16 +431,19 @@ public class GridWidgetDnDMouseMoveHandlerTest {
 
         verify(handler,
                never()).findMovableColumns(any(GridWidget.class),
+                                           any(BaseGridRendererHelper.RenderingInformation.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class));
         verify(handler,
                times(1)).findMovableRows(any(GridWidget.class),
+                                         any(BaseGridRendererHelper.RenderingInformation.class),
                                          any(Double.class),
                                          any(Double.class));
         verify(handler,
                times(1)).findResizableColumn(any(GridWidget.class),
+                                             any(BaseGridRendererHelper.RenderingInformation.class),
                                              any(Double.class));
 
         verify(state,
@@ -458,16 +478,19 @@ public class GridWidgetDnDMouseMoveHandlerTest {
 
         verify(handler,
                never()).findMovableColumns(any(GridWidget.class),
+                                           any(BaseGridRendererHelper.RenderingInformation.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class),
                                            any(Double.class));
         verify(handler,
                times(1)).findMovableRows(any(GridWidget.class),
+                                         any(BaseGridRendererHelper.RenderingInformation.class),
                                          any(Double.class),
                                          any(Double.class));
         verify(handler,
                times(1)).findResizableColumn(any(GridWidget.class),
+                                             any(BaseGridRendererHelper.RenderingInformation.class),
                                              any(Double.class));
 
         verify(state,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
@@ -19,7 +19,6 @@ package org.uberfire.ext.wires.core.grids.client.widget.dnd;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 
 import com.ait.lienzo.client.core.event.INodeXYEvent;
@@ -226,9 +225,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     public void findGridColumnWithInvisibleGridWidgets() {
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(false);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
 
         handler.onNodeMouseMove(event);
 
@@ -257,9 +254,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     public void findMovableGridWhenNoColumnOrRowOperationIsDetected() {
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
 
         //This location is top-left of the GridWidget; not within a column move/resize or row move hot-spot
         when(event.getX()).thenReturn(100);
@@ -297,9 +292,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     public void findMovableGridWhenNoColumnOrRowOperationIsDetectedAndGridIsPinned() {
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
         when(layer.isGridPinned()).thenReturn(true);
 
         //This location is top-left of the GridWidget; not within a column move/resize or row move hot-spot
@@ -350,9 +343,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
         when(gridWidget.isVisible()).thenReturn(true);
         when(gridWidget.onDragHandle(any(INodeXYEvent.class))).thenReturn(true);
         when(layer.isGridPinned()).thenReturn(isPinned);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
 
         //This location is top-left of the GridWidget; not within a column move/resize or row move hot-spot
         when(event.getX()).thenReturn(100);
@@ -370,9 +361,8 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     public void findMovableColumns() {
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
+
         //This location is in the GridWidget's header; within a column move hot-spot, but not within a column resize or row move hot-spot
         when(event.getX()).thenReturn(160);
         when(event.getY()).thenReturn(100);
@@ -417,9 +407,8 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     public void findResizableColumns() {
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
+
         //This location is in the GridWidget's body; within a column resize hot-spot, but not within a column move or row move hot-spot
         when(event.getX()).thenReturn(246);
         when(event.getY()).thenReturn(180);
@@ -464,9 +453,8 @@ public class GridWidgetDnDMouseMoveHandlerTest {
     public void findMovableRows() {
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
+
         //This location is in the GridWidget's body; within row 1's move hot-spot, but not within a column move or resize hot-spot
         final int eventX = (int) (gridWidget.getComputedLocation().getX() + uiColumn1.getWidth() / 2);
         final int eventY = (int) (gridWidget.getComputedLocation().getY() + renderer.getHeaderHeight() + uiModel.getRow(0).getHeight() + uiModel.getRow(1).getHeight() / 2);
@@ -516,9 +504,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
         when(state.getEventColumnHighlight()).thenReturn(highlight);
         when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
         when(gridWidget.isVisible()).thenReturn(true);
-        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
-            add(gridWidget);
-        }});
+        when(layer.getGridWidgets()).thenReturn(Collections.singleton(gridWidget));
 
         //This location is in the GridWidget's body; within row 0's move hot-spot, but not within a column move or resize hot-spot
         final int eventX = (int) (gridWidget.getComputedLocation().getX() + uiColumn1.getWidth() / 2);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetRenderingTestUtils.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetRenderingTestUtils.java
@@ -15,6 +15,7 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.grid.impl;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -63,6 +64,10 @@ public class BaseGridWidgetRenderingTestUtils {
                                                                 final int headerRowCount,
                                                                 final double headerRowHeight,
                                                                 final double headerRowsHeight) {
+        final List<Double> rowHeights = new ArrayList<>();
+        for (int rowIndex = 0; rowIndex < rowOffsets.size(); rowIndex++) {
+            rowHeights.add(20.0);
+        }
         return new RenderingInformation(mock(Bounds.class),
                                         model.getColumns(),
                                         new BaseGridRendererHelper.RenderingBlockInformation(model.getColumns(),
@@ -77,6 +82,7 @@ public class BaseGridWidgetRenderingTestUtils {
                                                                                              0.0),
                                         0,
                                         rowOffsets.size() - 1,
+                                        rowHeights,
                                         rowOffsets,
                                         false,
                                         false,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyFlattenedTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyFlattenedTest.java
@@ -16,7 +16,9 @@
 
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -170,10 +172,12 @@ public class ColumnRenderingStrategyFlattenedTest {
 
     @Test
     public void testRenderNotSelectionLayer() throws Exception {
+        final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(3, ROW_HEIGHT));
         final GridRenderer.GridRendererContext rendererContext = mock(GridRenderer.GridRendererContext.class);
         final Group group = mock(Group.class);
         doReturn(false).when(rendererContext).isSelectionLayer();
         doReturn(group).when(rendererContext).getGroup();
+        doReturn(allRowHeights).when(renderingInformation).getAllRowHeights();
 
         final List<GridRenderer.RendererCommand> commands = ColumnRenderingStrategyFlattened.render(column,
                                                                                                     context,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyFlattenedTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyFlattenedTest.java
@@ -29,7 +29,6 @@ import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwtmockito.GwtMockito;
 import com.google.gwtmockito.WithClassesToStub;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,6 +45,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.Grid
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.GridRendererTheme;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -58,11 +58,11 @@ import static org.mockito.Mockito.verify;
 @RunWith(LienzoMockitoTestRunner.class)
 public class ColumnRenderingStrategyFlattenedTest {
 
-    private final double ROW_HEIGHT = 50;
-    private final double CONTEXT_X_POSITION = 0;
-    private final double COLUMN_WIDTH = 220;
-    private final int MIN_VISIBLE_ROW_INDEX = 0;
-    private final int MAX_VISIBLE_ROW_INDEX = 2;
+    private static final double ROW_HEIGHT = 50;
+    private static final double CONTEXT_X_POSITION = 0;
+    private static final double COLUMN_WIDTH = 220;
+    private static final int MIN_VISIBLE_ROW_INDEX = 0;
+    private static final int MAX_VISIBLE_ROW_INDEX = 2;
 
     @Mock
     private GridColumn<?> column;
@@ -109,6 +109,7 @@ public class ColumnRenderingStrategyFlattenedTest {
     @Spy
     private MultiPath multiPath = new MultiPath();
 
+    @Mock
     private BaseGridRendererHelper rendererHelper;
 
     @Mock
@@ -127,7 +128,7 @@ public class ColumnRenderingStrategyFlattenedTest {
     private Group columnGroup;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         GwtMockito.useProviderForType(BoundingBoxPathClipperFactory.class, aClass -> boundingBoxPathClipperFactory);
         GwtMockito.useProviderForType(Group.class, aClass -> columnGroup);
 
@@ -148,7 +149,7 @@ public class ColumnRenderingStrategyFlattenedTest {
         doReturn(COLUMN_WIDTH).when(column).getWidth();
         doReturn(gridColumnRenderer).when(column).getColumnRenderer();
 
-        // grid not rendering for last column, so providing more
+        //Grid-lines are only rendered for all but the last column so ensure we have at least 2 columns
         doReturn(2).when(gridData).getColumnCount();
         doReturn(Arrays.asList(column, mock(GridColumn.class))).when(gridData).getColumns();
         doReturn(rowOne).when(gridData).getRow(0);
@@ -171,7 +172,8 @@ public class ColumnRenderingStrategyFlattenedTest {
     }
 
     @Test
-    public void testRenderNotSelectionLayer() throws Exception {
+    @SuppressWarnings("unchecked")
+    public void testRenderNotSelectionLayer() {
         final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(3, ROW_HEIGHT));
         final GridRenderer.GridRendererContext rendererContext = mock(GridRenderer.GridRendererContext.class);
         final Group group = mock(Group.class);
@@ -185,33 +187,35 @@ public class ColumnRenderingStrategyFlattenedTest {
                                                                                                     renderingInformation,
                                                                                                     columnRenderingConstraint);
 
-        // grid lines and column content
-        Assertions.assertThat(commands).hasSize(2);
+        // Grid lines and column content
+        assertThat(commands).hasSize(2);
 
-        // grid lines
+        // -- Grid lines --
         commands.get(0).execute(rendererContext);
+
         verify(group).add(multiPath);
-        // verify horizontal lines
-        // first row ignored
+        // Verify horizontal lines
+        // First row ignored
         verify(multiPath, never()).M(CONTEXT_X_POSITION, 0 + 0.5);
         verify(multiPath, never()).L(CONTEXT_X_POSITION + COLUMN_WIDTH, 0 + 0.5);
 
-        // second row
+        // Second row
         verify(multiPath).M(CONTEXT_X_POSITION, ROW_HEIGHT + 0.5);
         verify(multiPath).L(CONTEXT_X_POSITION + COLUMN_WIDTH, ROW_HEIGHT + 0.5);
 
-        // third row
+        // Third row
         verify(multiPath).M(CONTEXT_X_POSITION, ROW_HEIGHT * 2 + 0.5);
         verify(multiPath).L(CONTEXT_X_POSITION + COLUMN_WIDTH, ROW_HEIGHT * 2 + 0.5);
 
-        // vertical
+        // Vertical
         verify(multiPath).M(COLUMN_WIDTH + 0.5, 0);
         verify(multiPath).L(COLUMN_WIDTH + 0.5, ROW_HEIGHT * 3);
 
         reset(group);
 
-        // column content
+        // -- Column content --
         commands.get(1).execute(rendererContext);
+
         verify(gridColumnRenderer).renderCell(eq(cellOne),
                                               any(GridBodyCellRenderContext.class));
         verify(gridColumnRenderer).renderCell(eq(cellTwo),

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMergedTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMergedTest.java
@@ -16,7 +16,9 @@
 
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.assertj.core.api.Assertions;
@@ -53,13 +55,15 @@ public class ColumnRenderingStrategyMergedTest {
     @Test
     public void testGetCellHeightCells3() throws Exception {
         doReturn(3).when(gridCell).getMergedCellCount();
-        Assertions.assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, gridData, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 3);
+        final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(3, BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT));
+        Assertions.assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, allRowHeights, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 3);
     }
 
     @Test
     public void testGetCellHeightCells4() throws Exception {
         doReturn(4).when(gridCell).getMergedCellCount();
-        Assertions.assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, gridData, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 4);
+        final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(4, BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT));
+        Assertions.assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, allRowHeights, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 4);
     }
 
     @Test

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMergedTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/columns/impl/ColumnRenderingStrategyMergedTest.java
@@ -17,57 +17,151 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiFunction;
 
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.IPathClipper;
+import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import org.assertj.core.api.Assertions;
+import com.google.gwtmockito.GwtMockito;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.uberfire.ext.wires.core.grids.client.model.GridCell;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCell;
 import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridCellValue;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellRenderContext;
+import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyColumnRenderContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidgetRenderingTestUtils;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.themes.GridRendererTheme;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class ColumnRenderingStrategyMergedTest {
 
-    private GridData gridData = mock(GridData.class);
+    private static final double ROW_HEIGHT = 50;
 
-    private GridCell<String> gridCell = mock(GridCell.class);
+    private static final double COLUMN_WIDTH = 100;
 
-    private GridRow gridRow = mock(GridRow.class);
+    private static final double CONTEXT_X_POSITION = 0;
+
+    private static final int CONTEXT_MIN_VISIBLE_ROW_INDEX = 0;
+
+    private static final int CONTEXT_MAX_VISIBLE_ROW_INDEX = 2;
+
+    @Spy
+    private MultiPath multiPath = new MultiPath();
+
+    @Mock
+    private BaseGridRendererHelper rendererHelper;
+
+    @Mock
+    private BaseGridRendererHelper.RenderingInformation renderingInformation;
+
+    @Mock
+    private BiFunction<Boolean, GridColumn<?>, Boolean> columnRenderingConstraint;
+
+    @Mock
+    private BoundingBoxPathClipperFactory boundingBoxPathClipperFactory;
+
+    @Mock
+    private IPathClipper pathClipper;
+
+    @Mock
+    private Group columnGroup;
+
+    @Mock
+    private Group cellGroup;
+
+    @Mock
+    private GridColumn<?> gridColumn;
+
+    @Mock
+    private GridBodyColumnRenderContext context;
+
+    @Mock
+    private GridRenderer gridRenderer;
+
+    @Mock
+    private GridRendererTheme gridRendererTheme;
+
+    @Mock
+    private GridColumnRenderer gridColumnRenderer;
+
+    @Mock
+    private GridData gridData;
+
+    @Mock
+    private GridCell<String> gridCell;
+
+    @Mock
+    private GridRow gridRow;
 
     @Before
-    public void setUp() throws Exception {
-        doReturn(gridRow).when(gridData).getRow(anyInt());
-        doReturn(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT).when(gridRow).getHeight();
+    @SuppressWarnings("unchecked")
+    public void setUp() {
+        GwtMockito.useProviderForType(BoundingBoxPathClipperFactory.class, aClass -> boundingBoxPathClipperFactory);
+        GwtMockito.useProviderForType(Group.class, aClass -> columnGroup);
+
+        when(context.getX()).thenReturn(CONTEXT_X_POSITION);
+        when(context.getMinVisibleRowIndex()).thenReturn(CONTEXT_MIN_VISIBLE_ROW_INDEX);
+        when(context.getMaxVisibleRowIndex()).thenReturn(CONTEXT_MAX_VISIBLE_ROW_INDEX);
+        when(context.getModel()).thenReturn(gridData);
+        when(context.getRenderer()).thenReturn(gridRenderer);
+
+        when(gridRenderer.getTheme()).thenReturn(gridRendererTheme);
+        when(gridRendererTheme.getBodyGridLine()).thenReturn(multiPath);
+        when(columnRenderingConstraint.apply(false, gridColumn)).thenReturn(true);
+        when(renderingInformation.getVisibleRowOffsets()).thenReturn(Arrays.asList(0d, ROW_HEIGHT, ROW_HEIGHT * 2d));
+        when(boundingBoxPathClipperFactory.newClipper(anyDouble(), anyDouble(), anyDouble(), anyDouble())).thenReturn(pathClipper);
+
+        when(gridColumn.getWidth()).thenReturn(COLUMN_WIDTH);
+        when(gridColumn.getColumnRenderer()).thenReturn(gridColumnRenderer);
+        //Grid-lines are only rendered for all but the last column so ensure we have at least 2 columns
+        when(gridData.getColumnCount()).thenReturn(2);
+        when(gridData.getColumns()).thenReturn(Arrays.asList(gridColumn, mock(GridColumn.class)));
     }
 
     @Test
-    public void testGetCellHeightCells3() throws Exception {
+    public void testGetCellHeightCells3() {
         doReturn(3).when(gridCell).getMergedCellCount();
         final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(3, BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT));
-        Assertions.assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, allRowHeights, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 3);
+        assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, allRowHeights, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 3);
     }
 
     @Test
-    public void testGetCellHeightCells4() throws Exception {
+    public void testGetCellHeightCells4() {
         doReturn(4).when(gridCell).getMergedCellCount();
         final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(4, BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT));
-        Assertions.assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, allRowHeights, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 4);
+        assertThat(ColumnRenderingStrategyMerged.getCellHeight(0, allRowHeights, gridCell)).isEqualTo(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT * 4);
     }
 
     @Test
-    public void testIsCollapsedCellMixedValueThreeDifferentValues() throws Exception {
+    public void testIsCollapsedCellMixedValueThreeDifferentValues() {
+        when(gridData.getRow(anyInt())).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT);
+
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("two", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("three", 0);
@@ -77,11 +171,14 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(cellThree).when(gridData).getCell(2, 0);
         doReturn(true).when(gridRow).isCollapsed();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedCellMixedValueOneDifferentValue_1() throws Exception {
+    public void testIsCollapsedCellMixedValueOneDifferentValue_1() {
+        when(gridData.getRow(anyInt())).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT);
+
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("two", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("one", 0);
@@ -91,11 +188,14 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(cellThree).when(gridData).getCell(2, 0);
         doReturn(true).when(gridRow).isCollapsed();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedCellMixedValueOneDifferentValue_2() throws Exception {
+    public void testIsCollapsedCellMixedValueOneDifferentValue_2() {
+        when(gridData.getRow(anyInt())).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT);
+
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("two", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("one", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("one", 0);
@@ -105,11 +205,14 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(cellThree).when(gridData).getCell(2, 0);
         doReturn(true).when(gridRow).isCollapsed();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedCellMixedValueOneDifferentValue_3() throws Exception {
+    public void testIsCollapsedCellMixedValueOneDifferentValue_3() {
+        when(gridData.getRow(anyInt())).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT);
+
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("one", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("two", 0);
@@ -119,11 +222,14 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(cellThree).when(gridData).getCell(2, 0);
         doReturn(true).when(gridRow).isCollapsed();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedCellMixedValue() throws Exception {
+    public void testIsCollapsedCellMixedValue() {
+        when(gridData.getRow(anyInt())).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(BaseGridWidgetRenderingTestUtils.HEADER_ROW_HEIGHT);
+
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("one", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("one", 0);
@@ -133,12 +239,11 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(cellThree).when(gridData).getCell(2, 0);
         doReturn(true).when(gridRow).isCollapsed();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isFalse();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedCellMixedValue(gridData, 2, 0)).isFalse();
     }
 
     @Test
-    public void testIsCollapsedRowMixedValueThreeDifferentValues() throws Exception {
-        final GridColumn<String> gridColumn = mock(GridColumn.class);
+    public void testIsCollapsedRowMixedValueThreeDifferentValues() {
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("two", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("three", 0);
@@ -155,12 +260,11 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(Collections.singletonMap(0, cellTwo)).when(gridRowTwo).getCells();
         doReturn(Collections.singletonMap(0, cellThree)).when(gridRowThree).getCells();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedRowMixedValueOneDifferentValue_1() throws Exception {
-        final GridColumn<String> gridColumn = mock(GridColumn.class);
+    public void testIsCollapsedRowMixedValueOneDifferentValue_1() {
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("one", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("two", 0);
@@ -177,12 +281,11 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(Collections.singletonMap(0, cellTwo)).when(gridRowTwo).getCells();
         doReturn(Collections.singletonMap(0, cellThree)).when(gridRowThree).getCells();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedRowMixedValueOneDifferentValue_2() throws Exception {
-        final GridColumn<String> gridColumn = mock(GridColumn.class);
+    public void testIsCollapsedRowMixedValueOneDifferentValue_2() {
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("two", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("one", 0);
@@ -199,12 +302,11 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(Collections.singletonMap(0, cellTwo)).when(gridRowTwo).getCells();
         doReturn(Collections.singletonMap(0, cellThree)).when(gridRowThree).getCells();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedRowMixedValueOneDifferentValue_3() throws Exception {
-        final GridColumn<String> gridColumn = mock(GridColumn.class);
+    public void testIsCollapsedRowMixedValueOneDifferentValue_3() {
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("one", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("two", 0);
@@ -221,12 +323,11 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(Collections.singletonMap(0, cellTwo)).when(gridRowTwo).getCells();
         doReturn(Collections.singletonMap(0, cellThree)).when(gridRowThree).getCells();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isTrue();
     }
 
     @Test
-    public void testIsCollapsedRowMixedValue() throws Exception {
-        final GridColumn<String> gridColumn = mock(GridColumn.class);
+    public void testIsCollapsedRowMixedValue() {
         final GridCell<String> cellOne = gridCellWithMockedMergedCellCount("one", 3);
         final GridCell<String> cellTwo = gridCellWithMockedMergedCellCount("one", 0);
         final GridCell<String> cellThree = gridCellWithMockedMergedCellCount("one", 0);
@@ -243,15 +344,101 @@ public class ColumnRenderingStrategyMergedTest {
         doReturn(Collections.singletonMap(0, cellTwo)).when(gridRowTwo).getCells();
         doReturn(Collections.singletonMap(0, cellThree)).when(gridRowThree).getCells();
 
-        Assertions.assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isFalse();
+        assertThat(ColumnRenderingStrategyMerged.isCollapsedRowMultiValue(gridData, gridColumn, cellThree, 2)).isFalse();
     }
 
-    private GridCell<String> gridCellWithMockedMergedCellCount(final String value, final int mergedCellCount) {
-        return new BaseGridCell<String>(new BaseGridCellValue<String>(value)) {
+    private GridCell<String> gridCellWithMockedMergedCellCount(final String value,
+                                                               final int mergedCellCount) {
+        return new BaseGridCell<String>(new BaseGridCellValue<>(value)) {
             @Override
             public int getMergedCellCount() {
                 return mergedCellCount;
             }
         };
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRenderNotSelectionLayer_Unmerged() {
+        final GridCell cellOne = gridCellWithMockedMergedCellCount("one", 1);
+        final GridCell cellTwo = gridCellWithMockedMergedCellCount("two", 1);
+        final GridCell cellThree = gridCellWithMockedMergedCellCount("three", 1);
+        final GridRow gridRowOne = mock(GridRow.class);
+        final GridRow gridRowTwo = mock(GridRow.class);
+        final GridRow gridRowThree = mock(GridRow.class);
+        when(gridData.getRow(0)).thenReturn(gridRowOne);
+        when(gridData.getRow(1)).thenReturn(gridRowTwo);
+        when(gridData.getRow(2)).thenReturn(gridRowThree);
+        when(gridRowOne.isCollapsed()).thenReturn(false);
+        when(gridRowTwo.isCollapsed()).thenReturn(false);
+        when(gridRowThree.isCollapsed()).thenReturn(false);
+        when(gridRowOne.getCells()).thenReturn(Collections.singletonMap(0, cellOne));
+        when(gridRowTwo.getCells()).thenReturn(Collections.singletonMap(0, cellTwo));
+        when(gridRowThree.getCells()).thenReturn(Collections.singletonMap(0, cellThree));
+        when(gridData.getCell(0, 0)).thenReturn(cellOne);
+        when(gridData.getCell(1, 0)).thenReturn(cellTwo);
+        when(gridData.getCell(2, 0)).thenReturn(cellThree);
+        when(gridColumnRenderer.renderCell(any(GridCell.class), any(GridBodyCellRenderContext.class))).thenReturn(cellGroup);
+        when(cellGroup.setX(anyDouble())).thenReturn(cellGroup);
+        when(cellGroup.setY(anyDouble())).thenReturn(cellGroup);
+
+        final List<Double> allRowHeights = new ArrayList<>(Collections.nCopies(3, ROW_HEIGHT));
+        final GridRenderer.GridRendererContext rendererContext = mock(GridRenderer.GridRendererContext.class);
+        final Group group = mock(Group.class);
+        doReturn(false).when(rendererContext).isSelectionLayer();
+        doReturn(group).when(rendererContext).getGroup();
+        doReturn(allRowHeights).when(renderingInformation).getAllRowHeights();
+
+        final List<GridRenderer.RendererCommand> commands = ColumnRenderingStrategyMerged.render(gridColumn,
+                                                                                                 context,
+                                                                                                 rendererHelper,
+                                                                                                 renderingInformation,
+                                                                                                 columnRenderingConstraint);
+
+        // Grid lines and column content
+        assertThat(commands).hasSize(2);
+
+        // -- Grid lines --
+        commands.get(0).execute(rendererContext);
+
+        verify(group).add(multiPath);
+        // Verify horizontal lines
+        // First row
+        verify(multiPath).M(CONTEXT_X_POSITION, 0 + 0.5);
+        verify(multiPath).L(CONTEXT_X_POSITION + COLUMN_WIDTH, 0 + 0.5);
+
+        // Second row
+        verify(multiPath).M(CONTEXT_X_POSITION, ROW_HEIGHT + 0.5);
+        verify(multiPath).L(CONTEXT_X_POSITION + COLUMN_WIDTH, ROW_HEIGHT + 0.5);
+
+        // Third row
+        verify(multiPath).M(CONTEXT_X_POSITION, ROW_HEIGHT * 2 + 0.5);
+        verify(multiPath).L(CONTEXT_X_POSITION + COLUMN_WIDTH, ROW_HEIGHT * 2 + 0.5);
+
+        // Vertical
+        verify(multiPath).M(COLUMN_WIDTH + 0.5, 0);
+        verify(multiPath).L(COLUMN_WIDTH + 0.5, ROW_HEIGHT * 3);
+
+        reset(group);
+
+        // -- Column content --
+        commands.get(1).execute(rendererContext);
+
+        verify(gridColumnRenderer).renderCell(eq(cellOne),
+                                              any(GridBodyCellRenderContext.class));
+        verify(gridColumnRenderer).renderCell(eq(cellTwo),
+                                              any(GridBodyCellRenderContext.class));
+        verify(gridColumnRenderer).renderCell(eq(cellThree),
+                                              any(GridBodyCellRenderContext.class));
+
+        verify(boundingBoxPathClipperFactory).newClipper(0,
+                                                         0,
+                                                         COLUMN_WIDTH,
+                                                         ROW_HEIGHT * 3);
+        verify(pathClipper).setActive(true);
+
+        verify(columnGroup).setX(CONTEXT_X_POSITION);
+
+        verify(group).add(columnGroup);
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelperTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererHelperTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridData;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseGridRow;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseHeaderMetaData;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.columns.RowNumberColumn;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.columns.GridColumnRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class BaseGridRendererHelperTest {
+
+    private static final double HEADER_HEIGHT = 32.0;
+
+    private static final double HEADER_ROW_HEIGHT = 10.0;
+
+    private static final double BOUNDS_WIDTH = 1000.0;
+
+    private static final double BOUNDS_HEIGHT = 1000.0;
+
+    @Mock
+    private GridWidget gridWidget;
+
+    @Mock
+    private DefaultGridLayer gridLayer;
+
+    @Mock
+    private GridRenderer gridRenderer;
+
+    @Mock
+    private GridColumnRenderer<String> columnRenderer;
+
+    private GridColumn<Integer> uiColumn1;
+    private GridColumn<String> uiColumn2;
+    private GridRow uiRow1;
+    private GridRow uiRow2;
+    private GridRow uiRow3;
+
+    private GridData uiModel;
+
+    private BaseGridRendererHelper helper;
+
+    @Before
+    public void setup() {
+        this.uiColumn1 = new RowNumberColumn();
+        this.uiColumn2 = new BaseGridColumn<>(Arrays.asList(new BaseHeaderMetaData("title1"), new BaseHeaderMetaData("title2")),
+                                              columnRenderer,
+                                              100.0);
+        this.uiRow1 = new BaseGridRow();
+        this.uiRow2 = new BaseGridRow();
+        this.uiRow3 = new BaseGridRow();
+        this.uiModel = new BaseGridData();
+        this.uiModel.appendColumn(uiColumn1);
+        this.uiModel.appendColumn(uiColumn2);
+        this.uiModel.appendRow(uiRow1);
+        this.uiModel.appendRow(uiRow2);
+        this.uiModel.appendRow(uiRow3);
+        this.helper = new BaseGridRendererHelper(gridWidget);
+
+        when(gridWidget.getModel()).thenReturn(uiModel);
+        when(gridWidget.getLayer()).thenReturn(gridLayer);
+        when(gridWidget.getRenderer()).thenReturn(gridRenderer);
+        when(gridRenderer.getHeaderHeight()).thenReturn(HEADER_HEIGHT);
+        when(gridRenderer.getHeaderRowHeight()).thenReturn(HEADER_ROW_HEIGHT);
+        when(gridWidget.getWidth()).thenReturn(uiColumn1.getWidth() + uiColumn2.getWidth());
+        when(gridWidget.getHeight()).thenReturn(HEADER_HEIGHT + uiRow1.getHeight() + uiRow2.getHeight() + uiRow3.getHeight());
+    }
+
+    @Test
+    public void testGetColumnOffsetByObject() {
+        assertThat(helper.getColumnOffset(uiColumn1)).isEqualTo(0.0);
+        assertThat(helper.getColumnOffset(uiColumn2)).isEqualTo(uiColumn1.getWidth());
+    }
+
+    @Test
+    public void testGetColumnOffsetByObjectWithHiddenColumn() {
+        uiColumn1.setVisible(false);
+
+        assertThat(helper.getColumnOffset(uiColumn1)).isEqualTo(0.0);
+        assertThat(helper.getColumnOffset(uiColumn2)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void testGetColumnOffsetByIndex() {
+        assertThat(helper.getColumnOffset(0)).isEqualTo(0.0);
+        assertThat(helper.getColumnOffset(1)).isEqualTo(uiColumn1.getWidth());
+    }
+
+    @Test
+    public void testGetColumnOffsetByIndexWithHiddenColumn() {
+        uiColumn1.setVisible(false);
+
+        assertThat(helper.getColumnOffset(0)).isEqualTo(0.0);
+        assertThat(helper.getColumnOffset(1)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void testGetColumnOffsetByIndexAndSubList() {
+        assertThat(helper.getColumnOffset(uiModel.getColumns(), 0)).isEqualTo(0.0);
+        assertThat(helper.getColumnOffset(uiModel.getColumns(), 1)).isEqualTo(uiColumn1.getWidth());
+    }
+
+    @Test
+    public void testGetColumnOffsetByIndexAndSubListWithHiddenColumn() {
+        uiColumn1.setVisible(false);
+
+        assertThat(helper.getColumnOffset(uiModel.getColumns(), 0)).isEqualTo(0.0);
+        assertThat(helper.getColumnOffset(uiModel.getColumns(), 1)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void testGetRowOffsetWithObject() {
+        assertThat(helper.getRowOffset(uiRow1)).isEqualTo(0.0);
+        assertThat(helper.getRowOffset(uiRow2)).isEqualTo(uiRow1.getHeight());
+        assertThat(helper.getRowOffset(uiRow3)).isEqualTo(uiRow1.getHeight() + uiRow2.getHeight());
+    }
+
+    @Test
+    public void testGetRowOffsetWithIndex() {
+        assertThat(helper.getRowOffset(0)).isEqualTo(0.0);
+        assertThat(helper.getRowOffset(1)).isEqualTo(uiRow1.getHeight());
+        assertThat(helper.getRowOffset(2)).isEqualTo(uiRow1.getHeight() + uiRow2.getHeight());
+    }
+
+    @Test
+    public void testGetRowOffsetWithObjectAndExplicitRowHeights() {
+        final List<Double> allRowHeights = new ArrayList<>(Arrays.asList(uiRow1.getHeight(), uiRow2.getHeight(), uiRow3.getHeight()));
+        assertThat(helper.getRowOffset(uiRow1, allRowHeights)).isEqualTo(0.0);
+        assertThat(helper.getRowOffset(uiRow2, allRowHeights)).isEqualTo(uiRow1.getHeight());
+        assertThat(helper.getRowOffset(uiRow3, allRowHeights)).isEqualTo(uiRow1.getHeight() + uiRow2.getHeight());
+    }
+
+    @Test
+    public void testGetRowOffsetWithIndexAndExplicitRowHeights() {
+        final List<Double> allRowHeights = new ArrayList<>(Arrays.asList(uiRow1.getHeight(), uiRow2.getHeight(), uiRow3.getHeight()));
+        assertThat(helper.getRowOffset(0, allRowHeights)).isEqualTo(0.0);
+        assertThat(helper.getRowOffset(1, allRowHeights)).isEqualTo(uiRow1.getHeight());
+        assertThat(helper.getRowOffset(2, allRowHeights)).isEqualTo(uiRow1.getHeight() + uiRow2.getHeight());
+    }
+
+    @Test
+    public void testGetWidth() {
+        assertThat(helper.getWidth(uiModel.getColumns())).isEqualTo(uiColumn1.getWidth() + uiColumn2.getWidth());
+    }
+
+    @Test
+    public void testGetWidthWithHiddenColumn() {
+        uiColumn1.setVisible(false);
+
+        assertThat(helper.getWidth(uiModel.getColumns())).isEqualTo(uiColumn2.getWidth());
+    }
+
+    @Test
+    public void testGetRenderingInformation_BoundsLeft() {
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(-(uiColumn1.getWidth() + uiColumn2.getWidth()) - 1, 0));
+
+        assertThat(helper.getRenderingInformation()).isNull();
+    }
+
+    @Test
+    public void testGetRenderingInformation_BoundsRight() {
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(BOUNDS_WIDTH + 1, 0));
+
+        assertThat(helper.getRenderingInformation()).isNull();
+    }
+
+    @Test
+    public void testGetRenderingInformation_BoundsTop() {
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(0, -(HEADER_HEIGHT + uiRow1.getHeight() + uiRow2.getHeight() + uiRow3.getHeight()) - 1));
+
+        assertThat(helper.getRenderingInformation()).isNull();
+    }
+
+    @Test
+    public void testGetRenderingInformation_BoundsBottom() {
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(0, BOUNDS_HEIGHT + 1));
+
+        assertThat(helper.getRenderingInformation()).isNull();
+    }
+
+    @Test
+    public void testGetRenderingInformation_FixedHeaderSelected_NoFloatingColumns() {
+        when(gridWidget.isSelected()).thenReturn(true);
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(0, 0));
+
+        final BaseGridRendererHelper.RenderingInformation renderingInformation = helper.getRenderingInformation();
+        assertRenderingInformation(renderingInformation,
+                                   true,
+                                   false,
+                                   uiModel.getColumns(),
+                                   0,
+                                   uiModel.getRowCount() - 1,
+                                   Arrays.asList(uiRow1.getHeight(), uiRow2.getHeight(), uiRow3.getHeight()),
+                                   Arrays.asList(0.0, uiRow1.getHeight(), uiRow1.getHeight() + uiRow2.getHeight()),
+                                   uiModel.getHeaderRowCount(),
+                                   HEADER_ROW_HEIGHT,
+                                   HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount(),
+                                   HEADER_HEIGHT - HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount());
+
+        assertBlockInformation(renderingInformation.getBodyBlockInformation(),
+                               uiModel.getColumns(),
+                               0.0,
+                               0.0,
+                               HEADER_HEIGHT,
+                               uiColumn1.getWidth() + uiColumn2.getWidth());
+        assertBlockInformation(renderingInformation.getFloatingBlockInformation(),
+                               Collections.emptyList(),
+                               0.0,
+                               0.0,
+                               HEADER_HEIGHT,
+                               0.0);
+    }
+
+    @Test
+    public void testGetRenderingInformation_FixedHeaderNotSelected_NoFloatingColumns() {
+        when(gridWidget.isSelected()).thenReturn(false);
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(0, 0));
+
+        final BaseGridRendererHelper.RenderingInformation renderingInformation = helper.getRenderingInformation();
+        assertRenderingInformation(renderingInformation,
+                                   true,
+                                   false,
+                                   uiModel.getColumns(),
+                                   0,
+                                   uiModel.getRowCount() - 1,
+                                   Arrays.asList(uiRow1.getHeight(), uiRow2.getHeight(), uiRow3.getHeight()),
+                                   Arrays.asList(0.0, uiRow1.getHeight(), uiRow1.getHeight() + uiRow2.getHeight()),
+                                   uiModel.getHeaderRowCount(),
+                                   HEADER_ROW_HEIGHT,
+                                   HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount(),
+                                   HEADER_HEIGHT - HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount());
+
+        assertBlockInformation(renderingInformation.getBodyBlockInformation(),
+                               uiModel.getColumns(),
+                               0.0,
+                               0.0,
+                               HEADER_HEIGHT,
+                               uiColumn1.getWidth() + uiColumn2.getWidth());
+        assertBlockInformation(renderingInformation.getFloatingBlockInformation(),
+                               Collections.emptyList(),
+                               0.0,
+                               0.0,
+                               HEADER_HEIGHT,
+                               0.0);
+    }
+
+    @Test
+    public void testGetRenderingInformation_FloatingHeaderSelected_NoFloatingColumns() {
+        final double gridWidgetLocationY = -uiRow1.getHeight() - 5;
+        when(gridWidget.isSelected()).thenReturn(true);
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(0, gridWidgetLocationY));
+
+        final BaseGridRendererHelper.RenderingInformation renderingInformation = helper.getRenderingInformation();
+        assertRenderingInformation(renderingInformation,
+                                   false,
+                                   true,
+                                   uiModel.getColumns(),
+                                   1,
+                                   uiModel.getRowCount() - 1,
+                                   Arrays.asList(uiRow1.getHeight(), uiRow2.getHeight(), uiRow3.getHeight()),
+                                   Arrays.asList(uiRow1.getHeight(), uiRow1.getHeight() + uiRow2.getHeight()),
+                                   uiModel.getHeaderRowCount(),
+                                   HEADER_ROW_HEIGHT,
+                                   HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount(),
+                                   HEADER_HEIGHT - HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount());
+
+        assertBlockInformation(renderingInformation.getBodyBlockInformation(),
+                               uiModel.getColumns(),
+                               0.0,
+                               -gridWidgetLocationY,
+                               HEADER_HEIGHT + uiRow1.getHeight(),
+                               uiColumn1.getWidth() + uiColumn2.getWidth());
+        assertBlockInformation(renderingInformation.getFloatingBlockInformation(),
+                               Collections.emptyList(),
+                               0.0,
+                               -gridWidgetLocationY,
+                               HEADER_HEIGHT + uiRow1.getHeight(),
+                               0.0);
+    }
+
+    @Test
+    public void testGetRenderingInformation_FloatingHeaderSelected_FloatingColumns() {
+        final double gridWidgetLocationY = -uiRow1.getHeight() - 5;
+        final double gridWidgetLocationX = -uiColumn1.getWidth() - 5;
+        when(gridWidget.isSelected()).thenReturn(true);
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(gridWidgetLocationX, gridWidgetLocationY));
+
+        final BaseGridRendererHelper.RenderingInformation renderingInformation = helper.getRenderingInformation();
+        assertRenderingInformation(renderingInformation,
+                                   false,
+                                   true,
+                                   Collections.singletonList(uiColumn2),
+                                   1,
+                                   uiModel.getRowCount() - 1,
+                                   Arrays.asList(uiRow1.getHeight(), uiRow2.getHeight(), uiRow3.getHeight()),
+                                   Arrays.asList(uiRow1.getHeight(), uiRow1.getHeight() + uiRow2.getHeight()),
+                                   uiModel.getHeaderRowCount(),
+                                   HEADER_ROW_HEIGHT,
+                                   HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount(),
+                                   HEADER_HEIGHT - HEADER_ROW_HEIGHT * uiModel.getHeaderRowCount());
+
+        assertBlockInformation(renderingInformation.getBodyBlockInformation(),
+                               Collections.singletonList(uiColumn2),
+                               uiColumn1.getWidth(),
+                               -gridWidgetLocationY,
+                               HEADER_HEIGHT + uiRow1.getHeight(),
+                               uiColumn2.getWidth());
+        assertBlockInformation(renderingInformation.getFloatingBlockInformation(),
+                               Collections.singletonList(uiColumn1),
+                               -gridWidgetLocationX,
+                               -gridWidgetLocationY,
+                               HEADER_HEIGHT + uiRow1.getHeight(),
+                               uiColumn1.getWidth());
+    }
+
+    @Test
+    public void testGetColumnInformation_FixedHeaderSelected_NoFloatingColumns() {
+        when(gridWidget.isSelected()).thenReturn(true);
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(0, 0));
+
+        final BaseGridRendererHelper.ColumnInformation columnInformation = helper.getColumnInformation(uiColumn1.getWidth() / 2);
+        assertColumnInformation(columnInformation,
+                                uiColumn1,
+                                0,
+                                0.0);
+    }
+
+    @Test
+    public void testGetColumnInformation_FixedHeaderSelected_FloatingColumns() {
+        final double gridWidgetLocationX = -5;
+        when(gridWidget.isSelected()).thenReturn(true);
+        when(gridLayer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(gridWidget.getComputedLocation()).thenReturn(new Point2D(gridWidgetLocationX, 0));
+
+        final BaseGridRendererHelper.ColumnInformation columnInformation = helper.getColumnInformation(uiColumn1.getWidth() / 2);
+        assertColumnInformation(columnInformation,
+                                uiColumn1,
+                                0,
+                                -gridWidgetLocationX);
+    }
+
+    private void assertRenderingInformation(final BaseGridRendererHelper.RenderingInformation renderingInformation,
+                                            final boolean expectedIsFixedHeader,
+                                            final boolean expectedIsFloatingHeader,
+                                            final List<GridColumn<?>> expectedAllColumns,
+                                            final int expectedMinVisibleRowIndex,
+                                            final int expectedMaxVisibleRowIndex,
+                                            final List<Double> expectedAllRowHeights,
+                                            final List<Double> expectedVisibleRowOffsets,
+                                            final int expectedHeaderRowCount,
+                                            final double expectedHeaderRowHeight,
+                                            final double expectedHeaderRowsHeight,
+                                            final double expectedHeaderRowsYOffset) {
+        assertThat(renderingInformation).isNotNull();
+        assertThat(renderingInformation.isFixedHeader()).isEqualTo(expectedIsFixedHeader);
+        assertThat(renderingInformation.isFloatingHeader()).isEqualTo(expectedIsFloatingHeader);
+        assertThat(renderingInformation.getAllColumns()).containsSequence(expectedAllColumns);
+        assertThat(renderingInformation.getMinVisibleRowIndex()).isEqualTo(expectedMinVisibleRowIndex);
+        assertThat(renderingInformation.getMaxVisibleRowIndex()).isEqualTo(expectedMaxVisibleRowIndex);
+        assertThat(renderingInformation.getAllRowHeights()).containsSequence(expectedAllRowHeights);
+        assertThat(renderingInformation.getVisibleRowOffsets()).containsSequence(expectedVisibleRowOffsets);
+        assertThat(renderingInformation.getHeaderRowCount()).isEqualTo(expectedHeaderRowCount);
+        assertThat(renderingInformation.getHeaderRowHeight()).isEqualTo(expectedHeaderRowHeight);
+        assertThat(renderingInformation.getHeaderRowsHeight()).isEqualTo(expectedHeaderRowsHeight);
+        assertThat(renderingInformation.getHeaderRowsYOffset()).isEqualTo(expectedHeaderRowsYOffset);
+    }
+
+    private void assertBlockInformation(final BaseGridRendererHelper.RenderingBlockInformation blockInformation,
+                                        final List<GridColumn<?>> expectedBlockColumns,
+                                        final double expectedBlockOffsetX,
+                                        final double expectedBlockHeaderYOffset,
+                                        final double expectedBlockBodyYOffset,
+                                        final double expectedBlockWidth) {
+        assertThat(blockInformation).isNotNull();
+        assertThat(blockInformation.getColumns()).containsSequence(expectedBlockColumns);
+        assertThat(blockInformation.getX()).isEqualTo(expectedBlockOffsetX);
+        assertThat(blockInformation.getHeaderY()).isEqualTo(expectedBlockHeaderYOffset);
+        assertThat(blockInformation.getBodyY()).isEqualTo(expectedBlockBodyYOffset);
+        assertThat(blockInformation.getWidth()).isEqualTo(expectedBlockWidth);
+    }
+
+    private void assertColumnInformation(final BaseGridRendererHelper.ColumnInformation columnInformation,
+                                         final GridColumn<?> expectedColumn,
+                                         final int expectedUiColumnIndex,
+                                         final double expectedOffsetX) {
+        assertThat(columnInformation).isNotNull();
+        assertThat(columnInformation.getColumn()).isEqualTo(expectedColumn);
+        assertThat(columnInformation.getUiColumnIndex()).isEqualTo(expectedUiColumnIndex);
+        assertThat(columnInformation.getOffsetX()).isEqualTo(expectedOffsetX);
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRendererTest.java
@@ -17,6 +17,7 @@
 package org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -74,6 +75,9 @@ public abstract class BaseGridRendererTest {
 
     @Mock
     protected BaseGridRendererHelper rendererHelper;
+
+    @Mock
+    protected RenderingInformation renderingInformation;
 
     @Mock
     protected Group parent;
@@ -147,9 +151,11 @@ public abstract class BaseGridRendererTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testMakeCellHighlight() {
         final int rowIndex = 1;
         final int visibleRowIndex = 2;
+        final List<Double> allRowHeights = new ArrayList<>();
         final GridData model = mock(GridData.class);
         final GridRendererTheme theme = mock(GridRendererTheme.class);
         final Rectangle rectangle = mock(Rectangle.class);
@@ -159,12 +165,13 @@ public abstract class BaseGridRendererTest {
 
         doNothing().when(renderer).setCellHighlightX(rectangle, context, rendererHelper);
         doNothing().when(renderer).setCellHighlightY(rectangle, rendererHelper, visibleRowIndex, model);
-        doNothing().when(renderer).setCellHighlightSize(rectangle, model, column, rowIndex);
+        doNothing().when(renderer).setCellHighlightSize(rectangle, model, column, allRowHeights, rowIndex);
 
         final Rectangle current = renderer.makeCellHighlight(rowIndex,
                                                              visibleRowIndex,
                                                              model,
                                                              rendererHelper,
+                                                             renderingInformation,
                                                              column,
                                                              context);
 
@@ -252,11 +259,10 @@ public abstract class BaseGridRendererTest {
         final GridRow row = mock(GridRow.class);
         final double height = 20;
         when(column.getWidth()).thenReturn(width);
-        when(row.getHeight()).thenReturn(height);
         when(model.getRow(rowIndex)).thenReturn(row);
         doReturn(1).when(renderer).getMergedCellsCount(model, rowIndex);
 
-        renderer.setCellHighlightSize(rectangle, model, column, rowIndex);
+        renderer.setCellHighlightSize(rectangle, model, column, Collections.nCopies(5, height), rowIndex);
 
         verify(rectangle).setWidth(width);
         verify(rectangle).setHeight(height);
@@ -318,12 +324,14 @@ public abstract class BaseGridRendererTest {
                                                              visibleRowIndex,
                                                              dataModel,
                                                              rendererHelper,
+                                                             renderingInformation,
                                                              column,
                                                              context);
 
         final GridRenderer.RendererCommand cmd = renderer.getRendererCommand(dataModel,
                                                                              context,
                                                                              rendererHelper,
+                                                                             renderingInformation,
                                                                              column,
                                                                              visibleRowIndex);
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanelTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanelTest.java
@@ -16,9 +16,15 @@
 
 package org.uberfire.ext.wires.core.grids.client.widget.layer.impl;
 
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.INativeContext2D;
+import com.ait.lienzo.client.core.shape.Node;
 import com.ait.lienzo.client.widget.LienzoPanel;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.CanvasElement;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.MouseUpEvent;
 import com.google.gwt.event.dom.client.MouseUpHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -34,6 +40,7 @@ import org.uberfire.ext.wires.core.grids.client.model.GridData;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.scrollbars.GridLienzoScrollHandler;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -47,6 +54,10 @@ import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class GridLienzoPanelTest {
+
+    private static final int WIDTH = 100;
+
+    private static final int HEIGHT = 200;
 
     @Mock
     private AbsolutePanel rootPanel;
@@ -66,19 +77,48 @@ public class GridLienzoPanelTest {
     @Mock
     private LienzoPanel lienzoPanel;
 
+    @Mock
+    private DefaultGridLayer gridLayer;
+
+    @Mock
+    private DivElement gridLayerDivElement;
+
+    @Mock
+    private Style gridLayerDivElementStyle;
+
+    @Mock
+    private CanvasElement gridLayerCanvasElement;
+
+    @Mock
+    private Node gridLayerNode;
+
+    @Mock
+    private Context2D context2D;
+
+    @Mock
+    private INativeContext2D nativeContext2D;
+
     private GridLienzoPanel gridLienzoPanel;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUp() {
 
         gridLienzoPanel = spy(new GridLienzoPanel());
 
-        doReturn(rootPanel).when(gridLienzoPanel).getRootPanel();
-        doReturn(scrollPanel).when(gridLienzoPanel).getScrollPanel();
-        doReturn(internalScrollPanel).when(gridLienzoPanel).getInternalScrollPanel();
-        doReturn(domElementContainer).when(gridLienzoPanel).getDomElementContainer();
-        doReturn(lienzoPanel).when(gridLienzoPanel).getLienzoPanel();
-        doReturn(gridLienzoScrollHandler).when(gridLienzoPanel).getGridLienzoScrollHandler();
+        when(gridLienzoPanel.getRootPanel()).thenReturn(rootPanel);
+        when(gridLienzoPanel.getScrollPanel()).thenReturn(scrollPanel);
+        when(gridLienzoPanel.getInternalScrollPanel()).thenReturn(internalScrollPanel);
+        when(gridLienzoPanel.getDomElementContainer()).thenReturn(domElementContainer);
+        when(gridLienzoPanel.getLienzoPanel()).thenReturn(lienzoPanel);
+        when(gridLienzoPanel.getGridLienzoScrollHandler()).thenReturn(gridLienzoScrollHandler);
+
+        when(gridLayer.getElement()).thenReturn(gridLayerDivElement);
+        when(gridLayerDivElement.getStyle()).thenReturn(gridLayerDivElementStyle);
+        when(gridLayer.getCanvasElement()).thenReturn(gridLayerCanvasElement);
+        when(gridLayer.getContext()).thenReturn(context2D);
+        when(gridLayer.asNode()).thenReturn(gridLayerNode);
+        when(context2D.getNativeContext()).thenReturn(nativeContext2D);
     }
 
     @Test
@@ -251,5 +291,19 @@ public class GridLienzoPanelTest {
         gridLienzoPanel.propagateNewPanelSize(visibleWidth, visibleHeight);
 
         verify(gridData, times(1)).setVisibleSizeAndRefresh(visibleWidth, visibleHeight);
+    }
+
+    @Test
+    public void testConstructorWithSizeAndDefaultGridLayer() {
+        final GridLienzoPanel gridPanel = new GridLienzoPanel(WIDTH, HEIGHT, gridLayer);
+
+        assertThat(gridPanel.getDefaultGridLayer()).isEqualTo(gridLayer);
+    }
+
+    @Test
+    public void testConstructor() {
+        final GridLienzoPanel gridPanel = new GridLienzoPanel(gridLayer);
+
+        assertThat(gridPanel.getDefaultGridLayer()).isEqualTo(gridLayer);
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
@@ -506,17 +506,11 @@ public class GridLienzoScrollHandlerTest {
 
     @Test
     public void testGetDefaultGridLayerWhenLienzoGridLayerIsNotNull() {
-
-        final DefaultGridLayer expectedLayer = mock(DefaultGridLayer.class);
-
-        doReturn(expectedLayer).when(gridLienzoPanel).getDefaultGridLayer();
-        doCallRealMethod().when(gridLienzoScrollHandler).getDefaultGridLayer();
-
         final DefaultGridLayer actualLayer = gridLienzoScrollHandler.getDefaultGridLayer();
 
         verify(gridLienzoScrollHandler, never()).emptyLayer();
 
-        assertEquals(expectedLayer,
+        assertEquals(defaultGridLayer,
                      actualLayer);
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
@@ -33,6 +33,7 @@ import com.google.gwt.event.dom.client.ScrollEvent;
 import com.google.gwt.event.dom.client.ScrollHandler;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.ui.AbsolutePanel;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -484,6 +485,26 @@ public class GridLienzoScrollHandlerTest {
     }
 
     @Test
+    public void testEmptyLayerReuse() {
+        Assertions.assertThat(gridLienzoScrollHandler.emptyLayer()).isEqualTo(gridLienzoScrollHandler.emptyLayer());
+    }
+
+    @Test
+    public void testScrollBarsReuse() {
+        Assertions.assertThat(gridLienzoScrollHandler.scrollBars()).isEqualTo(gridLienzoScrollHandler.scrollBars());
+    }
+
+    @Test
+    public void testScrollPositionReuse() {
+        Assertions.assertThat(gridLienzoScrollHandler.scrollPosition()).isEqualTo(gridLienzoScrollHandler.scrollPosition());
+    }
+
+    @Test
+    public void testScrollBoundsReuse() {
+        Assertions.assertThat(gridLienzoScrollHandler.scrollBounds()).isEqualTo(gridLienzoScrollHandler.scrollBounds());
+    }
+
+    @Test
     public void testGetDefaultGridLayerWhenLienzoGridLayerIsNotNull() {
 
         final DefaultGridLayer expectedLayer = mock(DefaultGridLayer.class);
@@ -492,6 +513,8 @@ public class GridLienzoScrollHandlerTest {
         doCallRealMethod().when(gridLienzoScrollHandler).getDefaultGridLayer();
 
         final DefaultGridLayer actualLayer = gridLienzoScrollHandler.getDefaultGridLayer();
+
+        verify(gridLienzoScrollHandler, never()).emptyLayer();
 
         assertEquals(expectedLayer,
                      actualLayer);


### PR DESCRIPTION
See https://issues.jboss.org/browse/DROOLS-4735

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/843
- https://github.com/kiegroup/kie-wb-common/pull/3004
- https://github.com/kiegroup/drools-wb/pull/1264

This PR really moves calculation of row heights from "on demand" to be cached in the `RenderingInformation` class. Subsequent uses of rows' heights was then moved to use the cached value if a `RenderingInformation` instance was available (i.e had been instantiated elsewhere in the class and could be passed as a parameter etc to needy code). 