### PR TITLE
AF-903: Update authzPolicy reference when it is saved

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/acl/ACLSettings.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/acl/ACLSettings.java
@@ -18,12 +18,14 @@ package org.uberfire.ext.security.management.client.widgets.management.editor.ac
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.security.shared.api.Group;
 import org.jboss.errai.security.shared.api.Role;
+import org.uberfire.backend.events.AuthorizationPolicySavedEvent;
 import org.uberfire.client.authz.PerspectiveTreeProvider;
 import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.mvp.UberView;
@@ -45,6 +47,7 @@ public class ACLSettings implements IsWidget {
     Event<PriorityChangedEvent> priorityChangedEvent;
     AuthorizationPolicy authzPolicy;
     boolean isEditMode;
+
     @Inject
     public ACLSettings(View view,
                        PermissionManager permissionManager,
@@ -158,6 +161,10 @@ public class ACLSettings implements IsWidget {
         int priority = getPriority();
         priorityChangedEvent.fire(new PriorityChangedEvent(this,
                                                            priority));
+    }
+
+    public void updateAuthzPolicy(@Observes AuthorizationPolicySavedEvent authzPolicySavedEvent) {
+        this.authzPolicy = authzPolicySavedEvent.getPolicy();
     }
 
     public interface View extends UberView<ACLSettings> {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/acl/ACLSettingsTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/acl/ACLSettingsTest.java
@@ -25,11 +25,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.events.AuthorizationPolicySavedEvent;
 import org.uberfire.client.authz.PerspectiveTreeProvider;
 import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.ext.security.management.client.widgets.management.events.HomePerspectiveChangedEvent;
 import org.uberfire.ext.security.management.client.widgets.management.events.PriorityChangedEvent;
 import org.uberfire.ext.widgets.common.client.dropdown.PerspectiveDropDown;
+import org.uberfire.security.authz.AuthorizationPolicy;
 import org.uberfire.security.authz.PermissionManager;
 import org.uberfire.security.impl.authz.DefaultPermissionManager;
 import org.uberfire.security.impl.authz.DefaultPermissionTypeRegistry;
@@ -69,10 +71,9 @@ public class ACLSettingsTest {
         permissionManager = spy(new DefaultPermissionManager(new DefaultPermissionTypeRegistry()));
 
         permissionManager.setAuthorizationPolicy(permissionManager.newAuthorizationPolicy()
-                                                         .role("admin").home("HomeAdmin").priority(10)
-                                                         .group("group1").home("HomeGroup1").priority(DEFAULT_PRIORITY)
-                                                         .build()
-        );
+                                                                  .role("admin").home("HomeAdmin").priority(10)
+                                                                  .group("group1").home("HomeGroup1").priority(DEFAULT_PRIORITY)
+                                                                  .build());
 
         presenter = new ACLSettings(view,
                                     permissionManager,
@@ -177,5 +178,24 @@ public class ACLSettingsTest {
         presenter.onPrioritySelected();
 
         verify(priorityChangedEvent).fire(any());
+    }
+
+    @Test
+    public void testAuthorizationPolicyChange() {
+        
+        final int NEW_PRIORITY = 100;
+        final String NEW_PERSPECTIVE = "NewHomeAdmin";
+
+        final AuthorizationPolicy newPolicy = permissionManager.newAuthorizationPolicy()
+                                                               .role("admin").home(NEW_PERSPECTIVE).priority(NEW_PRIORITY)
+                                                               .group("group1").home("HomeGroup1").priority(DEFAULT_PRIORITY)
+                                                               .build();
+        
+        presenter.updateAuthzPolicy(new AuthorizationPolicySavedEvent(newPolicy));
+
+        presenter.edit(new RoleImpl("admin"));
+
+        verify(homePerspectiveDropDown).setSelectedPerspective(NEW_PERSPECTIVE);
+        verify(priorityDropDown).setSelectedPriority(NEW_PRIORITY);
     }
 }


### PR DESCRIPTION
The bug is caused because authzPolicy is retrieved only when the ACLSettings is created, after it is created the reference changes (with the new HomePage), but not updated on ACLSettings.

In this change we change the reference when it is updated.