### PR TITLE
AF-2397 :Deletion of group from Business Central UI does not remove group from the security-policy.properties file

### DIFF
--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/authz/AuthorizationPolicyStorage.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/authz/AuthorizationPolicyStorage.java
@@ -15,6 +15,7 @@
  */
 package org.uberfire.backend.authz;
 
+import org.jboss.errai.security.shared.api.Group;
 import org.uberfire.security.authz.AuthorizationPolicy;
 
 /**
@@ -34,4 +35,11 @@ public interface AuthorizationPolicyStorage {
      * @param policy The authorization policy to store
      */
     void savePolicy(AuthorizationPolicy policy);
+
+    /**
+     * Deletes the group from  {@link AuthorizationPolicy} instance stored in the backend
+     * @param policy The authorization policy to store
+     * @param group Group instance
+     */
+    void deletePolicyByGroup(Group group, AuthorizationPolicy policy);
 }

--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/authz/AuthorizationService.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/authz/AuthorizationService.java
@@ -16,6 +16,7 @@
 package org.uberfire.backend.authz;
 
 import org.jboss.errai.bus.server.annotations.Remote;
+import org.jboss.errai.security.shared.api.Group;
 import org.uberfire.security.authz.AuthorizationPolicy;
 
 /**
@@ -36,4 +37,11 @@ public interface AuthorizationService {
      * @param policy The authorization policy to store
      */
     void savePolicy(AuthorizationPolicy policy);
+
+    /**
+     * Deletes the group from {@link AuthorizationPolicy} instance stored in the backend
+     * @param policy The authorization policy to store
+     * @param group Group instance
+     */
+    void deletePolicyByGroup(Group group , AuthorizationPolicy policy);
 }

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/authz/AuthorizationPolicyMarshaller.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/authz/AuthorizationPolicyMarshaller.java
@@ -323,6 +323,39 @@ public class AuthorizationPolicyMarshaller {
         }
     }
 
