### PR TITLE
DROOLS-4518: Remove unused dependencies

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/pom.xml
@@ -53,10 +53,6 @@
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-dataset-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.dashbuilder</groupId>
-      <artifactId>dashbuilder-dataset-client</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.dashbuilder</groupId>
@@ -81,11 +77,6 @@
     <dependency>
       <groupId>com.google.jsinterop</groupId>
       <artifactId>jsinterop-annotations</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-api</artifactId>
     </dependency>
 
     <dependency>

--- a/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/resources/org/dashbuilder/renderer/C3Renderer.gwt.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-renderers/dashbuilder-renderer-c3/src/main/resources/org/dashbuilder/renderer/C3Renderer.gwt.xml
@@ -6,8 +6,6 @@
   <inherits name="org.jboss.errai.ioc.Container"/>
   <inherits name="org.jboss.errai.ui.UI"/>
 
-  <inherits name="org.uberfire.UberfireAPI"/>
-
   <inherits name="org.dashbuilder.DisplayerClient"/>
 
   <inherits name="org.gwtbootstrap3.GwtBootstrap3NoTheme"/>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/pom.xml
@@ -43,11 +43,6 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-bus</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-common</artifactId>
     </dependency>
 

--- a/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/resources/org/dashbuilder/DisplayerAPI.gwt.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/resources/org/dashbuilder/DisplayerAPI.gwt.xml
@@ -18,7 +18,6 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
     "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
 <module>
-  <inherits name="org.jboss.errai.bus.ErraiBus"/>
   <inherits name="org.dashbuilder.JSON"/>
 
   <source path='displayer'/>


### PR DESCRIPTION
During https://github.com/kiegroup/appformer/pull/860 review these unused dependencies were found.