### PR TITLE
AF-2347: [wires-grids] CellContextUtilities.makeCellRenderContext() wrong for scrolled grids

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilities.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilities.java
@@ -24,7 +24,6 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.types.Point2D;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
-import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.context.GridBodyCellEditContext;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
@@ -38,12 +37,9 @@ public class CellContextUtilities {
                                                                 final int uiRowIndex) {
         final GridColumn<?> column = ci.getColumn();
         final GridRenderer renderer = gridWidget.getRenderer();
-        final GridRow gridRow = gridWidget.getModel().getRow(uiRowIndex);
-        final double headerRowsHeight = ri.getHeaderRowsHeight();
-        final double rowYOffset = gridWidget.getRendererHelper().getRowOffset(gridRow);
 
         final double cellX = getCellX(gridWidget, ci);
-        final double cellY = getHeaderY(gridWidget, ri) + headerRowsHeight + rowYOffset;
+        final double cellY = getCellY(gridWidget, uiRowIndex);
 
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = ri.getFloatingBlockInformation();
         final double clipMinX = getClipMinX(gridWidget, floatingBlockInformation);
@@ -166,6 +162,13 @@ public class CellContextUtilities {
     private static double getCellX(final GridWidget gridWidget,
                                    final BaseGridRendererHelper.ColumnInformation ci) {
         return gridWidget.getComputedLocation().getX() + ci.getOffsetX();
+    }
+
+    private static double getCellY(final GridWidget gridWidget,
+                                   final int uiRowIndex) {
+        final GridRenderer renderer = gridWidget.getRenderer();
+        final BaseGridRendererHelper rendererHelper = gridWidget.getRendererHelper();
+        return gridWidget.getComputedLocation().getY() + renderer.getHeaderHeight() + rendererHelper.getRowOffset(uiRowIndex);
     }
 
     private static double getHeaderY(final GridWidget gridWidget,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
@@ -139,7 +139,6 @@ public class CellContextUtilitiesTest {
 
     @Test
     public void testMakeCellRenderContextOneRow() {
-        final double headerRowsHeight = 100.0;
         final BaseGridRow row = new BaseGridRow();
         final List<GridColumn<?>> allColumns = new ArrayList<>();
         final List<Double> allRowHeights = Collections.singletonList(row.getHeight());
@@ -151,8 +150,6 @@ public class CellContextUtilitiesTest {
         allColumns.add(uiColumn3);
         gridWidget.getModel().appendRow(row);
 
-        doReturn(allColumns).when(ri).getAllColumns();
-        doReturn(headerRowsHeight).when(ri).getHeaderRowsHeight();
         doReturn(allRowHeights).when(ri).getAllRowHeights();
         doReturn(uiColumn2).when(ci).getColumn();
         doReturn(25.0).when(ci).getOffsetX();
@@ -170,12 +167,11 @@ public class CellContextUtilitiesTest {
 
         assertThat(context.getAbsoluteCellY())
                 .as("Should be headers height")
-                .isEqualTo(headerRowsHeight);
+                .isEqualTo(HEADER_HEIGHT);
     }
 
     @Test
     public void testMakeCellRenderContextThreeRows() {
-        final double headerRowsHeight = 100.0;
         final BaseGridRow row1 = new BaseGridRow();
         final BaseGridRow row2 = new BaseGridRow();
         final BaseGridRow row3 = new BaseGridRow();
@@ -192,8 +188,6 @@ public class CellContextUtilitiesTest {
         gridWidget.getModel().appendRow(row2);
         gridWidget.getModel().appendRow(row3);
 
-        doReturn(allColumns).when(ri).getAllColumns();
-        doReturn(headerRowsHeight).when(ri).getHeaderRowsHeight();
         doReturn(allRowHeights).when(ri).getAllRowHeights();
         doReturn(uiColumn3).when(ci).getColumn();
         doReturn(25.0).when(ci).getOffsetX();
@@ -211,7 +205,7 @@ public class CellContextUtilitiesTest {
 
         assertThat(context.getAbsoluteCellY())
                 .as("Should be sum of header height plus preceding row heights")
-                .isEqualTo(headerRowsHeight + row1.getHeight() + row2.getHeight());
+                .isEqualTo(HEADER_HEIGHT + row1.getHeight() + row2.getHeight());
     }
 
     @Test

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/CellContextUtilitiesTest.java
@@ -84,9 +84,9 @@ public class CellContextUtilitiesTest {
     private Point2D rp = new Point2D(0, 0);
     private Point2D computedLocation = new Point2D(0, 0);
     private BaseGridRendererHelper gridRendererHelper;
-    private BaseGridRow row1 = new BaseGridRow();
-    private BaseGridRow row2 = new BaseGridRow();
-    private BaseGridRow row3 = new BaseGridRow();
+    private BaseGridRow row1;
+    private BaseGridRow row2;
+    private BaseGridRow row3;
 
     @Before
     public void setup() {
@@ -569,8 +569,8 @@ public class CellContextUtilitiesTest {
         doReturn(0).when(gridColumn).getIndex();
 
         gridWidget.getModel().appendColumn(gridColumn);
-        gridWidget.getModel().appendRow(new BaseGridRow());
-        gridWidget.getModel().appendRow(new BaseGridRow());
+        gridWidget.getModel().appendRow(row1);
+        gridWidget.getModel().appendRow(row2);
         gridWidget.getModel().selectCell(1, 0);
 
         CellContextUtilities.editSelectedCell(gridWidget);
@@ -591,7 +591,7 @@ public class CellContextUtilitiesTest {
 
         gridWidget.getModel().appendColumn(gridColumnOne);
         gridWidget.getModel().appendColumn(gridColumnTwo);
-        gridWidget.getModel().appendRow(new BaseGridRow());
+        gridWidget.getModel().appendRow(row1);
         gridWidget.getModel().selectCell(0, 1);
 
         CellContextUtilities.editSelectedCell(gridWidget);


### PR DESCRIPTION
See https://issues.jboss.org/browse/AF-2347