+    public void remove(Group group, AuthorizationPolicy policy,
+                       Map out) {
+
+        write(policy, out);
+
+        for (Group subject : policy.getGroups()) {
+            if (group.getName().equals(subject.getName())) {
+                remove(subject,
+                       out);
+                remove(subject,
+                       policy.getPermissions(subject),
+                       out);
+            }
+        }
+    }
+
+    private void remove(Group group,
+                       Map out) {
+        String homePerspectiveKey = GROUP + "." + group.getName() + "." + HOME;
+        String priorityKey = GROUP + "." + group.getName() + "." + PRIORITY;
+        out.remove(priorityKey);
+        out.remove(homePerspectiveKey);
+    }
+
+    private void remove(Group group,
+                       PermissionCollection permissions,
+                       Map out) {
+        for (Permission p : permissions.collection()) {
+            String key = GROUP + "." + group.getName() + "." + PERMISSION + "." + p.getName();
+            out.remove(key);
+        }
+    }
+
     public Key parse(String key) {
         int _idx = 0;
         String _key = key.endsWith(".*") ? key.substring(0,

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthorizationServiceTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthorizationServiceTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.backend.server.authz;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.enterprise.event.Event;
+
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.GroupImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.authz.AuthorizationPolicyStorage;
+import org.uberfire.backend.events.AuthorizationPolicyDeployedEvent;
+import org.uberfire.backend.events.AuthorizationPolicySavedEvent;
+import org.uberfire.security.authz.AuthorizationPolicy;
+import org.uberfire.security.authz.PermissionManager;
+import org.uberfire.security.authz.PermissionTypeRegistry;
+import org.uberfire.security.impl.authz.DefaultPermissionManager;
+import org.uberfire.security.impl.authz.DefaultPermissionTypeRegistry;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuthorizationServiceTest {
+
+    AuthorizationServiceImpl authorizationService;
+
+    AuthorizationPolicyDeployer deployer;
+
+    @Mock
+    AuthorizationPolicyStorage storage;
+
+    @Mock
+    Event<AuthorizationPolicyDeployedEvent> event;
+
+    @Mock
+    Event<AuthorizationPolicySavedEvent> policySavedEvent;
+
+    PermissionManager permissionManager;
+
+    private static final String path = "WEB-INF/classes/security-policy.properties";
+
+    @Before
+    public void setUp(){
+        PermissionTypeRegistry permissionTypeRegistry = new DefaultPermissionTypeRegistry();
+        permissionManager = spy(new DefaultPermissionManager(permissionTypeRegistry));
+        deployer = new AuthorizationPolicyDeployer(storage, permissionManager, event);
+        authorizationService = new AuthorizationServiceImpl(storage, permissionManager, policySavedEvent);
+    }
+
+    @Test
+    public void testPolicyLoad() throws Exception {
+        getPolicyFromPath(path);
+    }
+
+    @Test
+    public void testPolicySave() throws Exception {
+        Path policyDir = getPolicyFromPath(path);
+        deployer.deployPolicy(policyDir);
+
+        ArgumentCaptor<AuthorizationPolicy> policyCaptor = ArgumentCaptor.forClass(AuthorizationPolicy.class);
+        verify(storage).loadPolicy();
+        verify(storage).savePolicy(policyCaptor.capture());
+        AuthorizationPolicy ap = policyCaptor.getValue();
+
+        authorizationService.savePolicy(ap);
+        verify(permissionManager, times(2)).setAuthorizationPolicy(ap);
+        verify(policySavedEvent).fire(any());
+    }
+
+    @Test
+    public void testPolicyDelete() throws Exception {
+        Path policyDir = getPolicyFromPath(path);
+        deployer.deployPolicy(policyDir);
+
+        ArgumentCaptor<AuthorizationPolicy> policyCaptor = ArgumentCaptor.forClass(AuthorizationPolicy.class);
+        verify(storage).loadPolicy();
+        verify(storage).savePolicy(policyCaptor.capture());
+
+        AuthorizationPolicy ap = policyCaptor.getValue();
+        Group group = new GroupImpl("group1");
+        authorizationService.deletePolicyByGroup(group, ap);
+        verify(storage).deletePolicyByGroup(group, ap);
+        verify(permissionManager, times(2)).setAuthorizationPolicy(any());
+        verify(policySavedEvent, times(1)).fire(any());
+    }
+
+    private Path getPolicyFromPath(String path) throws Exception {
+        URL fileURL = Thread.currentThread().getContextClassLoader().getResource(path);
+        Path policyDir = Paths.get(fileURL.toURI()).getParent();
+        assertNotNull(policyDir);
+        return policyDir;
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthzPolicyMarshallerTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/authz/AuthzPolicyMarshallerTest.java
@@ -26,6 +26,8 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.GroupImpl;
 import org.jboss.errai.security.shared.api.Role;
 import org.jboss.errai.security.shared.api.RoleImpl;
 import org.jboss.errai.security.shared.api.identity.User;
@@ -42,8 +44,13 @@ import org.uberfire.security.impl.authz.DefaultPermissionManager;
 import org.uberfire.security.impl.authz.DefaultPermissionTypeRegistry;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AuthzPolicyMarshallerTest {
 
@@ -385,5 +392,30 @@ public class AuthzPolicyMarshallerTest {
                      "false");
         assertEquals(output.get("default.permission.p2"),
                      "true");
+    }
+
+    @Test
+    public void testPolicyRemove() {
+        builder.group("group2").priority(3).home("B")
+                .permission("p1",
+                            false)
+                .permission("p2",
+                            true);
+
+        AuthorizationPolicy policy = builder.build();
+        TreeMap<String, String> output = new TreeMap<>();
+        marshaller.write(policy,
+                         output);
+        Group g = new GroupImpl("group2");
+        assertEquals("B", output.get("group.group2.home"));
+        assertEquals("3", output.get("group.group2.priority"));
+        assertEquals("false", output.get("group.group2.permission.p1"));
+        assertEquals("true", output.get("group.group2.permission.p2"));
+        marshaller.remove(g, policy, output);
+
+        assertEquals(null, output.get("group.group2.home"));
+        assertEquals(null, output.get("group.group2.priority"));
+        assertEquals(null, output.get("group.group2.permission.p1"));
+        assertEquals(null, output.get("group.group2.permission.p2"));
     }
 }

--- a/uberfire-backend/uberfire-backend-server/src/test/resources/WEB-INF/classes/security-policy.properties
+++ b/uberfire-backend/uberfire-backend-server/src/test/resources/WEB-INF/classes/security-policy.properties
@@ -29,3 +29,9 @@ role.manager.priority=3
 role.manager.permission.perspective.read.*=true
 role.manager.permission.filesystem.system.master.*=false
 role.manager.permission.repository.read.git://repo1=true
+
+# Group "group1"
+group.group1.description=group1desc
+group.group1.home=Home
+group.group1.priority=3
+group.group1.permission.perspective.read.*=true

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflowTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflowTest.java
@@ -40,6 +40,7 @@ import org.uberfire.ext.security.management.client.widgets.management.events.OnE
 import org.uberfire.ext.security.management.client.widgets.management.events.SaveGroupEvent;
 import org.uberfire.ext.security.management.client.widgets.popup.ConfirmBox;
 import org.uberfire.ext.security.management.client.widgets.popup.LoadingBox;
+import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.mvp.Command;
 import org.uberfire.security.authz.PermissionCollection;
@@ -59,7 +60,9 @@ import static org.mockito.Mockito.*;
 public class GroupEditorWorkflowTest extends AbstractSecurityManagementTest {
 
     @Mock
-    Caller<AuthorizationService> authorizationService;
+    AuthorizationService authorizationService;
+    Caller<AuthorizationService> authorizationServiceCaller;
+
     @Mock
     EventSourceMock<OnErrorEvent> errorEvent;
     @Mock
@@ -108,9 +111,9 @@ public class GroupEditorWorkflowTest extends AbstractSecurityManagementTest {
         when(view.setSaveButtonText(anyString())).thenReturn(view);
         when(view.showNotification(anyString())).thenReturn(view);
         when(groupsManagerService.get(anyString())).thenReturn(group);
-
+        authorizationServiceCaller = new CallerMock<>(authorizationService);
         tested = spy(new GroupEditorWorkflow(userSystemManager,
-                                             authorizationService,
+                                             authorizationServiceCaller,
                                              permissionManager,
                                              errorEvent,
                                              confirmBox,
@@ -178,7 +181,7 @@ public class GroupEditorWorkflowTest extends AbstractSecurityManagementTest {
     }
 
     @Test
-    public void testOnDeleteUserEvent() {
+    public void testOnDeleteGroupEvent() {
         final OnDeleteEvent onDeleteEvent = mock(OnDeleteEvent.class);
         when(onDeleteEvent.getContext()).thenReturn(groupEditor);
         doAnswer(new Answer<Void>() {

--- a/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/auth/ShadowedAuthorizationService.java
+++ b/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/auth/ShadowedAuthorizationService.java
@@ -18,6 +18,7 @@ package org.uberfire.client.auth;
 import javax.inject.Singleton;
 
 import org.jboss.errai.bus.server.annotations.ShadowService;
+import org.jboss.errai.security.shared.api.Group;
 import org.uberfire.backend.authz.AuthorizationService;
 import org.uberfire.security.authz.AuthorizationPolicy;
 import org.uberfire.security.impl.authz.DefaultAuthorizationPolicy;
@@ -39,6 +40,11 @@ public class ShadowedAuthorizationService implements AuthorizationService {
 
     @Override
     public void savePolicy(AuthorizationPolicy policy) {
+        this.policy = policy;
+    }
+
+    @Override
+    public void deletePolicyByGroup(Group group , AuthorizationPolicy policy) {
         this.policy = policy;
     }
 }


### PR DESCRIPTION
-  Added feature to remove a specific group from security-policy.properties
-  If the user adds a group with the same name as deleted group, default configurations will be applied to the newly added group.