### PR TITLE
AF-1395 : The new Form modeler editor is not locked when it is edited

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
@@ -17,6 +17,8 @@
 package org.uberfire.ext.layout.editor.client;
 
 import java.util.List;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -49,6 +51,13 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
     private String pluginName;
     private String emptyTitleText;
     private String emptySubTitleText;
+
+    private boolean locked = false;
+
+    @PostConstruct
+    public void setup() {
+        layoutEditorPresenter.setup(() -> locked);
+    }
 
     @Override
     public void init(String layoutName,
@@ -152,5 +161,15 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
     @Override
     public void visit(LayoutElementVisitor visitor) {
         layoutEditorPresenter.visit(visitor);
+    }
+
+    @Override
+    public void lock() {
+        this.locked = true;
+    }
+
+    @Override
+    public void unlock() {
+        this.locked = false;
     }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImpl.java
@@ -56,7 +56,7 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
 
     @PostConstruct
     public void setup() {
-        layoutEditorPresenter.setup(() -> locked);
+        layoutEditorPresenter.setup(this::isLocked);
     }
 
     @Override
@@ -163,13 +163,17 @@ public class LayoutEditorPluginImpl implements LayoutEditorPlugin {
         layoutEditorPresenter.visit(visitor);
     }
 
+    public boolean isLocked() {
+        return locked;
+    }
+
     @Override
     public void lock() {
-        this.locked = true;
+        locked = true;
     }
 
     @Override
     public void unlock() {
-        this.locked = false;
+        locked = false;
     }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPresenter.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorPresenter.java
@@ -33,6 +33,7 @@ import org.uberfire.ext.layout.editor.client.generator.LayoutGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 @Dependent
 public class LayoutEditorPresenter {
@@ -51,6 +52,10 @@ public class LayoutEditorPresenter {
         this.container = container;
         this.layoutGenerator = layoutGenerator;
         view.init(this);
+    }
+
+    public void setup(Supplier<Boolean> lockSupplier) {
+        container.setLockSupplier(lockSupplier);
     }
 
     @PostConstruct

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/api/LayoutEditor.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/api/LayoutEditor.java
@@ -50,4 +50,7 @@ public interface LayoutEditor {
 
     void visit(LayoutElementVisitor visitor);
 
+    void lock();
+
+    void unlock();
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
@@ -28,6 +28,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.jboss.errai.codegen.util.Bool;
 import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
@@ -66,6 +67,7 @@ public class ColumnWithComponents implements Column {
     private Event<LockRequiredEvent> lockRequiredEvent;
     private LayoutTemplate.Style pageStyle;
     private Supplier<LayoutTemplate> currentLayoutTemplateSupplier;
+    private Supplier<Boolean> lockSupplier;
     private Integer columnHeight = DEFAULT_COLUMN_HEIGHT;
     private Integer columnWidth;
     private boolean selected = false;
@@ -103,6 +105,7 @@ public class ColumnWithComponents implements Column {
                      ParameterizedCommand<ColumnDrop> removeComponentCommand,
                      ParameterizedCommand<Column> removeCommand,
                      Supplier<LayoutTemplate> currentLayoutTemplateSupplier,
+                     Supplier<Boolean> lockSupplier,
                      Integer columnHeight) {
         this.columnWidth = columnWidth;
         this.parentElement = parent;
@@ -111,6 +114,7 @@ public class ColumnWithComponents implements Column {
         this.removeColumnCommand = removeCommand;
         this.pageStyle = pageStyle;
         this.currentLayoutTemplateSupplier = currentLayoutTemplateSupplier;
+        this.lockSupplier = lockSupplier;
         this.columnHeight = columnHeight;
         view.setWidth(columnWidth);
         setupPageLayout();
@@ -123,6 +127,7 @@ public class ColumnWithComponents implements Column {
                  createComponentRemoveCommand(),
                  this,
                  currentLayoutTemplateSupplier,
+                 lockSupplier,
                  Row.ROW_DEFAULT_HEIGHT);
     }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
@@ -63,6 +63,7 @@ public class ColumnWithComponents implements Column {
     private boolean canResizeLeft;
     private boolean canResizeRight;
     private Event<ColumnResizeEvent> columnResizeEvent;
+    private Event<LockRequiredEvent> lockRequiredEvent;
     private LayoutTemplate.Style pageStyle;
     private Supplier<LayoutTemplate> currentLayoutTemplateSupplier;
     private Integer columnHeight = DEFAULT_COLUMN_HEIGHT;
@@ -71,19 +72,18 @@ public class ColumnWithComponents implements Column {
     private boolean selectable = true;
 
     @Inject
-    Event<LockRequiredEvent> lockRequiredEvent;
-
-    @Inject
     public ColumnWithComponents(final View view,
                                 Instance<Row> rowInstance,
                                 DnDManager dndManager,
                                 LayoutDragComponentHelper layoutDragComponentHelper,
-                                Event<ColumnResizeEvent> columnResizeEvent) {
+                                Event<ColumnResizeEvent> columnResizeEvent,
+                                Event<LockRequiredEvent> lockRequiredEvent) {
         this.view = view;
         this.rowInstance = rowInstance;
         this.dndManager = dndManager;
         this.layoutDragComponentHelper = layoutDragComponentHelper;
         this.columnResizeEvent = columnResizeEvent;
+        this.lockRequiredEvent = lockRequiredEvent;
     }
 
     @PostConstruct

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
@@ -28,6 +28,7 @@ import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
@@ -68,6 +69,9 @@ public class ColumnWithComponents implements Column {
     private Integer columnWidth;
     private boolean selected = false;
     private boolean selectable = true;
+
+    @Inject
+    Event<LockRequiredEvent> lockRequiredEvent;
 
     @Inject
     public ColumnWithComponents(final View view,
@@ -196,6 +200,7 @@ public class ColumnWithComponents implements Column {
                                    id,
                                    orientation));
         }
+        lockRequiredEvent.fire(new LockRequiredEvent());
     }
 
     public boolean hasComponent(Column targetColumn) {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsView.java
@@ -28,7 +28,6 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.client.workbench.docks.UberfireDocksInteractionEvent;
-import org.uberfire.ext.layout.editor.api.css.CssRule;
 import org.uberfire.ext.layout.editor.client.components.rows.Row;
 import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
 import org.uberfire.ext.layout.editor.client.infra.ContainerResizeEvent;

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
@@ -27,6 +27,7 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
@@ -69,6 +70,9 @@ public class ComponentColumn implements Column {
     private Event<LayoutEditorElementUnselectEvent> columnUnselectEvent;
     private ManagedInstance<ComponentColumnPart> componentColumnManagedInstance;
     private List<LayoutEditorElementPart> parts = new ArrayList<>();
+
+    @Inject
+    Event<LockRequiredEvent> lockRequiredEvent;
 
     @Inject
     public ComponentColumn(final View view,
@@ -363,6 +367,7 @@ public class ComponentColumn implements Column {
                                         .fromMove(
                                                 dndManager.getDraggedColumn()));
         }
+        lockRequiredEvent.fire(new LockRequiredEvent());
     }
 
     private boolean dropInTheSameColumn() {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
@@ -441,6 +442,11 @@ public class ComponentColumn implements Column {
             }
         }
     }
+
+    public void onDragEnd(@Observes DragComponentEndEvent dragComponentEndEvent) {
+        view.notifyDragEnd();
+        requiredLock();
+    }
     
     @Override
     public List<LayoutEditorElementPart> getLayoutEditorElementParts() {
@@ -479,6 +485,8 @@ public class ComponentColumn implements Column {
         void setColumnHeight(Integer columnHeight);
 
         void setSelected(boolean selected);
+
+        void notifyDragEnd();
 
         List<PropertyEditorCategory> getPropertyCategories();
     }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
@@ -58,6 +58,7 @@ public class ComponentColumn implements Column {
     private boolean innerColumn = false;
     private LayoutComponent layoutComponent;
     private Supplier<LayoutTemplate> currentLayoutTemplateSupplier;
+    private Supplier<Boolean> lockSupplier;
     private boolean componentReady;
     private ParameterizedCommand<Column> removeCommand;
     private LayoutDragComponentHelper layoutDragComponentHelper;
@@ -103,9 +104,11 @@ public class ComponentColumn implements Column {
                      ParameterizedCommand<ColumnDrop> dropCommand,
                      ParameterizedCommand<Column> removeCommand,
                      Supplier<LayoutTemplate> currentLayoutTemplateSupplier,
+                     Supplier<Boolean> lockSupplier,
                      boolean newComponent) {
         this.layoutComponent = layoutComponent;
         this.currentLayoutTemplateSupplier = currentLayoutTemplateSupplier;
+        this.lockSupplier = lockSupplier;
         view.setup(layoutComponent, pageStyle);
         this.parentElement = parent;
         this.columnWidth = columnWidth;
@@ -216,7 +219,9 @@ public class ComponentColumn implements Column {
     }
 
     void configComponent(boolean newComponent) {
-
+        if (lockSupplier.get()) {
+            return;
+        }
         if (hasModalConfiguration(newComponent)) {
             view.showConfigComponentModal(this::configurationFinish,
                                           this::configurationCanceled,

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
@@ -69,11 +69,9 @@ public class ComponentColumn implements Column {
     private boolean selectable = true;
     private Event<LayoutEditorElementSelectEvent> columnSelectEvent;
     private Event<LayoutEditorElementUnselectEvent> columnUnselectEvent;
+    private Event<LockRequiredEvent> lockRequiredEvent;
     private ManagedInstance<ComponentColumnPart> componentColumnManagedInstance;
     private List<LayoutEditorElementPart> parts = new ArrayList<>();
-
-    @Inject
-    Event<LockRequiredEvent> lockRequiredEvent;
 
     @Inject
     public ComponentColumn(final View view,
@@ -82,6 +80,7 @@ public class ComponentColumn implements Column {
                            Event<ColumnResizeEvent> columnResizeEvent,
                            Event<LayoutEditorElementSelectEvent> columnSelectEvent,
                            Event<LayoutEditorElementUnselectEvent> columnUnselectEvent,
+                           Event<LockRequiredEvent> lockRequiredEvent,
                            ManagedInstance<ComponentColumnPart> componentColumnManagedInstance) {
         this.view = view;
         this.dndManager = dndManager;
@@ -89,6 +88,7 @@ public class ComponentColumn implements Column {
         this.columnResizeEvent = columnResizeEvent;
         this.columnSelectEvent = columnSelectEvent;
         this.columnUnselectEvent = columnUnselectEvent;
+        this.lockRequiredEvent = lockRequiredEvent;
         this.componentColumnManagedInstance = componentColumnManagedInstance;
     }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumn.java
@@ -349,6 +349,11 @@ public class ComponentColumn implements Column {
             newComponentDrop(orientation,
                              dndData);
         }
+        requiredLock();
+    }
+
+    public void requiredLock() {
+        lockRequiredEvent.fire(new LockRequiredEvent());
     }
 
     private void newComponentDrop(ColumnDrop.Orientation orientation,
@@ -367,7 +372,6 @@ public class ComponentColumn implements Column {
                                         .fromMove(
                                                 dndManager.getDraggedColumn()));
         }
-        lockRequiredEvent.fire(new LockRequiredEvent());
     }
 
     private boolean dropInTheSameColumn() {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -42,7 +42,6 @@ import org.uberfire.ext.layout.editor.client.api.LayoutDragComponent;
 import org.uberfire.ext.layout.editor.client.api.RenderingContext;
 import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
 import org.uberfire.ext.layout.editor.client.infra.ContainerResizeEvent;
-import org.uberfire.ext.layout.editor.client.infra.DragComponentEndEvent;
 import org.uberfire.ext.layout.editor.client.infra.DragHelperComponentColumn;
 import org.uberfire.ext.layout.editor.client.infra.LayoutEditorFocusController;
 import org.uberfire.ext.layout.editor.client.resources.i18n.CommonConstants;
@@ -605,14 +604,15 @@ public class ComponentColumnView
         return (dragOverY - top) < (bottom - dragOverY);
     }
 
-    public void onDragEnd(@Observes DragComponentEndEvent dragComponentEndEvent) {
+    @Override
+    public void notifyDragEnd() {
         removeCSSClass(colUp,
                        "componentDropInColumnPreview");
-        presenter.requiredLock();
     }
-    
+
+    @Override
     public LayoutDragComponent getLayoutDragComponent() {
         return helper.getLayoutDragComponent();
     }
-    
+
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -19,6 +19,7 @@ package org.uberfire.ext.layout.editor.client.components.columns;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -32,6 +33,7 @@ import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.client.workbench.docks.UberfireDocksInteractionEvent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
@@ -101,6 +103,9 @@ public class ComponentColumnView
 
     @Inject
     private DragHelperComponentColumn helper;
+
+    @Inject
+    Event<LockRequiredEvent> lockRequiredEvent;
 
     @Override
     public void init(ComponentColumn presenter) {
@@ -601,6 +606,7 @@ public class ComponentColumnView
     }
 
     public void cleanUp(@Observes DragComponentEndEvent dragComponentEndEvent) {
+        lockRequiredEvent.fire(new LockRequiredEvent());
         removeCSSClass(colUp,
                        "componentDropInColumnPreview");
     }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -19,7 +19,6 @@ package org.uberfire.ext.layout.editor.client.components.columns;
 import java.util.List;
 import java.util.function.Supplier;
 import javax.enterprise.context.Dependent;
-import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -33,7 +32,6 @@ import org.jboss.errai.common.client.ui.ElementWrapperWidget;
 import org.jboss.errai.ui.client.local.api.IsElement;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
-import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.client.workbench.docks.UberfireDocksInteractionEvent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
@@ -102,9 +100,6 @@ public class ComponentColumnView
 
     @Inject
     private DragHelperComponentColumn helper;
-
-    @Inject
-    private Event<LockRequiredEvent> lockRequiredEvent;
 
     @Override
     public void init(ComponentColumn presenter) {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -105,7 +105,7 @@ public class ComponentColumnView
     private DragHelperComponentColumn helper;
 
     @Inject
-    Event<LockRequiredEvent> lockRequiredEvent;
+    private Event<LockRequiredEvent> lockRequiredEvent;
 
     @Override
     public void init(ComponentColumn presenter) {
@@ -608,7 +608,7 @@ public class ComponentColumnView
     public void onDragEnd(@Observes DragComponentEndEvent dragComponentEndEvent) {
         removeCSSClass(colUp,
                        "componentDropInColumnPreview");
-        lockRequiredEvent.fire(new LockRequiredEvent());
+        presenter.requiredLock();
     }
     
     public LayoutDragComponent getLayoutDragComponent() {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -605,10 +605,10 @@ public class ComponentColumnView
         return (dragOverY - top) < (bottom - dragOverY);
     }
 
-    public void cleanUp(@Observes DragComponentEndEvent dragComponentEndEvent) {
-        lockRequiredEvent.fire(new LockRequiredEvent());
+    public void onDragEnd(@Observes DragComponentEndEvent dragComponentEndEvent) {
         removeCSSClass(colUp,
                        "componentDropInColumnPreview");
+        lockRequiredEvent.fire(new LockRequiredEvent());
     }
     
     public LayoutDragComponent getLayoutDragComponent() {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -71,14 +71,12 @@ public class Container implements LayoutEditorElement {
     private LayoutTemplate.Style pageStyle = LayoutTemplate.Style.FLUID;
     private Event<LayoutEditorElementSelectEvent> containerSelectEvent;
     private Event<LayoutEditorElementUnselectEvent> containerUnselectEvent;
+    private Event<LockRequiredEvent> lockRequiredEvent;
     private DnDManager dndManager;
     private boolean selectable = false;
     private boolean selected = false;
-    
-    LayoutEditorFocusController layoutEditorFocusController;
 
-    @Inject
-    Event<LockRequiredEvent> lockRequiredEvent;
+    LayoutEditorFocusController layoutEditorFocusController;
 
     @Inject
     public Container(final View view,
@@ -88,6 +86,7 @@ public class Container implements LayoutEditorElement {
                      Event<ComponentDropEvent> componentDropEvent,
                      Event<LayoutEditorElementSelectEvent> containerSelectEvent,
                      Event<LayoutEditorElementUnselectEvent> containerUnselectEvent,
+                     Event<LockRequiredEvent> lockRequiredEvent,
                      DnDManager dndManager,
                      LayoutEditorFocusController layoutEditorFocusController) {
         this.layoutCssHelper = layoutCssHelper;
@@ -97,6 +96,7 @@ public class Container implements LayoutEditorElement {
         this.componentDropEvent = componentDropEvent;
         this.containerSelectEvent = containerSelectEvent;
         this.containerUnselectEvent = containerUnselectEvent;
+        this.lockRequiredEvent = lockRequiredEvent;
         this.dndManager = dndManager;
         this.layoutEditorFocusController = layoutEditorFocusController;
         this.id = idGenerator.createContainerID();

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -326,6 +326,7 @@ public class Container implements LayoutEditorElement {
             }
             rows = updatedRows;
             getView();
+            lockRequiredEvent.fire(new LockRequiredEvent());
         };
     }
 
@@ -357,7 +358,6 @@ public class Container implements LayoutEditorElement {
                   updatedRows);
         // notifying dndManager that the move has finished!
         dndManager.endComponentMove();
-        lockRequiredEvent.fire(new LockRequiredEvent());
     }
 
     private void removeOldComponent(Column column) {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -270,7 +270,7 @@ public class Container implements LayoutEditorElement {
         return row;
     }
 
-    private Supplier<Boolean> getLockSupplier() {
+    public Supplier<Boolean> getLockSupplier() {
         return () -> lockSupplier.get();
     }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -31,6 +31,7 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.ext.layout.editor.api.css.CssValue;
 import org.uberfire.ext.layout.editor.api.editor.LayoutRow;
@@ -75,6 +76,9 @@ public class Container implements LayoutEditorElement {
     private boolean selected = false;
     
     LayoutEditorFocusController layoutEditorFocusController;
+
+    @Inject
+    Event<LockRequiredEvent> lockRequiredEvent;
 
     @Inject
     public Container(final View view,
@@ -353,6 +357,7 @@ public class Container implements LayoutEditorElement {
                   updatedRows);
         // notifying dndManager that the move has finished!
         dndManager.endComponentMove();
+        lockRequiredEvent.fire(new LockRequiredEvent());
     }
 
     private void removeOldComponent(Column column) {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/Container.java
@@ -75,6 +75,7 @@ public class Container implements LayoutEditorElement {
     private DnDManager dndManager;
     private boolean selectable = false;
     private boolean selected = false;
+    private Supplier<Boolean> lockSupplier = () -> false;
 
     LayoutEditorFocusController layoutEditorFocusController;
 
@@ -122,6 +123,10 @@ public class Container implements LayoutEditorElement {
             destroy(row);
         }
         rows = new ArrayList<>();
+    }
+
+    public void setLockSupplier(Supplier<Boolean> lockSupplier) {
+        this.lockSupplier = lockSupplier;
     }
 
     @Override
@@ -257,11 +262,16 @@ public class Container implements LayoutEditorElement {
                  createRemoveRowCommand(),
                  createRemoveComponentCommand(),
                  createCurrentLayoutTemplateSupplier(),
+                 getLockSupplier(),
                  height);
         row.withOneColumn(drop.getComponent(),
                           drop.newComponent());
         view.addRow(row.getView());
         return row;
+    }
+
+    private Supplier<Boolean> getLockSupplier() {
+        return () -> lockSupplier.get();
     }
 
     Supplier<LayoutTemplate> createCurrentLayoutTemplateSupplier() {
@@ -475,7 +485,8 @@ public class Container implements LayoutEditorElement {
                  layoutRow,
                  createRemoveRowCommand(),
                  createRemoveComponentCommand(),
-                 createCurrentLayoutTemplateSupplier());
+                 createCurrentLayoutTemplateSupplier(),
+                 getLockSupplier());
         return row;
     }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
@@ -405,11 +405,11 @@ public class Row implements LayoutEditorElement {
         Optional<Column> optional = checkIfColumnExistsInChildColumnWithComponents(targetColumn);
 
         // If present let's remove it!
-        optional.ifPresent(column -> removeComponentFromColumnWihtComponents((ColumnWithComponents) column,
+        optional.ifPresent(column -> removeComponentFromColumnWithComponents((ColumnWithComponents) column,
                                                                              targetColumn));
     }
 
-    private void removeComponentFromColumnWihtComponents(ColumnWithComponents parent,
+    private void removeComponentFromColumnWithComponents(ColumnWithComponents parent,
                                                          Column targetColumn) {
         PortablePreconditions.checkNotNull("parent",
                                            parent);
@@ -436,21 +436,17 @@ public class Row implements LayoutEditorElement {
         if (columnToReplace.getRow().getColumns().size() == 1) {
 
             // getting the remaining column
-            Column column = columnToReplace.getRow().getColumns().remove(0);
+            ComponentColumn originalColumn = (ComponentColumn) columnToReplace.getRow().getColumns().remove(0);
+            ComponentColumn column = createNewComponentColumn(originalColumn.getLayoutComponent(),
+                                              columnToReplace.getColumnWidth(),
+                                              false);
+
+            column.setId(columnToReplace.getId());
 
             int index = columns.indexOf(columnToReplace);
 
-            if (column instanceof ComponentColumn) {
-                // if it is a ComponentColumn we must regenerate to reload all the styling
-                ComponentColumn originalColumn = (ComponentColumn) column;
-                column = createNewComponentColumn(originalColumn.getLayoutComponent(),
-                                                  columnToReplace.getColumnWidth(),
-                                                  false);
-            }
-
             // promoting the remaining child on the actual row
-            columns.set(index,
-                        column);
+            columns.set(index, column);
 
             // destroy current column & update view
             columnToReplace.preDestroy();

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
@@ -72,6 +72,7 @@ public class Row implements LayoutEditorElement {
 
     private ParameterizedCommand<ColumnDrop> removeComponentCommand;
     private Supplier<LayoutTemplate> currentLayoutTemplateSupplier;
+    private Supplier<Boolean> lockSupplier;
 
     private ColumnWithComponents parentColumnWithComponents;
 
@@ -89,7 +90,7 @@ public class Row implements LayoutEditorElement {
     private Integer height;
     private boolean canResizeUp;
     private boolean canResizeDown;
-    
+
     LayoutEditorFocusController layoutEditorFocusController;
 
     @Inject
@@ -124,11 +125,13 @@ public class Row implements LayoutEditorElement {
                      ParameterizedCommand<Row> removeCommand,
                      ParameterizedCommand<ColumnDrop> removeComponentCommand,
                      Supplier<LayoutTemplate> currentLayoutTemplateSupplier,
+                     Supplier<Boolean> lockSupplier,
                      Integer height) {
         this.dropOnRowCommand = dropOnRowCommand;
         this.removeRowCommand = removeCommand;
         this.removeComponentCommand = removeComponentCommand;
         this.currentLayoutTemplateSupplier = currentLayoutTemplateSupplier;
+        this.lockSupplier = lockSupplier;
         this.parentColumnWithComponents = null;
         this.height = height;
         setupPageLayout(height);
@@ -139,12 +142,14 @@ public class Row implements LayoutEditorElement {
                      ParameterizedCommand<ColumnDrop> removeComponentCommand,
                      ColumnWithComponents parentColumnWithComponents,
                      Supplier<LayoutTemplate> currentLayoutTemplateSupplier,
+                     Supplier<Boolean> lockSupplier,
                      Integer height) {
         this.dropOnRowCommand = dropOnRowCommand;
         this.removeRowCommand = removeCommand;
         this.removeComponentCommand = removeComponentCommand;
         this.parentColumnWithComponents = parentColumnWithComponents;
         this.currentLayoutTemplateSupplier = currentLayoutTemplateSupplier;
+        this.lockSupplier = lockSupplier;
         this.height = height;
         setupPageLayout(height);
     }
@@ -153,11 +158,13 @@ public class Row implements LayoutEditorElement {
                      LayoutRow layoutRow,
                      ParameterizedCommand<Row> removeCommand,
                      ParameterizedCommand<ColumnDrop> removeComponentCommand,
-                     Supplier<LayoutTemplate> currentLayoutTemplateSupplier) {
+                     Supplier<LayoutTemplate> currentLayoutTemplateSupplier,
+                     Supplier<Boolean> lockSupplier) {
         this.dropOnRowCommand = dropOnRowCommand;
         this.removeRowCommand = removeCommand;
         this.removeComponentCommand = removeComponentCommand;
         this.currentLayoutTemplateSupplier = currentLayoutTemplateSupplier;
+        this.lockSupplier = lockSupplier;
         this.height = getHeight(layoutRow.getHeight());
         this.properties = layoutRow.getProperties();
         setupPageLayout(height);
@@ -211,6 +218,7 @@ public class Row implements LayoutEditorElement {
                           removeComponentCommand,
                           removeColumnCommand(),
                           currentLayoutTemplateSupplier,
+                          lockSupplier,
                           getHeight(layoutColumn.getHeight()));
 
             for (LayoutColumn column : row.getLayoutColumns()) {
@@ -275,6 +283,7 @@ public class Row implements LayoutEditorElement {
                     dropCommand(),
                     removeColumnCommand(),
                     currentLayoutTemplateSupplier,
+                    lockSupplier,
                     newComponent);
         columns.add(column);
         setupColumnResizeActions();
@@ -660,6 +669,7 @@ public class Row implements LayoutEditorElement {
                        dropCommand(),
                        removeColumnCommand(),
                        currentLayoutTemplateSupplier,
+                       lockSupplier,
                        drop.newComponent());
         newColumn.setColumnHeight(innerColumnHeight);
         return newColumn;
@@ -681,6 +691,7 @@ public class Row implements LayoutEditorElement {
                           removeComponentCommand,
                           removeColumnCommand(),
                           currentLayoutTemplateSupplier,
+                          lockSupplier,
                           currentColumn.getColumnHeight());
 
             final ComponentColumn newColumn = createComponentColumn(
@@ -736,6 +747,7 @@ public class Row implements LayoutEditorElement {
                        dropCommand(),
                        removeColumnCommand(),
                        currentLayoutTemplateSupplier,
+                       lockSupplier,
                        newComponent);
         return newColumn;
     }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
@@ -414,11 +414,11 @@ public class Row implements LayoutEditorElement {
         Optional<Column> optional = checkIfColumnExistsInChildColumnWithComponents(targetColumn);
 
         // If present let's remove it!
-        optional.ifPresent(column -> removeComponentFromColumnWithComponents((ColumnWithComponents) column,
+        optional.ifPresent(column -> removeComponentFromColumnWihtComponents((ColumnWithComponents) column,
                                                                              targetColumn));
     }
 
-    private void removeComponentFromColumnWithComponents(ColumnWithComponents parent,
+    private void removeComponentFromColumnWihtComponents(ColumnWithComponents parent,
                                                          Column targetColumn) {
         PortablePreconditions.checkNotNull("parent",
                                            parent);
@@ -445,17 +445,21 @@ public class Row implements LayoutEditorElement {
         if (columnToReplace.getRow().getColumns().size() == 1) {
 
             // getting the remaining column
-            ComponentColumn originalColumn = (ComponentColumn) columnToReplace.getRow().getColumns().remove(0);
-            ComponentColumn column = createNewComponentColumn(originalColumn.getLayoutComponent(),
-                                              columnToReplace.getColumnWidth(),
-                                              false);
-
-            column.setId(columnToReplace.getId());
+            Column column = columnToReplace.getRow().getColumns().remove(0);
 
             int index = columns.indexOf(columnToReplace);
 
+            if (column instanceof ComponentColumn) {
+                // if it is a ComponentColumn we must regenerate to reload all the styling
+                ComponentColumn originalColumn = (ComponentColumn) column;
+                column = createNewComponentColumn(originalColumn.getLayoutComponent(),
+                                                  columnToReplace.getColumnWidth(),
+                                                  false);
+            }
+
             // promoting the remaining child on the actual row
-            columns.set(index, column);
+            columns.set(index,
+                        column);
 
             // destroy current column & update view
             columnToReplace.preDestroy();

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
@@ -27,12 +27,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import org.jboss.errai.ioc.client.api.ManagedInstance;
-import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.api.ComponentDropEvent;
@@ -100,6 +100,8 @@ public abstract class AbstractLayoutEditorTest {
     @Mock
     protected EventSourceMock<LayoutEditorElementUnselectEvent> columnUnselectedEvent;
     @Mock
+    protected EventSourceMock<LockRequiredEvent> lockRequiredEventMock;
+    @Mock
     protected LayoutEditorFocusController layoutEditorFocusController;
 
     protected EmptyDropRow emptyDropRow = new EmptyDropRow(mock(EmptyDropRow.View.class),
@@ -118,6 +120,7 @@ public abstract class AbstractLayoutEditorTest {
                              componentDropEventMock,
                              layoutElementSelectEventMock,
                              layoutElementUnselectEventMock,
+                             lockRequiredEventMock,
                              dnDManager,
                              layoutEditorFocusController) {
             private UniqueIDGenerator idGenerator = new UniqueIDGenerator();

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/AbstractLayoutEditorTest.java
@@ -171,6 +171,7 @@ public abstract class AbstractLayoutEditorTest {
                                                                       mock(Event.class),
                                                                       columnSelectedEvent,
                                                                       columnUnselectedEvent,
+                                                                      mock(Event.class),
                                                                       managedInstanceMock) {
                     @Override
                     protected boolean hasConfiguration() {
@@ -188,6 +189,7 @@ public abstract class AbstractLayoutEditorTest {
                         null,
                         dnDManager,
                         dragHelper,
+                        mock(Event.class),
                         mock(Event.class)) {
                     @Override
                     protected Row createInstanceRow() {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImplTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImplTest.java
@@ -17,17 +17,33 @@
 
 package org.uberfire.ext.layout.editor.client;
 
+import java.util.function.Supplier;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LayoutEditorPluginImplTest {
 
+    @Mock
+    private LayoutEditorPresenter layoutEditorPresenter;
+
     @Spy
+    @InjectMocks
     private LayoutEditorPluginImpl layoutEditorPlugin;
+
+    @Captor
+    private ArgumentCaptor<Supplier<Boolean>> lockSupplierCaptor;
 
     @Test
     public void testLock() {
@@ -39,5 +55,12 @@ public class LayoutEditorPluginImplTest {
     public void testUnlock() {
         layoutEditorPlugin.unlock();
         Assert.assertFalse(layoutEditorPlugin.isLocked());
+    }
+
+    @Test
+    public void testSetup() {
+        layoutEditorPlugin.setup();
+        verify(layoutEditorPresenter, times(1)).setup(lockSupplierCaptor.capture());
+        Assert.assertFalse(lockSupplierCaptor.getValue().get());
     }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImplTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/LayoutEditorPluginImplTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.layout.editor.client;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LayoutEditorPluginImplTest {
+
+    @Spy
+    private LayoutEditorPluginImpl layoutEditorPlugin;
+
+    @Test
+    public void testLock() {
+        layoutEditorPlugin.lock();
+        Assert.assertTrue(layoutEditorPlugin.isLocked());
+    }
+
+    @Test
+    public void testUnlock() {
+        layoutEditorPlugin.unlock();
+        Assert.assertFalse(layoutEditorPlugin.isLocked());
+    }
+}

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/LayoutEditorPresenterTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/LayoutEditorPresenterTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.ext.layout.editor.client;
 
+import java.util.function.Supplier;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,7 +26,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.components.container.Container;
 import org.uberfire.ext.layout.editor.client.generator.LayoutGenerator;
-import org.uberfire.ext.layout.editor.client.widgets.LayoutEditorPropertiesPresenter;
 import org.uberfire.ext.layout.editor.client.widgets.LayoutDragComponentGroupPresenter;
 
 import static org.mockito.Matchers.any;
@@ -89,6 +90,13 @@ public class LayoutEditorPresenterTest {
                                           LayoutTemplate.Style.FLUID,
                                           EMPTY_TITLE_TEXT,
                                           EMPTY_SUB_TITLE_TEXT);
+    }
+
+    @Test
+    public void testSetup() {
+        Supplier<Boolean> lockSupplier = () -> false;
+        presenter.setup(lockSupplier);
+        verify(container).setLockSupplier(lockSupplier);
     }
 
     public void testLayoutEditorClear() {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsTest.java
@@ -17,20 +17,14 @@
 
 package org.uberfire.ext.layout.editor.client.components.columns;
 
-import java.util.function.Supplier;
-
 import javax.enterprise.event.Event;
-import javax.enterprise.inject.Instance;
 
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.uberfire.client.mvp.LockRequiredEvent;
-import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.AbstractLayoutEditorTest;
-import org.uberfire.ext.layout.editor.client.api.LayoutEditorElement;
-import org.uberfire.ext.layout.editor.client.components.rows.Row;
 import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
 import org.uberfire.mvp.ParameterizedCommand;
 
@@ -52,7 +46,6 @@ public class ColumnWithComponentsTest extends AbstractLayoutEditorTest {
 
     @Test
     public void testOnDrop() throws Exception {
-        loadLayout(SINGLE_ROW_COMPONENT_LAYOUT_WITH_PARTS);
         columnWithComponents.onDrop(ColumnDrop.Orientation.UP, "this-is-a-requirement-to-firefox-html5dnd");
         verify(lockRequiredEvent,
                times(1)).fire(any(LockRequiredEvent.class));

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsTest.java
@@ -26,16 +26,21 @@ import org.mockito.Spy;
 import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.layout.editor.client.AbstractLayoutEditorTest;
 import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
+import org.uberfire.ext.layout.editor.client.infra.DnDManager;
 import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ColumnWithComponentsTest extends AbstractLayoutEditorTest {
 
     @Mock
     private Event<LockRequiredEvent> lockRequiredEvent;
+
+    @Mock
+    private DnDManager dndManager;
 
     @Spy
     @InjectMocks
@@ -45,7 +50,16 @@ public class ColumnWithComponentsTest extends AbstractLayoutEditorTest {
     private ParameterizedCommand<ColumnDrop> dropCommand;
 
     @Test
-    public void testOnDrop() throws Exception {
+    public void testOnDropComponentMove() {
+        when(dndManager.isOnComponentMove()).thenReturn(true);
+        columnWithComponents.onDrop(ColumnDrop.Orientation.UP, "this-is-a-requirement-to-firefox-html5dnd");
+        verify(lockRequiredEvent,
+               times(1)).fire(any(LockRequiredEvent.class));
+    }
+
+    @Test
+    public void testOnDropNewComponent() {
+        when(dndManager.isOnComponentMove()).thenReturn(false);
         columnWithComponents.onDrop(ColumnDrop.Orientation.UP, "this-is-a-requirement-to-firefox-html5dnd");
         verify(lockRequiredEvent,
                times(1)).fire(any(LockRequiredEvent.class));

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponentsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.layout.editor.client.components.columns;
+
+import java.util.function.Supplier;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.Instance;
+
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.uberfire.client.mvp.LockRequiredEvent;
+import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
+import org.uberfire.ext.layout.editor.client.AbstractLayoutEditorTest;
+import org.uberfire.ext.layout.editor.client.api.LayoutEditorElement;
+import org.uberfire.ext.layout.editor.client.components.rows.Row;
+import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
+import org.uberfire.mvp.ParameterizedCommand;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ColumnWithComponentsTest extends AbstractLayoutEditorTest {
+
+    @Mock
+    private Event<LockRequiredEvent> lockRequiredEvent;
+
+    @Spy
+    @InjectMocks
+    private ColumnWithComponents columnWithComponents;
+
+    @Mock
+    private ParameterizedCommand<ColumnDrop> dropCommand;
+
+    @Test
+    public void testOnDrop() throws Exception {
+        loadLayout(SINGLE_ROW_COMPONENT_LAYOUT_WITH_PARTS);
+        columnWithComponents.onDrop(ColumnDrop.Orientation.UP, "this-is-a-requirement-to-firefox-html5dnd");
+        verify(lockRequiredEvent,
+               times(1)).fire(any(LockRequiredEvent.class));
+    }
+
+}

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
@@ -18,17 +18,55 @@ package org.uberfire.ext.layout.editor.client.components.columns;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import javax.enterprise.event.Event;
+
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.uberfire.client.mvp.LockRequiredEvent;
+import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponentPart;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.AbstractLayoutEditorTest;
+import org.uberfire.ext.layout.editor.client.api.LayoutEditorElement;
+import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
+import org.uberfire.mvp.ParameterizedCommand;
 
 public class ComponentColumnTest extends AbstractLayoutEditorTest {
+
+    @Mock
+    private Event<LockRequiredEvent> lockRequiredEvent;
+
+    @Spy
+    @InjectMocks
+    private ComponentColumn componentColumn;
+
+    @Mock
+    private LayoutEditorElement parent;
+
+    @Mock
+    private LayoutComponent layoutComponent;
+
+    @Mock
+    private ParameterizedCommand<ColumnDrop> dropCommand;
+
+    @Mock
+    private ParameterizedCommand<Column> removeCommand;
+
+    @Mock
+    private Supplier<LayoutTemplate> currentLayoutTemplateSupplier;
+
+    @Mock
+    private ComponentColumn.View view;
 
     @Test
     public void assertThereIsNoGWTDepInComponentColumn() throws Exception {
@@ -65,5 +103,22 @@ public class ComponentColumnTest extends AbstractLayoutEditorTest {
         part1.addCssProperty("NEW_PROP", "NEW_VALUE");
         assertEquals("NEW_VALUE", part1.getCssProperties().get("NEW_PROP"));
     }
-    
+
+    @Test
+    public void testOnDrop() throws Exception {
+        loadLayout(SINGLE_ROW_COMPONENT_LAYOUT_WITH_PARTS);
+        componentColumn.init(parent, 300, layoutComponent, dropCommand, removeCommand, currentLayoutTemplateSupplier, false);
+        componentColumn.onDrop(ColumnDrop.Orientation.UP,"this-is-a-requirement-to-firefox-html5dnd");
+        verify(lockRequiredEvent,
+               times(1)).fire(any(LockRequiredEvent.class));
+    }
+
+    @Test
+    public void testRequiredLock() throws Exception{
+        loadLayout(SINGLE_ROW_COMPONENT_LAYOUT_WITH_PARTS);
+        componentColumn.init(parent, 300, layoutComponent, dropCommand, removeCommand, currentLayoutTemplateSupplier, false);
+        componentColumn.requiredLock();
+        verify(lockRequiredEvent,
+               times(1)).fire(any(LockRequiredEvent.class));
+    }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +66,9 @@ public class ComponentColumnTest extends AbstractLayoutEditorTest {
 
     @Mock
     private Supplier<LayoutTemplate> currentLayoutTemplateSupplier;
+
+    @Mock
+    private Supplier<Boolean> lockSupplier;
 
     @Mock
     private ComponentColumn.View view;
@@ -125,5 +129,20 @@ public class ComponentColumnTest extends AbstractLayoutEditorTest {
         verify(view, times(1)).notifyDragEnd();
         verify(lockRequiredEvent,
                times(1)).fire(any(LockRequiredEvent.class));
+    }
+
+    @Test
+    public void testConfigComponentSupplier() {
+        when(lockSupplier.get()).thenReturn(true);
+        componentColumn.configComponent(true);
+        verify(view, times(0)).hasModalConfiguration();
+    }
+
+    @Test
+    public void testConfigComponent() {
+        when(lockSupplier.get()).thenReturn(false);
+        when(view.hasModalConfiguration()).thenReturn(true);
+        componentColumn.configComponent(true);
+        verify(view,times(1)).hasModalConfiguration();
     }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
@@ -39,6 +39,7 @@ import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.AbstractLayoutEditorTest;
 import org.uberfire.ext.layout.editor.client.api.LayoutEditorElement;
 import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
+import org.uberfire.ext.layout.editor.client.infra.DragComponentEndEvent;
 import org.uberfire.mvp.ParameterizedCommand;
 
 public class ComponentColumnTest extends AbstractLayoutEditorTest {
@@ -105,19 +106,23 @@ public class ComponentColumnTest extends AbstractLayoutEditorTest {
     }
 
     @Test
-    public void testOnDrop() throws Exception {
-        loadLayout(SINGLE_ROW_COMPONENT_LAYOUT_WITH_PARTS);
-        componentColumn.init(parent, 300, layoutComponent, dropCommand, removeCommand, currentLayoutTemplateSupplier, false);
+    public void testOnDrop() {
         componentColumn.onDrop(ColumnDrop.Orientation.UP,"this-is-a-requirement-to-firefox-html5dnd");
         verify(lockRequiredEvent,
                times(1)).fire(any(LockRequiredEvent.class));
     }
 
     @Test
-    public void testRequiredLock() throws Exception{
-        loadLayout(SINGLE_ROW_COMPONENT_LAYOUT_WITH_PARTS);
-        componentColumn.init(parent, 300, layoutComponent, dropCommand, removeCommand, currentLayoutTemplateSupplier, false);
+    public void testRequiredLock() {
         componentColumn.requiredLock();
+        verify(lockRequiredEvent,
+               times(1)).fire(any(LockRequiredEvent.class));
+    }
+
+    @Test
+    public void onDragEnd() {
+        componentColumn.onDragEnd(new DragComponentEndEvent());
+        verify(view, times(1)).notifyDragEnd();
         verify(lockRequiredEvent,
                times(1)).fire(any(LockRequiredEvent.class));
     }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
+import java.util.function.Supplier;
 
 import org.junit.Test;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponentPart;

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/container/ContainerTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/container/ContainerTest.java
@@ -324,4 +324,10 @@ public class ContainerTest extends AbstractLayoutEditorTest {
         assertEquals(expected,
                      currentLayoutTemplateSupplier.get());
     }
+
+    @Test
+    public void testLockSupplier() {
+        container.setLockSupplier(() -> false);
+        assertEquals(Boolean.FALSE, container.getLockSupplier().get());
+    }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/container/ContainerTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/container/ContainerTest.java
@@ -19,6 +19,7 @@ package org.uberfire.ext.layout.editor.client.components.container;
 import java.util.function.Supplier;
 
 import org.junit.Test;
+import org.uberfire.client.mvp.LockRequiredEvent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.ext.layout.editor.client.AbstractLayoutEditorTest;
@@ -282,7 +283,7 @@ public class ContainerTest extends AbstractLayoutEditorTest {
                      getRowsSizeFromContainer());
         assertEquals(dropRow,
                      getRowByIndex(FIRST_ROW));
-
+        verify(lockRequiredEventMock, times(1)).fire(any(LockRequiredEvent.class));
         verify(componentDropEventMock,
                times(1)).fire(any(ComponentDropEvent.class));
     }


### PR DESCRIPTION
Added the LockRequiredEvent when a component is dropped in the editor in canvas.
  
ensemble: 
kie-wb-common: https://github.com/kiegroup/kie-wb-common/pull/3063
