### PR TITLE
AF-2410: Added switch to disable Business Central Features

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/migration/DashbuilderDataMigration.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/migration/DashbuilderDataMigration.java
@@ -38,6 +38,7 @@ import org.uberfire.java.nio.file.FileVisitResult;
 import org.uberfire.java.nio.file.Files;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.SimpleFileVisitor;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 import org.uberfire.java.nio.fs.jgit.FileSystemLock;
 import org.uberfire.java.nio.fs.jgit.FileSystemLockManager;
@@ -80,12 +81,18 @@ public class DashbuilderDataMigration {
     }
 
     @PostConstruct
-    private void init() {
+    protected void init() {
+        if (this.isMigrationEnabled()) {
             runWithLock(() -> {
                 migrateDatasets();
                 migratePerspectives();
                 migrateNavigation();
             });
+        }
+    }
+
+    protected boolean isMigrationEnabled() {
+        return FileSystemUtils.isGitDefaultFileSystem();
     }
 
     private void migrateDatasets() {
@@ -206,7 +213,7 @@ public class DashbuilderDataMigration {
         }
     }
 
-    private void runWithLock(Command command) {
+    protected void runWithLock(Command command) {
         String lockName = "data-migration.lock";
         String markerName = "data-migration.done";
 

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IndexerDispatcher.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IndexerDispatcher.java
@@ -48,6 +48,7 @@ import org.uberfire.ext.metadata.model.KObject;
 import org.uberfire.ext.metadata.model.KObjectKey;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
 
 import static java.lang.String.format;
 
@@ -94,6 +95,11 @@ public class IndexerDispatcher {
      *              is supported (see {@link Indexer#supportsPath(Path)}).
      */
     public void offer(IndexableIOEvent event) {
+
+        if (!FileSystemUtils.isGitDefaultFileSystem()) {
+            return;
+        }
+
         jobs.stream()
             .filter(job -> supportsUnderlyingPath(job.indexer, event))
             .forEach(job -> {

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -30,6 +30,6 @@
 # limitations under the License.
 #
 
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider
 org.uberfire.ext.metadata.io.common.util.TestFileSystemProvider # A mock provider for unit tests

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/main/java/org/uberfire/java/nio/file/api/FileSystemUtils.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/main/java/org/uberfire/java/nio/file/api/FileSystemUtils.java
@@ -23,6 +23,7 @@ import org.uberfire.java.nio.file.spi.FileSystemProvider;
 public class FileSystemUtils {
 
     public static final String CFG_KIE_CONTROLLER_OCP_ENABLED = "org.kie.server.controller.openshift.enabled";
+    public static final String SIMPLIFIED_MONITORING_ENABLED = "org.appformer.server.simplified.monitoring.enabled";
     public static final String K8S_FS_SCHEME = "k8s";
     private static final String GIT_FS_SCHEME = "git";
 
@@ -39,11 +40,15 @@ public class FileSystemUtils {
         return "true".equals(getConfigProps().getProperty(CFG_KIE_CONTROLLER_OCP_ENABLED, "false"));
     }
 
+    public static boolean isSimplifiedMonitoringEnabled() {
+        return "true".equals(getConfigProps().getProperty(SIMPLIFIED_MONITORING_ENABLED, "false"));
+    }
+
     public static boolean isGitDefaultFileSystem() {
         return FileSystemProviders.getDefaultProvider().getScheme().equals(GIT_FS_SCHEME);
     }
 
     public static boolean isK8SFileSystemProviderAsDefault(FileSystemProvider provider) {
-        return isOpenShiftSupported() && K8S_FS_SCHEME.equals(provider.getScheme());
+        return K8S_FS_SCHEME.equals(provider.getScheme()) && isOpenShiftSupported() && isSimplifiedMonitoringEnabled();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/FileSystemProvidersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/FileSystemProvidersTest.java
@@ -47,6 +47,7 @@ public class FileSystemProvidersTest {
 
     @Test
     public void k8sFileSystemProivdeAsDefaultTests() {
+        FileSystemUtils.getConfigProps().setProperty(FileSystemUtils.SIMPLIFIED_MONITORING_ENABLED, "true");
         FileSystemUtils.getConfigProps().setProperty(FileSystemUtils.CFG_KIE_CONTROLLER_OCP_ENABLED, "true");
         assertThat(FileSystemProviders.resolveProvider(URI.create("default:///"))).isInstanceOf(K8SFileSystemProvider.class);
         assertThat(FileSystemProviders.resolveProvider(URI.create("k8s:///"))).isInstanceOf(K8SFileSystemProvider.class);
@@ -54,5 +55,4 @@ public class FileSystemProvidersTest {
         assertThat(FileSystemProviders.getDefaultProvider()).isInstanceOf(K8SFileSystemProvider.class);
         assertThat(FileSystemProviders.installedProviders().get(0).isDefault()).isFalse();
     }
-
 }

--- a/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/migration/ACLMigrationTool.java
+++ b/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/migration/ACLMigrationTool.java
@@ -18,6 +18,7 @@ package org.guvnor.common.services.backend.migration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -33,6 +34,7 @@ import org.jboss.errai.security.shared.api.Group;
 import org.jboss.errai.security.shared.api.GroupImpl;
 import org.uberfire.backend.authz.AuthorizationPolicyStorage;
 import org.uberfire.backend.events.AuthorizationPolicyDeployedEvent;
+import org.uberfire.java.nio.file.api.FileSystemUtils;
 import org.uberfire.security.authz.AuthorizationPolicy;
 import org.uberfire.security.authz.Permission;
 import org.uberfire.security.authz.PermissionCollection;
@@ -74,10 +76,19 @@ public class ACLMigrationTool {
     }
 
     public void onDeploy(@Observes AuthorizationPolicyDeployedEvent event) {
+
+        if (!this.isACLMigrationToolEnabled()) {
+            return;
+        }
+
         AuthorizationPolicy policy = event.getPolicy();
         migrateOrgUnits(policy);
         migrateRepositories(policy);
         authorizationPolicyStorage.savePolicy(policy);
+    }
+
+    protected boolean isACLMigrationToolEnabled() {
+        return FileSystemUtils.isGitDefaultFileSystem();
     }
 
     private Group getGroup(String groupName) {

--- a/uberfire-services/uberfire-services-backend/src/test/java/org/guvnor/common/services/backend/migration/ACLMigrationToolTest.java
+++ b/uberfire-services/uberfire-services-backend/src/test/java/org/guvnor/common/services/backend/migration/ACLMigrationToolTest.java
@@ -44,8 +44,14 @@ import org.uberfire.security.authz.PermissionCollection;
 import org.uberfire.security.authz.PermissionManager;
 import org.uberfire.security.impl.authz.DefaultPermissionManager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ACLMigrationToolTest {
@@ -98,7 +104,7 @@ public class ACLMigrationToolTest {
 
         when(repo1.getIdentifier()).thenReturn("repo1");
         final Branch master = new Branch("master",
-                                   repo1root);
+                                         repo1root);
         when(repo1.getBranch("master")).thenReturn(Optional.of(master));
         when(repo1.getDefaultBranch()).thenReturn(Optional.of(master));
 
@@ -107,6 +113,8 @@ public class ACLMigrationToolTest {
         groupList.add("group1");
         groupList.add("group2");
         when(repo1.getGroups()).thenReturn(groupList);
+
+        when(migrationTool.isACLMigrationToolEnabled()).thenReturn(true);
     }
 
     @Test
@@ -141,5 +149,12 @@ public class ACLMigrationToolTest {
         assertNotNull(pc2);
         assertEquals(pc2.collection().size(),
                      1);
+    }
+
+    @Test
+    public void testMonitoringEnabled() {
+        when(migrationTool.isACLMigrationToolEnabled()).thenReturn(false);
+        migrationTool.onDeploy(new AuthorizationPolicyDeployedEvent(authorizationPolicy));
+        verify(migrationTool, never()).migrateOrgUnits(any());
     }
 }

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/LoadReposOnAppInit.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/LoadReposOnAppInit.java
@@ -16,6 +16,7 @@
 
 package org.guvnor.structure.backend.repositories;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -42,12 +43,14 @@ public class LoadReposOnAppInit {
 
         this.configuredRepositories = configuredRepositories;
         this.organizationalUnitService = organizationalUnitService;
-        this.execute();
     }
 
-    protected void execute() {
+    @PostConstruct
+    public void execute() {
         if (this.isGitDefaultFileSystem()) {
-            organizationalUnitService.getAllOrganizationalUnits().forEach(ou -> configuredRepositories.getAllConfiguredRepositories(ou.getSpace()));
+            organizationalUnitService
+                    .getAllOrganizationalUnits()
+                    .forEach(ou -> configuredRepositories.getAllConfiguredRepositories(ou.getSpace()));
         }
     }
 

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/FileSystemDeleteWorkerTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/FileSystemDeleteWorkerTest.java
@@ -30,7 +30,18 @@ import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.fs.jgit.JGitPathImpl;
 import org.uberfire.spaces.Space;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FileSystemDeleteWorkerTest {
@@ -187,5 +198,12 @@ public class FileSystemDeleteWorkerTest {
                times(1)).removeRepository(repo3);
         verify(worker,
                times(1)).removeRepository(repo4);
+    }
+
+    @Test
+    public void testMonitoringEnabled(){
+       when(worker.isDeleteWorkerEnabled()).thenReturn(false);
+        worker.doRemove();
+        verify(worker, never()).removeAllDeletedSpaces();
     }
 }

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/LoadReposOnAppInitTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/LoadReposOnAppInitTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.uberfire.java.nio.file.api.FileSystemUtils;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -59,9 +59,25 @@ public class LoadReposOnAppInitTest {
                                                                                  organizationalUnitService));
 
         doReturn(true).when(loadReposOnAppInit).isGitDefaultFileSystem();
-
         loadReposOnAppInit.execute();
-
         verify(configuredRepositories, times(1)).getAllConfiguredRepositories(any());
+    }
+
+    @Test
+    public void testOnlyRunInBCServerType() {
+        {
+            LoadReposOnAppInit loadReposOnInit = spy(new LoadReposOnAppInit(configuredRepositories,
+                                                                            organizationalUnitService));
+            doReturn(false).when(loadReposOnInit).isGitDefaultFileSystem();
+            loadReposOnInit.execute();
+            verify(organizationalUnitService, never()).getAllOrganizationalUnits();
+        }
+        {
+            LoadReposOnAppInit loadReposOnInit = spy(new LoadReposOnAppInit(configuredRepositories,
+                                                                            organizationalUnitService));
+            doReturn(true).when(loadReposOnInit).isGitDefaultFileSystem();
+            loadReposOnInit.execute();
+            verify(organizationalUnitService, times(1)).getAllOrganizationalUnits();
+        }
     }
 }


### PR DESCRIPTION
## Intention

* Disable JGit specific features when JGit is not the default FS
* Add a switch to choose between Monitoring and Simplified Monitoring

## Simplified Monitoring 
Simplified monitoring is the K8S FS based solution. This can't use JGit specific parts so they are disabled (Like _Pages_)

Possible values:
* -Dorg.appformer.server.simplified.monitoring.enabled=true/false

## Related PRs:
* https://github.com/kiegroup/appformer/pull/882
* https://github.com/kiegroup/kie-wb-common/pull/3128
* https://github.com/kiegroup/drools-wb/pull/1363
* https://github.com/kiegroup/jbpm-designer/pull/881