### PR TITLE
Remove unused dependencies of the uberfire-workbench-client-views-pat…

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -41,10 +41,6 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-experimental-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client-api</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
…ternfly module

Unused dependencies were found during https://github.com/kiegroup/appformer/pull/836 PR review however probably there is no connection with that PR.