### PR TITLE
DROOLS-4585: Focus doesn't moves after the selected header cell

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
@@ -104,7 +104,7 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
         return renderingInformation != null;
     }
 
-    private boolean isGridColumnCandidateForScroll(final GridWidget gridWidget, boolean isHeaderCellSelected) {
+    private boolean isGridColumnCandidateForScroll(final GridWidget gridWidget, final boolean isHeaderCellSelected) {
         final GridData gridModel = gridWidget.getModel();
         final BaseGridRendererHelper rendererHelper = gridWidget.getRendererHelper();
         final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
@@ -152,9 +152,13 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
 
         double dy = 0;
         final Bounds bounds = gridLayer.getVisibleBounds();
-        final double rowHeight = gridModel.getRow(uiRowIndex).getHeight();
-        final double headerHeight = gridWidget.getRenderer().getHeaderHeight();
-        final double gridCellY = gridWidget.getY() + headerHeight + gridWidget.getRendererHelper().getRowOffset(uiRowIndex);
+        final double rowHeight = isHeaderCellSelected ? gridWidget.getRenderer().getHeaderRowHeight() :
+                                                        gridModel.getRow(uiRowIndex).getHeight();
+        final double headerHeight = isHeaderCellSelected ? 0 :
+                                                           gridWidget.getRenderer().getHeaderHeight();
+        final double rowOffset = isHeaderCellSelected ? rowHeight * uiRowIndex:
+                                                        gridWidget.getRendererHelper().getRowOffset(uiRowIndex);
+        final double gridCellY = gridWidget.getY() + headerHeight + rowOffset;
 
         if (gridCellY + rowHeight >= bounds.getY() + bounds.getHeight()) {
             dy = bounds.getY() + bounds.getHeight() - gridCellY - rowHeight;
@@ -172,7 +176,7 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
      * @param isHeaderCellSelected
      * @return
      */
-    private GridData.SelectedCell getSelectedCellOrigin(GridData gridModel, boolean isHeaderCellSelected) {
+    private GridData.SelectedCell getSelectedCellOrigin(GridData gridModel, final boolean isHeaderCellSelected) {
         if (isHeaderCellSelected) {
             List<GridData.SelectedCell> selectedHeaderCells = gridModel.getSelectedHeaderCells();
             if (KEY_RIGHT == getKeyCode()) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
@@ -177,7 +177,7 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
      * @param isHeaderCellSelected
      * @return
      */
-    private GridData.SelectedCell getSelectedCellOrigin(GridData gridModel, final boolean isHeaderCellSelected) {
+    protected GridData.SelectedCell getSelectedCellOrigin(final GridData gridModel, final boolean isHeaderCellSelected) {
         if (isHeaderCellSelected) {
             List<GridData.SelectedCell> selectedHeaderCells = gridModel.getSelectedHeaderCells();
             if (KEY_RIGHT == getKeyCode()) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
@@ -113,7 +113,7 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
         }
 
         final List<GridColumn<?>> columns = gridModel.getColumns();
-        final GridData.SelectedCell origin = getSelectedCell(gridModel, isHeaderCellSelected);
+        final GridData.SelectedCell origin = getSelectedCellOrigin(gridModel, isHeaderCellSelected);
         final int uiColumnIndex = ColumnIndexUtilities.findUiColumnIndex(columns,
                                                                          origin.getColumnIndex());
 
@@ -127,7 +127,7 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
     private double getCellScrollDeltaX(final GridWidget gridWidget, final boolean isHeaderCellSelected) {
         final GridData gridModel = gridWidget.getModel();
         final List<GridColumn<?>> columns = gridModel.getColumns();
-        final GridData.SelectedCell origin = getSelectedCell(gridModel, isHeaderCellSelected);
+        final GridData.SelectedCell origin = getSelectedCellOrigin(gridModel, isHeaderCellSelected);
         final int uiColumnIndex = ColumnIndexUtilities.findUiColumnIndex(columns,
                                                                          origin.getColumnIndex());
 
@@ -147,7 +147,7 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
 
     private double getCellScrollDeltaY(final GridWidget gridWidget, final boolean isHeaderCellSelected) {
         final GridData gridModel = gridWidget.getModel();
-        final GridData.SelectedCell origin = getSelectedCell(gridModel, isHeaderCellSelected);
+        final GridData.SelectedCell origin = getSelectedCellOrigin(gridModel, isHeaderCellSelected);
         final int uiRowIndex = origin.getRowIndex();
 
         double dy = 0;
@@ -165,7 +165,14 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
         return dy;
     }
 
-    private GridData.SelectedCell getSelectedCell(GridData gridModel, boolean isHeaderCellSelected) {
+    /**
+     * It retrieves the selected cell in <code>GridData</code> model, which could be a <b>header</b> cell or a
+     * simple one.
+     * @param gridModel
+     * @param isHeaderCellSelected
+     * @return
+     */
+    private GridData.SelectedCell getSelectedCellOrigin(GridData gridModel, boolean isHeaderCellSelected) {
         if (isHeaderCellSelected) {
             List<GridData.SelectedCell> selectedHeaderCells = gridModel.getSelectedHeaderCells();
             if (KEY_RIGHT == getKeyCode()) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
@@ -169,8 +169,10 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
     }
 
     /**
-     * It retrieves the selected cell in <code>GridData</code> model, which could be a <b>header</b> cell or a
-     * simple one.
+     * It retrieves the selected cell in <code>GridData</code> model, which could be an <b>header</b> cell or a
+     * simple one. In case of an <b>header</b> cell, it manages a possible case where a cell is spanned over multiple
+     * columns: when pressing <code>KEY_RIGHT</code>, it selected the last cell of the selected header cells group in
+     * order to show all the spanned cell. The otherwise in all other cases
      * @param gridModel
      * @param isHeaderCellSelected
      * @return

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperation.java
@@ -152,18 +152,17 @@ public abstract class BaseKeyboardOperation implements KeyboardOperation {
 
         double dy = 0;
         final Bounds bounds = gridLayer.getVisibleBounds();
-        final double rowHeight = isHeaderCellSelected ? gridWidget.getRenderer().getHeaderRowHeight() :
-                                                        gridModel.getRow(uiRowIndex).getHeight();
-        final double headerHeight = isHeaderCellSelected ? 0 :
-                                                           gridWidget.getRenderer().getHeaderHeight();
-        final double rowOffset = isHeaderCellSelected ? rowHeight * uiRowIndex:
-                                                        gridWidget.getRendererHelper().getRowOffset(uiRowIndex);
-        final double gridCellY = gridWidget.getY() + headerHeight + rowOffset;
+        final int headerRowCount = gridModel.getHeaderRowCount();
+        final double headerHeight = gridWidget.getRenderer().getHeaderHeight();
+        final double rowHeight = isHeaderCellSelected ? gridWidget.getRenderer().getHeaderRowHeight() : gridModel.getRow(uiRowIndex).getHeight();
+        final double headerYOffset = isHeaderCellSelected ? headerHeight - headerRowCount * rowHeight : headerHeight;
+        final double rowOffset = isHeaderCellSelected ? rowHeight * uiRowIndex : gridWidget.getRendererHelper().getRowOffset(uiRowIndex);
+        final double gridCellY = gridWidget.getY() + headerYOffset + rowOffset;
 
         if (gridCellY + rowHeight >= bounds.getY() + bounds.getHeight()) {
             dy = bounds.getY() + bounds.getHeight() - gridCellY - rowHeight;
-        } else if (gridCellY <= bounds.getY() + headerHeight) {
-            dy = bounds.getY() + headerHeight - gridCellY;
+        } else if (gridCellY <= bounds.getY() + headerYOffset) {
+            dy = bounds.getY() + headerYOffset - gridCellY;
         }
 
         return dy;

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
@@ -80,6 +80,8 @@ public class BaseKeyboardOperationTest {
     @Mock
     private Viewport viewport;
 
+    private Transform transform;
+
     private BaseKeyboardOperation baseKeyboardOperationSpy;
     private int currentKeyCode = 0;
 
@@ -93,7 +95,8 @@ public class BaseKeyboardOperationTest {
         when(gridWidget.getRenderer()).thenReturn(gridRenderer);
         when(layer.getViewport()).thenReturn(viewport);
         when(layer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
-        when(viewport.getTransform()).thenReturn(new Transform());
+        transform = spy(new Transform());
+        when(viewport.getTransform()).thenReturn(transform);
 
         baseKeyboardOperationSpy = spy(new BaseKeyboardOperation(layer) {
             @Override
@@ -142,10 +145,12 @@ public class BaseKeyboardOperationTest {
     @Test
     public void scrollSelectedCellIntoView_HeaderSelected_WithDeltaXScroll() {
         when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(new GridData.SelectedCell(0,0)));
-        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(500, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(600, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
         assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
         verify(layer, times(1)).getViewport();
         verify(viewport, times(1)).getTransform();
+        verify(transform, times(1)).scale(1, 1);
+        verify(transform, times(1)).translate(600, 0);
     }
 
     @Test
@@ -157,6 +162,56 @@ public class BaseKeyboardOperationTest {
         assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
         verify(layer, times(1)).getViewport();
         verify(viewport, times(1)).getTransform();
+        verify(transform, times(1)).scale(1, 1);
+        verify(transform, times(1)).translate(500d, 0);
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_HeaderSelected_WithDeltaYScroll() {
+        when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(new GridData.SelectedCell(0,0)));
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(0, 250, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, times(1)).getViewport();
+        verify(viewport, times(1)).getTransform();
+        verify(transform, times(1)).scale(1, 1);
+        verify(transform, times(1)).translate(0, 250);
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_CellSelected_WithDeltaYScroll() {
+        when(gridData.getSelectedCellsOrigin()).thenReturn(new GridData.SelectedCell(0,0));
+        when(gridData.getRow(0)).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(30d);
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(0, 400, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, times(1)).getViewport();
+        verify(viewport, times(1)).getTransform();
+        verify(transform, times(1)).scale(1, 1);
+        verify(transform, times(1)).translate(0, 400);
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_HeaderSelected_WithDeltaXYScroll() {
+        when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(new GridData.SelectedCell(0,0)));
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(50, 75, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, times(1)).getViewport();
+        verify(viewport, times(1)).getTransform();
+        verify(transform, times(1)).scale(1, 1);
+        verify(transform, times(1)).translate(50, 75);
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_CellSelected_WithDeltaXYScroll() {
+        when(gridData.getSelectedCellsOrigin()).thenReturn(new GridData.SelectedCell(0,0));
+        when(gridData.getRow(0)).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(30d);
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(75, 100, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, times(1)).getViewport();
+        verify(viewport, times(1)).getTransform();
+        verify(transform, times(1)).scale(1, 1);
+        verify(transform, times(1)).translate(75, 100);
     }
 
     @Test

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
@@ -16,13 +16,12 @@
 
 package org.uberfire.ext.wires.core.grids.client.widget.grid.impl;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import javax.validation.constraints.NotNull;
-
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,6 +77,9 @@ public class BaseKeyboardOperationTest {
     @Mock
     private GridRenderer gridRenderer;
 
+    @Mock
+    private Viewport viewport;
+
     private BaseKeyboardOperation baseKeyboardOperationSpy;
     private int currentKeyCode = 0;
 
@@ -89,7 +91,9 @@ public class BaseKeyboardOperationTest {
         when(gridData.getColumns()).thenReturn(Collections.singletonList(gridColumn));
         when(gridColumn.getIndex()).thenReturn(0);
         when(gridWidget.getRenderer()).thenReturn(gridRenderer);
+        when(layer.getViewport()).thenReturn(viewport);
         when(layer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        when(viewport.getTransform()).thenReturn(new Transform());
 
         baseKeyboardOperationSpy = spy(new BaseKeyboardOperation(layer) {
             @Override
@@ -121,6 +125,8 @@ public class BaseKeyboardOperationTest {
     public void scrollSelectedCellIntoView_HeaderSelected() {
         when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(new GridData.SelectedCell(0,0)));
         assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, never()).getViewport();
+        verify(viewport, never()).getTransform();
     }
 
     @Test
@@ -129,6 +135,28 @@ public class BaseKeyboardOperationTest {
         when(gridData.getRow(0)).thenReturn(gridRow);
         when(gridRow.getHeight()).thenReturn(30d);
         assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, never()).getViewport();
+        verify(viewport, never()).getTransform();
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_HeaderSelected_WithDeltaXScroll() {
+        when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(new GridData.SelectedCell(0,0)));
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(500, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, times(1)).getViewport();
+        verify(viewport, times(1)).getTransform();
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_CellSelected_WithDeltaXScroll() {
+        when(gridData.getSelectedCellsOrigin()).thenReturn(new GridData.SelectedCell(0,0));
+        when(gridData.getRow(0)).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(30d);
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(500, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+        verify(layer, times(1)).getViewport();
+        verify(viewport, times(1)).getTransform();
     }
 
     @Test

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.grid.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
+import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.model.GridRow;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+import static com.google.gwt.event.dom.client.KeyCodes.KEY_LEFT;
+import static com.google.gwt.event.dom.client.KeyCodes.KEY_RIGHT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class BaseKeyboardOperationTest {
+
+    private static final double BOUNDS_WIDTH = 1000.0;
+    private static final double BOUNDS_HEIGHT = 1000.0;
+
+    @Mock
+    private DefaultGridLayer layer;
+
+    @Mock
+    private GridWidget gridWidget;
+
+    @Mock
+    private GridData gridData;
+
+    @Mock
+    private GridColumn gridColumn;
+
+    @Mock
+    private GridRow gridRow;
+
+    @Mock
+    private BaseGridRendererHelper baseGridRendererHelperMock;
+
+    @Mock
+    private BaseGridRendererHelper.RenderingInformation baseGridRendererInformationMock;
+
+    @Mock
+    private GridRenderer gridRenderer;
+
+    private BaseKeyboardOperation baseKeyboardOperationSpy;
+    private int currentKeyCode = 0;
+
+    @Before
+    public void setup() {
+        when(gridWidget.getModel()).thenReturn(gridData);
+        when(gridWidget.getRendererHelper()).thenReturn(baseGridRendererHelperMock);
+        when(baseGridRendererHelperMock.getRenderingInformation()).thenReturn(baseGridRendererInformationMock);
+        when(gridData.getColumns()).thenReturn(Collections.singletonList(gridColumn));
+        when(gridColumn.getIndex()).thenReturn(0);
+        when(gridWidget.getRenderer()).thenReturn(gridRenderer);
+        when(layer.getVisibleBounds()).thenReturn(new BaseBounds(0, 0, BOUNDS_WIDTH, BOUNDS_HEIGHT));
+
+        baseKeyboardOperationSpy = spy(new BaseKeyboardOperation(layer) {
+            @Override
+            public int getKeyCode() {
+                return currentKeyCode;
+            }
+
+            @Override
+            public TriStateBoolean isControlKeyDown() {
+                return super.isControlKeyDown();
+            }
+
+            @Override
+            public boolean perform(GridWidget gridWidget, boolean isShiftKeyDown, boolean isControlKeyDown) {
+                return false;
+            }
+        });
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_NoSelection() {
+        assertFalse(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_NoRenderedInformation() {
+        List<GridData.SelectedCell> selectedCells = Arrays.asList(new GridData.SelectedCell(0,0));
+        when(gridData.getSelectedHeaderCells()).thenReturn(selectedCells);
+        when(baseGridRendererHelperMock.getRenderingInformation()).thenReturn(null);
+        assertFalse(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_HeaderSelected() {
+        when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(new GridData.SelectedCell(0,0)));
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+    }
+
+    @Test
+    public void scrollSelectedCellIntoView_CellSelected() {
+        when(gridData.getSelectedCellsOrigin()).thenReturn(new GridData.SelectedCell(0,0));
+        when(gridData.getRow(0)).thenReturn(gridRow);
+        when(gridRow.getHeight()).thenReturn(30d);
+        assertTrue(baseKeyboardOperationSpy.scrollSelectedCellIntoView(gridWidget));
+    }
+
+    @Test
+    public void getSelectedCellOrigin_NotHeaderCell() {
+        when(gridData.getSelectedCellsOrigin()).thenReturn(new GridData.SelectedCell(0,0));
+        baseKeyboardOperationSpy.getSelectedCellOrigin(gridData, false);
+        verify(gridData, times(1)).getSelectedCellsOrigin();
+        verify(gridData, never()).getSelectedHeaderCells();
+
+    }
+
+    @Test
+    public void getSelectedCellOrigin_SingleHeaderCell_KeyRight() {
+        currentKeyCode = KEY_RIGHT;
+        GridData.SelectedCell headerCell = new GridData.SelectedCell(0, 0);
+        when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(headerCell));
+        assertEquals(headerCell, baseKeyboardOperationSpy.getSelectedCellOrigin(gridData, true));
+        verify(gridData, times(1)).getSelectedHeaderCells();
+        verify(gridData, never()).getSelectedCellsOrigin();
+    }
+
+    @Test
+    public void getSelectedCellOrigin_SingleHeaderCell_KeyLeft() {
+        currentKeyCode = KEY_LEFT;
+        GridData.SelectedCell headerCell = new GridData.SelectedCell(0, 0);
+        when(gridData.getSelectedHeaderCells()).thenReturn(Collections.singletonList(headerCell));
+        assertEquals(headerCell, baseKeyboardOperationSpy.getSelectedCellOrigin(gridData, true));
+        verify(gridData, times(1)).getSelectedHeaderCells();
+        verify(gridData, never()).getSelectedCellsOrigin();
+    }
+
+    @Test
+    public void getSelectedCellOrigin_MultipleHeaderCell_KeyRight() {
+        currentKeyCode = KEY_RIGHT;
+        GridData.SelectedCell headerCell = new GridData.SelectedCell(0, 0);
+        GridData.SelectedCell headerCell2 = new GridData.SelectedCell(0, 1);
+        when(gridData.getSelectedHeaderCells()).thenReturn(Arrays.asList(headerCell, headerCell2));
+        assertEquals(headerCell2, baseKeyboardOperationSpy.getSelectedCellOrigin(gridData, true));
+        verify(gridData, times(1)).getSelectedHeaderCells();
+        verify(gridData, never()).getSelectedCellsOrigin();
+    }
+
+    @Test
+    public void getSelectedCellOrigin_MultipleHeaderCell_KeyLeft() {
+        currentKeyCode = KEY_LEFT;
+        GridData.SelectedCell headerCell = new GridData.SelectedCell(0, 0);
+        GridData.SelectedCell headerCell2 = new GridData.SelectedCell(0, 1);
+        when(gridData.getSelectedHeaderCells()).thenReturn(Arrays.asList(headerCell, headerCell2));
+        assertEquals(headerCell, baseKeyboardOperationSpy.getSelectedCellOrigin(gridData, true));
+        verify(gridData, times(1)).getSelectedHeaderCells();
+        verify(gridData, never()).getSelectedCellsOrigin();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseKeyboardOperationTest.java
@@ -98,11 +98,6 @@ public class BaseKeyboardOperationTest {
             }
 
             @Override
-            public TriStateBoolean isControlKeyDown() {
-                return super.isControlKeyDown();
-            }
-
-            @Override
             public boolean perform(GridWidget gridWidget, boolean isShiftKeyDown, boolean isControlKeyDown) {
                 return false;
             }
@@ -142,7 +137,6 @@ public class BaseKeyboardOperationTest {
         baseKeyboardOperationSpy.getSelectedCellOrigin(gridData, false);
         verify(gridData, times(1)).getSelectedCellsOrigin();
         verify(gridData, never()).getSelectedHeaderCells();
-
     }
 
     @Test


### PR DESCRIPTION
@jomarko @dupliaka @danielezonca @manstis @danielzhe 

It seems the management of this case was not present. I just added this case i.e. the case where a HEADER cell is selected. To manage case where header cells are spanned over multiple column, It selects the last selected cell if pressed key is RIGHT, and the first one otherwise. 

https://issues.redhat.com/browse/DROOLS-4585