### PR TITLE
KOGITO-652: Context for editors

### DIFF
--- a/appformer-kogito-bridge/pom.xml
+++ b/appformer-kogito-bridge/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-       ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+       ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/EditorContextProvider.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/EditorContextProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.context;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.appformer.kogito.bridge.client.context.interop.EditorContextWrapper;
+
+/**
+ * 
+ * CDI Bean to provide access to EditorContext properties
+ *
+ */
+@ApplicationScoped
+public class EditorContextProvider {
+
+    /**
+     * The channel where the editor is running
+     * @return
+     */
+    public Optional<String> getChannel() {
+        return nullSafe(wrapper -> wrapper.getChannel());
+    }
+
+    private Optional<String> nullSafe(Function<EditorContextWrapper, String> action) {
+        EditorContextWrapper wrapper = EditorContextWrapper.get();
+        if (wrapper != null) {
+            return Optional.of(action.apply(wrapper));
+        }
+        return Optional.empty();
+    }
+
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/EditorContextProvider.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/EditorContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ public interface EditorContextProvider {
      * Access the channel where the editor is running (e.g. ONLINE, GITHUB or VSCODE).
      * 
      * @return
-     * The channel where the editor is running or an empty optional if no channel is available.
+     * The channel where the editor is running or DEFAULT if no channel is available.
      */
     KogitoChannel getChannel();
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/KogitoChannel.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/KogitoChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/KogitoChannel.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/KogitoChannel.java
@@ -16,19 +16,29 @@
 
 package org.appformer.kogito.bridge.client.context;
 
-/**
- * 
- * Provide access to EditorContext properties
- *
- */
-public interface EditorContextProvider {
+import java.util.stream.Stream;
 
-    /**
-     * Access the channel where the editor is running (e.g. ONLINE, GITHUB or VSCODE).
-     * 
-     * @return
-     * The channel where the editor is running or an empty optional if no channel is available.
-     */
-    KogitoChannel getChannel();
+public enum KogitoChannel {
+
+    DEFAULT("DEFAULT"),
+    ONLINE("ONLINE"),
+    VSCODE("VSCODE"),
+    GITHUB("GITHUB");
+
+    private final String name;
+
+    KogitoChannel(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static KogitoChannel withName(String name) {
+        return Stream.of(KogitoChannel.values())
+                     .filter(channel -> channel.getName().equalsIgnoreCase(name))
+                     .findFirst().orElseThrow(() -> new IllegalArgumentException("Name not recognized: " + name));
+    }
 
 }

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/impl/EditorContextProviderImpl.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/impl/EditorContextProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/impl/EditorContextProviderImpl.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/impl/EditorContextProviderImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.context.impl;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.appformer.kogito.bridge.client.context.KogitoChannel;
+import org.appformer.kogito.bridge.client.context.EditorContextProvider;
+import org.appformer.kogito.bridge.client.context.interop.EditorContextWrapper;
+import org.appformer.kogito.bridge.client.interop.WindowRef;
+
+@ApplicationScoped
+public class EditorContextProviderImpl implements EditorContextProvider {
+
+    @Override
+    public KogitoChannel getChannel() {
+        if (WindowRef.isEnvelopeAvailable()) {
+            String channel = EditorContextWrapper.get().getChannel();
+            if (channel != null) {
+                return KogitoChannel.withName(channel);
+            }
+        }
+        return KogitoChannel.DEFAULT;
+    }
+
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/interop/EditorContextWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/interop/EditorContextWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/interop/EditorContextWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/context/interop/EditorContextWrapper.java
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-package org.appformer.kogito.bridge.client.resource.interop;
+package org.appformer.kogito.bridge.client.context.interop;
 
-import jsinterop.annotations.JsOverlay;
-import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
-@JsType(isNative = true, name = "window", namespace = JsPackage.GLOBAL)
-public class Envelope {
+/**
+ * 
+ * Provide access to the editorContext object 
+ * 
+ */
+@JsType(isNative = true, namespace = "window", name = "envelope")
+public class EditorContextWrapper {
 
-    @JsProperty(name = "envelope")
-    private static native Envelope get();
+    @JsProperty
+    public native String getChannel();
 
-    @JsOverlay
-    public static boolean isAvailable() {
-        return get() != null;
-    }
+    @JsProperty(name = "editorContext")
+    public static native EditorContextWrapper get();
 
 }

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/interop/Envelope.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/interop/Envelope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.interop;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, name = "window", namespace = JsPackage.GLOBAL)
+public class Envelope {
+
+    @JsProperty(name = "envelope")
+    private static native Envelope get();
+
+    @JsOverlay
+    public static boolean isAvailable() {
+        return get() != null;
+    }
+
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/interop/WindowRef.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/interop/WindowRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/interop/WindowRef.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/interop/WindowRef.java
@@ -22,14 +22,14 @@ import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, name = "window", namespace = JsPackage.GLOBAL)
-public class Envelope {
+public class WindowRef {
 
     @JsProperty(name = "envelope")
-    private static native Envelope get();
+    private static native WindowRef getEnvelope();
 
     @JsOverlay
-    public static boolean isAvailable() {
-        return get() != null;
+    public static boolean isEnvelopeAvailable() {
+        return getEnvelope() != null;
     }
 
 }

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/ResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/ResourceContentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/EnvelopeResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/EnvelopeResourceContentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/NoOpResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/NoOpResourceContentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentEditorServiceWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentEditorServiceWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/producer/ResourceContentServiceProducer.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/producer/ResourceContentServiceProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/producer/ResourceContentServiceProducer.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/producer/ResourceContentServiceProducer.java
@@ -20,7 +20,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
 import elemental2.dom.DomGlobal;
-import org.appformer.kogito.bridge.client.interop.Envelope;
+import org.appformer.kogito.bridge.client.interop.WindowRef;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
 import org.appformer.kogito.bridge.client.resource.impl.EnvelopeResourceContentService;
 import org.appformer.kogito.bridge.client.resource.impl.NoOpResourceContentService;
@@ -34,7 +34,7 @@ public class ResourceContentServiceProducer {
     @Produces
     @ApplicationScoped
     public ResourceContentService produce() {
-        if (Envelope.isAvailable()) {
+        if (WindowRef.isEnvelopeAvailable()) {
             return new EnvelopeResourceContentService();
         }
         DomGlobal.console.info("[ResourceContentServiceProducer] Envelope API is not available. Producing NoOpResourceContentService");

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/producer/ResourceContentServiceProducer.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/producer/ResourceContentServiceProducer.java
@@ -20,10 +20,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
 import elemental2.dom.DomGlobal;
+import org.appformer.kogito.bridge.client.interop.Envelope;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
-import org.appformer.kogito.bridge.client.resource.impl.NoOpResourceContentService;
 import org.appformer.kogito.bridge.client.resource.impl.EnvelopeResourceContentService;
-import org.appformer.kogito.bridge.client.resource.interop.Envelope;
+import org.appformer.kogito.bridge.client.resource.impl.NoOpResourceContentService;
 
 /**
  * Produces {@link ResourceContentService} beans according to whether the envelope API is available or not

--- a/appformer-kogito-bridge/src/main/resources/META-INF/ErraiApp.properties
+++ b/appformer-kogito-bridge/src/main/resources/META-INF/ErraiApp.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Red Hat, Inc. and/or its affiliates.
+# Copyright 2020 Red Hat, Inc. and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/main/resources/org/appformer/kogito/bridge/AppformerKogitoBridge.gwt.xml
+++ b/appformer-kogito-bridge/src/main/resources/org/appformer/kogito/bridge/AppformerKogitoBridge.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2019 Red Hat, Inc. and/or its affiliates.
+  ~ Copyright 2020 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/KogitoChannelTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/KogitoChannelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/KogitoChannelTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/KogitoChannelTest.java
@@ -16,19 +16,20 @@
 
 package org.appformer.kogito.bridge.client.context;
 
-/**
- * 
- * Provide access to EditorContext properties
- *
- */
-public interface EditorContextProvider {
+import org.junit.Test;
 
-    /**
-     * Access the channel where the editor is running (e.g. ONLINE, GITHUB or VSCODE).
-     * 
-     * @return
-     * The channel where the editor is running or an empty optional if no channel is available.
-     */
-    KogitoChannel getChannel();
+import static org.junit.Assert.assertEquals;
+
+public class KogitoChannelTest {
+
+    @Test
+    public void withNameTest() {
+        assertEquals(KogitoChannel.GITHUB, KogitoChannel.withName("GitHub"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void withWrongNameTest() {
+        KogitoChannel.withName("foo");
+    }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
@@ -30,9 +30,9 @@ public interface WorkbenchClientEditorActivity extends WorkbenchActivity {
      *  Set the editor content
      *  
      * @param path
-     * Content Path 
+     *  Content Relative Path
      * @param value
-     * The editor content
+     *  The editor content
      */
     void setContent(String path, String value);
 

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
@@ -26,11 +26,15 @@ import org.uberfire.workbench.model.ActivityResourceType;
 public interface WorkbenchClientEditorActivity extends WorkbenchActivity {
 
     /**
-     * Set the editor content
+     *  
+     *  Set the editor content
+     *  
+     * @param path
+     * Content Path 
      * @param value
-     *  The the editor content
+     * The editor content
      */
-    void setContent(String value);
+    void setContent(String path, String value);
 
     /**
      * Get the editor content

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
@@ -48,8 +48,8 @@ public class GWTEditorNativeRegister {
             this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::onOpen()();
         };
 
-        $wnd.GWTEditor.prototype.setContent = function (value) {
-            this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::setContent(Ljava/lang/String;)(value);
+        $wnd.GWTEditor.prototype.setContent = function (path, value) {
+            this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::setContent(Ljava/lang/String;Ljava/lang/String;)(path, value);
         };
 
         $wnd.GWTEditor.prototype.getContent = function () {

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
@@ -85,7 +85,7 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
                                  Kind.ERROR,
                                  Diagnostic.NOPOS,
                                  Diagnostic.NOPOS,
-                                 "org.uberfire.annotations.processors.WorkbenchClientEditorTest4Activity: The WorkbenchClientEditor must provide a @SetContent annotated method that has two java.lang.String as parameters.");
+                                 "org.uberfire.annotations.processors.WorkbenchClientEditorTest4Activity: The WorkbenchClientEditor must provide a @SetContent annotated method that has two java.lang.String (path and content) as parameters.");
         assertNull(result.getActualCode());
     }
     

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
@@ -85,7 +85,7 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
                                  Kind.ERROR,
                                  Diagnostic.NOPOS,
                                  Diagnostic.NOPOS,
-                                 "org.uberfire.annotations.processors.WorkbenchClientEditorTest4Activity: The WorkbenchClientEditor must provide a @SetContent annotated method that has a java.lang.String as parameter.");
+                                 "org.uberfire.annotations.processors.WorkbenchClientEditorTest4Activity: The WorkbenchClientEditor must provide a @SetContent annotated method that has two java.lang.String as parameters.");
         assertNull(result.getActualCode());
     }
     

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest5.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest5.java
@@ -16,7 +16,7 @@ public class WorkbenchClientEditorTest5 extends Widget {
     }
     
     @SetContent
-    public void setContent(String content) {
+    public void setContent(String path, String content) {
         
     }
 

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest6.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest6.java
@@ -19,7 +19,7 @@ public class WorkbenchClientEditorTest6 extends Widget {
     }
     
     @SetContent
-    public void setContent(String content) {
+    public void setContent(String path, String content) {
         
     }
     

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
@@ -63,8 +63,8 @@ public class WorkbenchClientEditorTest6Activity extends AbstractWorkbenchClientE
     }
 
     @Override
-    public void setContent(String value) {
-        realPresenter.setContent(value);
+    public void setContent(String path, String value) {
+        realPresenter.setContent(path, value);
     }
     @Override
     public Promise<String> getContent() {

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
@@ -210,7 +210,7 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
         }
         //Validate setContentMethodName
         if (setContentMethodName == null) {
-            throw new GenerationException("The WorkbenchClientEditor must provide a @SetContent annotated method that has a java.lang.String as parameter.",
+            throw new GenerationException("The WorkbenchClientEditor must provide a @SetContent annotated method that has two java.lang.String as parameters.",
                                           packageName + "." + className);
         }
         //Validate getContentMethodName

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
@@ -210,7 +210,7 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
         }
         //Validate setContentMethodName
         if (setContentMethodName == null) {
-            throw new GenerationException("The WorkbenchClientEditor must provide a @SetContent annotated method that has two java.lang.String as parameters.",
+            throw new GenerationException("org.uberfire.annotations.processors.WorkbenchClientEditorTest4Activity: The WorkbenchClientEditor must provide a @SetContent annotated method that has two java.lang.String (path and content) as parameters.",
                                           packageName + "." + className);
         }
         //Validate getContentMethodName

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
@@ -134,7 +134,7 @@ public class GeneratorUtils {
                 processingEnvironment,
                 APIModule.getSetContentClass(),
                 requiredReturnType,
-                new String[]{"java.lang.String"});
+                new String[]{"java.lang.String", "java.lang.String"});
     }
 
     public static ExecutableElement getGetContentMethodName(TypeElement classElement, ProcessingEnvironment processingEnvironment) {

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
@@ -193,8 +193,8 @@ public class ${className} extends AbstractWorkbenchClientEditorActivity {
     </#if>
     <#if setContentMethodName??>
     @Override
-    public void setContent(String value) {
-        realPresenter.${setContentMethodName}(value);
+    public void setContent(String path, String value) {
+        realPresenter.${setContentMethodName}(path, value);
     }
     </#if>
     <#if getContentMethodName??>


### PR DESCRIPTION
Add a new parameter to the editor `setContent` method and make sure it is generated correctly.

Also create a wrapper object for the context. Editors can now access the context by injecting  `EditorContextProvider`.

Part of an ensemble:

https://github.com/kiegroup/kogito-tooling/pull/47
https://github.com/kiegroup/kie-wb-common/pull/3099