### PR TITLE
[7.30.x] RHPAM-2317 - Users cannot find the properties menu unless it's pointed out to them

### DIFF
--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/items/SideDockItem.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/items/SideDockItem.java
@@ -62,7 +62,13 @@ public class SideDockItem extends AbstractSideDockItem {
         itemButton.setSize(ButtonSize.SMALL);
         itemButton.setType(ButtonType.LINK);
         configureIcon(itemButton, getDock().getImageIcon());
-        configureTooltip(itemTooltip, getDock().getLabel());
+
+        String tooltip = getDock().getTooltip();
+        if (tooltip == null) {
+            tooltip = getDock().getLabel();
+        }
+
+        configureTooltip(itemTooltip, tooltip);
 
         itemButton.addStyleName(CSS.CSS().sideDockItem());
         itemButton.addClickHandler(new ClickHandler() {

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/items/SideDockItemTest.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/items/SideDockItemTest.java
@@ -29,6 +29,7 @@ import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
@@ -57,12 +58,16 @@ public class SideDockItemTest {
         dockWithFontIcon = new UberfireDock(UberfireDockPosition.EAST,
                                             "BRIEFCASE",
                                             placeRequest,
-                                            "").withSize(450).withLabel("dock");
+                                            "")
+                .withSize(450)
+                .withLabel("dock");
         dockWithImageIcon = new UberfireDock(UberfireDockPosition.EAST,
                                              imageResource,
                                              imageResourceFocused,
                                              placeRequest,
-                                             "").withSize(450).withLabel("dock");
+                                             "")
+                .withSize(450)
+                .withLabel("dock");
 
         sideDockWithFontIcon = spy(new SideDockItem(dockWithFontIcon,
                                                     emptyCommand,
@@ -133,6 +138,36 @@ public class SideDockItemTest {
 
     @Test
     public void createSideDockItemWithTooltipTest() {
+        final String dock_screenID = "SCREEN_ID";
+        final String dock_label = "DOCK TITLE";
+        final String dock_tooltip = "DOCK TOOLTIP";
+
+        UberfireDock dock1 = new UberfireDock(UberfireDockPosition.EAST,
+                                              "BRIEFCASE",
+                                              placeRequest,
+                                              "")
+                .withLabel(dock_label)
+                .withTooltip(dock_tooltip);
+        SideDockItem tested1 = spy(new SideDockItem(dock1, emptyCommand, emptyCommand));
+        tested1.createButton();
+        verify(tested1).configureTooltip(any(Tooltip.class), eq(dock_tooltip));
+
+        UberfireDock dock2 = new UberfireDock(UberfireDockPosition.EAST,
+                                              "BRIEFCASE",
+                                              placeRequest,
+                                              "")
+                .withLabel(dock_label);
+        SideDockItem tested2 = spy(new SideDockItem(dock2, emptyCommand, emptyCommand));
+        tested2.createButton();
+        verify(tested2).configureTooltip(any(Tooltip.class), eq(dock_label));
+
+        UberfireDock dock3 = new UberfireDock(UberfireDockPosition.EAST,
+                                              "BRIEFCASE",
+                                              new DefaultPlaceRequest(dock_screenID),
+                                              "");
+        SideDockItem tested3 = spy(new SideDockItem(dock3, emptyCommand, emptyCommand));
+        tested3.createButton();
+        verify(tested3).configureTooltip(any(Tooltip.class), eq(dock_screenID));
 
         Tooltip tooltip = new Tooltip();
         sideDockWithImageIcon.configureTooltip(tooltip, sideDockWithImageIcon.getLabel());

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/docks/UberfireDock.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/docks/UberfireDock.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.client.workbench.docks;
 
+import java.util.Objects;
+
 import com.google.gwt.resources.client.ImageResource;
 import org.uberfire.mvp.PlaceRequest;
 
@@ -32,6 +34,8 @@ public class UberfireDock {
     private Double size;
 
     private String label;
+
+    private String tooltip;
 
     private ImageResource imageIcon;
 
@@ -86,6 +90,11 @@ public class UberfireDock {
         return this;
     }
 
+    public UberfireDock withTooltip(String tooltip) {
+        this.tooltip = tooltip;
+        return this;
+    }
+
     public UberfireDock withSize(double size) {
         this.size = size;
         return this;
@@ -119,6 +128,10 @@ public class UberfireDock {
         return label;
     }
 
+    public String getTooltip() {
+        return tooltip;
+    }
+
     public String getIconType() {
         return iconType;
     }
@@ -142,36 +155,35 @@ public class UberfireDock {
 
         UberfireDock that = (UberfireDock) o;
 
-        if (placeRequest != null ? !placeRequest.equals(that.placeRequest) : that.placeRequest != null) {
-            return false;
-        }
-        if (iconType != that.iconType) {
-            return false;
-        }
-        if (uberfireDockPosition != that.uberfireDockPosition) {
-            return false;
-        }
-        if (associatedPerspective != null ? !associatedPerspective.equals(that.associatedPerspective) : that.associatedPerspective != null) {
-            return false;
-        }
-        if (size != null ? !size.equals(that.size) : that.size != null) {
-            return false;
-        }
-        return !(label != null ? !label.equals(that.label) : that.label != null);
+        return Objects.equals(uberfireDockPosition, that.uberfireDockPosition) &&
+                Objects.equals(iconType, that.iconType) &&
+                Objects.equals(imageIcon, that.imageIcon) &&
+                Objects.equals(imageIconFocused, that.imageIconFocused) &&
+                Objects.equals(placeRequest, that.placeRequest) &&
+                Objects.equals(associatedPerspective, that.associatedPerspective) &&
+                Objects.equals(size, that.size) &&
+                Objects.equals(label, that.label) &&
+                Objects.equals(tooltip, that.tooltip);
     }
 
     @Override
     public int hashCode() {
-        int result = placeRequest != null ? placeRequest.hashCode() : 0;
+        int result = placeRequest.hashCode();
+        result = 31 * result + (uberfireDockPosition != null ? uberfireDockPosition.hashCode() : 0);
+        result = ~~result;
         result = 31 * result + (iconType != null ? iconType.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + (uberfireDockPosition != null ? uberfireDockPosition.hashCode() : 0);
+        result = 31 * result + (imageIcon != null ? imageIcon.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (imageIconFocused != null ? imageIconFocused.hashCode() : 0);
         result = ~~result;
         result = 31 * result + (associatedPerspective != null ? associatedPerspective.hashCode() : 0);
         result = ~~result;
         result = 31 * result + (size != null ? size.hashCode() : 0);
         result = ~~result;
         result = 31 * result + (label != null ? label.hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + (tooltip != null ? tooltip.hashCode() : 0);
         result = ~~result;
         return result;
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/docks/UberfireDockTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/docks/UberfireDockTest.java
@@ -1,0 +1,259 @@
+package org.uberfire.client.workbench.docks;
+
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class UberfireDockTest extends TestCase {
+
+    private static final UberfireDockPosition DOCK_POSITION = UberfireDockPosition.EAST;
+    private static String ICON_TYPE = "ICON_TYPE";
+    private static final String SCREEN_ID = "SCREEN_ID";
+    private static final String PERSPECTIVE_ID = "PERSPECTIVE_ID";
+
+    private static final int SIZE = 450;
+    private static final String LABEL = "DOCK TITLE";
+    private static final String TOOLTIP = "DOCK TOOLTIP";
+
+    @Mock
+    private ImageResource imageIcon1;
+    @Mock
+    private ImageResource imageIcon2;
+
+    @Mock
+    private ImageResource imageIconFocused1;
+    @Mock
+    private ImageResource imageIconFocused2;
+
+    private UberfireDock tested;
+    private UberfireDock testedWithImages;
+
+    @Before
+    public void setUp() {
+        tested = new UberfireDock(DOCK_POSITION,
+                                  ICON_TYPE,
+                                  new DefaultPlaceRequest(SCREEN_ID),
+                                  PERSPECTIVE_ID)
+                .withLabel(LABEL)
+                .withTooltip(TOOLTIP)
+                .withSize(SIZE);
+
+        testedWithImages = new UberfireDock(DOCK_POSITION,
+                                            imageIcon1,
+                                            imageIconFocused1,
+                                            new DefaultPlaceRequest(SCREEN_ID),
+                                            PERSPECTIVE_ID);
+    }
+
+    @Test
+    public void testWithLabel() {
+        assertEquals(0, tested.getLabel().compareTo(LABEL));
+    }
+
+    @Test
+    public void testWithTooltip() {
+        assertEquals(0, tested.getTooltip().compareTo(TOOLTIP));
+
+        final UberfireDock tested2 = new UberfireDock(UberfireDockPosition.EAST,
+                                                      ICON_TYPE,
+                                                      new DefaultPlaceRequest(SCREEN_ID),
+                                                      PERSPECTIVE_ID);
+        assertNull(tested2.getTooltip());
+    }
+
+    @Test
+    public void testWithSize() {
+        assertEquals(SIZE, tested.getSize(), 0);
+    }
+
+    @Test
+    public void testSetUberfireDockPosition() {
+
+        UberfireDock uberfireDock = tested = new UberfireDock(UberfireDockPosition.EAST,
+                                                              ICON_TYPE,
+                                                              new DefaultPlaceRequest(SCREEN_ID),
+                                                              PERSPECTIVE_ID);
+        uberfireDock.setUberfireDockPosition(UberfireDockPosition.WEST);
+        assertEquals(UberfireDockPosition.WEST, tested.getDockPosition());
+    }
+
+    @Test
+    public void testGetAssociatedPerspective() {
+        assertEquals(PERSPECTIVE_ID, tested.getAssociatedPerspective());
+    }
+
+    @Test
+    public void testGetIdentifier() {
+        assertEquals(SCREEN_ID, tested.getIdentifier());
+    }
+
+    @Test
+    public void testGetPlaceRequest() {
+        assertEquals(SCREEN_ID, tested.getPlaceRequest().getIdentifier());
+    }
+
+    @Test
+    public void testGetDockPosition() {
+        assertEquals(DOCK_POSITION, tested.getDockPosition());
+    }
+
+    @Test
+    public void testGetSize() {
+        assertEquals(SIZE, tested.getSize(), 0);
+    }
+
+    @Test
+    public void testGetLabel() {
+        assertEquals(LABEL, tested.getLabel());
+    }
+
+    @Test
+    public void testGetTooltip() {
+        assertEquals(TOOLTIP, tested.getTooltip());
+    }
+
+    @Test
+    public void testGetIconType() {
+        assertEquals(ICON_TYPE, tested.getIconType());
+    }
+
+    @Test
+    public void testGetImageIcon() {
+        assertEquals(imageIcon1, testedWithImages.getImageIcon());
+    }
+
+    @Test
+    public void testGetImageIconFocused() {
+        assertEquals(imageIconFocused1, testedWithImages.getImageIconFocused());
+    }
+
+    @Test
+    public void testEquals() {
+        UberfireDock compareDock1 = new UberfireDock(DOCK_POSITION,
+                                                     ICON_TYPE,
+                                                     new DefaultPlaceRequest(SCREEN_ID),
+                                                     PERSPECTIVE_ID)
+                .withSize(SIZE)
+                .withLabel(LABEL)
+                .withTooltip(TOOLTIP);
+
+        UberfireDock compareDock2 = new UberfireDock(DOCK_POSITION,
+                                                     imageIcon1,
+                                                     imageIconFocused1,
+                                                     new DefaultPlaceRequest(SCREEN_ID),
+                                                     PERSPECTIVE_ID)
+                .withSize(SIZE)
+                .withLabel(LABEL)
+                .withTooltip(TOOLTIP);
+
+        UberfireDock compareDock3 = new UberfireDock(null,
+                                                     null,
+                                                     new DefaultPlaceRequest(SCREEN_ID));
+
+        UberfireDock compareDock4 = new UberfireDock(null,
+                                                     null,
+                                                     null,
+                                                     new DefaultPlaceRequest(SCREEN_ID));
+
+        UberfireDock compareDock5 = new UberfireDock(UberfireDockPosition.WEST,
+                                                     ICON_TYPE + "EXTRA",
+                                                     new DefaultPlaceRequest(SCREEN_ID + "EXTRA"),
+                                                     PERSPECTIVE_ID + "EXTRA")
+                .withSize(SIZE + 20)
+                .withLabel(LABEL + "EXTRA")
+                .withTooltip(TOOLTIP + "EXTRA");
+
+        UberfireDock compareDock6 = new UberfireDock(UberfireDockPosition.WEST,
+                                                     imageIcon2,
+                                                     imageIconFocused2,
+                                                     new DefaultPlaceRequest(SCREEN_ID + "EXTRA"),
+                                                     PERSPECTIVE_ID + "EXTRA")
+                .withSize(SIZE + 20)
+                .withLabel(LABEL + "EXTRA")
+                .withTooltip(TOOLTIP + "EXTRA");
+
+        assertEquals(tested, tested);
+        assertEquals(tested, compareDock1);
+        assertNotEquals(null, tested);
+        assertNotEquals(tested, new Object());
+        assertNotEquals(tested, compareDock2);
+        assertNotEquals(tested, compareDock3);
+        assertNotEquals(tested, compareDock4);
+        assertNotEquals(tested, compareDock5);
+        assertNotEquals(tested, compareDock6);
+        assertNotEquals(compareDock1, compareDock2);
+        assertNotEquals(compareDock1, compareDock3);
+        assertNotEquals(compareDock1, compareDock4);
+        assertNotEquals(compareDock1, compareDock5);
+        assertNotEquals(compareDock1, compareDock6);
+        assertNotEquals(compareDock2, compareDock3);
+        assertNotEquals(compareDock2, compareDock4);
+        assertNotEquals(compareDock2, compareDock5);
+        assertNotEquals(compareDock2, compareDock6);
+        assertEquals(compareDock3, compareDock4);
+        assertNotEquals(compareDock3, compareDock5);
+        assertNotEquals(compareDock3, compareDock6);
+        assertNotEquals(compareDock4, compareDock5);
+        assertNotEquals(compareDock4, compareDock6);
+        assertNotEquals(compareDock5, compareDock6);
+    }
+
+    @Test
+    public void testTestHashCode() {
+        UberfireDock compareDock1 = new UberfireDock(DOCK_POSITION,
+                                                     ICON_TYPE,
+                                                     new DefaultPlaceRequest(SCREEN_ID),
+                                                     PERSPECTIVE_ID)
+                .withSize(SIZE)
+                .withLabel(LABEL)
+                .withTooltip(TOOLTIP);
+
+        UberfireDock compareDock2 = new UberfireDock(DOCK_POSITION,
+                                                     imageIcon1,
+                                                     imageIconFocused1,
+                                                     new DefaultPlaceRequest(SCREEN_ID),
+                                                     PERSPECTIVE_ID)
+                .withSize(SIZE)
+                .withLabel(LABEL)
+                .withTooltip(TOOLTIP);
+
+        UberfireDock compareDock3 = new UberfireDock(null,
+                                                     null,
+                                                     new DefaultPlaceRequest(SCREEN_ID));
+
+        UberfireDock compareDock4 = new UberfireDock(null,
+                                                     null,
+                                                     null,
+                                                     new DefaultPlaceRequest(SCREEN_ID));
+
+        UberfireDock compareDock5 = new UberfireDock(DOCK_POSITION,
+                                                     ICON_TYPE,
+                                                     new DefaultPlaceRequest(SCREEN_ID),
+                                                     PERSPECTIVE_ID)
+                .withLabel(null);
+
+        assertEquals(tested.hashCode(), compareDock1.hashCode());
+        assertNotSame(tested.hashCode(), compareDock2.hashCode());
+        assertNotSame(tested.hashCode(), compareDock3.hashCode());
+        assertNotSame(tested.hashCode(), compareDock4.hashCode());
+        assertNotSame(tested.hashCode(), compareDock5.hashCode());
+        assertNotSame(compareDock1.hashCode(), compareDock2.hashCode());
+        assertNotSame(compareDock1.hashCode(), compareDock3.hashCode());
+        assertNotSame(compareDock1.hashCode(), compareDock4.hashCode());
+        assertNotSame(compareDock1.hashCode(), compareDock5.hashCode());
+        assertNotSame(compareDock2.hashCode(), compareDock3.hashCode());
+        assertNotSame(compareDock2.hashCode(), compareDock4.hashCode());
+        assertNotSame(compareDock2.hashCode(), compareDock5.hashCode());
+        assertNotSame(compareDock3.hashCode(), compareDock4.hashCode());
+        assertNotSame(compareDock3.hashCode(), compareDock5.hashCode());
+        assertNotSame(compareDock4.hashCode(), compareDock5.hashCode());
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/docks/UberfireDockTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/docks/UberfireDockTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.uberfire.client.workbench.docks;
 
 import com.google.gwt.resources.client.ImageResource;


### PR DESCRIPTION
**This is part of an ensemble**:
**https://github.com/kiegroup/kie-wb-common/pull/3024**

https://issues.jboss.org/browse/RHPAM-2317

This adds the possibility of having different labels and tooltips for the docks which was not supported.

Some small adjustments due to sonar cloud fail.
* Wider test coverage
* Change to method name in a test.
* Unnecessary code removed.

Video (Updated - Tooltip shows Properties instead of Open properties panel):
https://drive.google.com/file/d/1AbYsbhHG2RfZJjtSz3Kb2cKyQJG6tLsB/view?usp=sharing