### PR TITLE
KOGITO-436: Remove unused dependencies

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client/pom.xml
@@ -53,10 +53,6 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-cdi-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
     </dependency>
     <dependency>
@@ -121,10 +117,6 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.gwtbootstrap3</groupId>
-      <artifactId>gwtbootstrap3</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
During KOGITO-436 review some unused dependencies were found, this PR is an effor to eliminate them.