### PR TITLE
KOGITO-862: Adding bridge to new resource content get method with Options

### DIFF
--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/ResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/ResourceContentService.java
@@ -17,6 +17,7 @@
 package org.appformer.kogito.bridge.client.resource;
 
 import elemental2.promise.Promise;
+import org.appformer.kogito.bridge.client.resource.interop.Options;
 
 /**
  * Service to access resources in the project or workspace where the editor is open
@@ -33,6 +34,18 @@ public interface ResourceContentService {
      * The resource content or null if the resource is not available
      */
     public Promise<String> get(String uri);
+
+    /**
+     * Returns a resource's content
+     * 
+     * @param uri
+     *  The resource URI relative to the workspace/project
+     * @param options
+     *  Options when retrieving the resource content
+     * @return
+     * The resource content or null if the resource is not available
+     */
+    public Promise<String> get(String uri, Options options);
 
     /**
      * List files from the project/workspace where the editor is running

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/ResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/ResourceContentService.java
@@ -17,7 +17,7 @@
 package org.appformer.kogito.bridge.client.resource;
 
 import elemental2.promise.Promise;
-import org.appformer.kogito.bridge.client.resource.interop.Options;
+import org.appformer.kogito.bridge.client.resource.interop.ResourceContentOptions;
 
 /**
  * Service to access resources in the project or workspace where the editor is open
@@ -45,7 +45,7 @@ public interface ResourceContentService {
      * @return
      * The resource content or null if the resource is not available
      */
-    public Promise<String> get(String uri, Options options);
+    public Promise<String> get(String uri, ResourceContentOptions options);
 
     /**
      * List files from the project/workspace where the editor is running

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/EnvelopeResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/EnvelopeResourceContentService.java
@@ -18,6 +18,7 @@ package org.appformer.kogito.bridge.client.resource.impl;
 
 import elemental2.promise.Promise;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
+import org.appformer.kogito.bridge.client.resource.interop.Options;
 import org.appformer.kogito.bridge.client.resource.interop.ResourceContentEditorServiceWrapper;
 
 /**
@@ -34,6 +35,11 @@ public class EnvelopeResourceContentService implements ResourceContentService {
     @Override
     public Promise<String[]> list(String pattern) {
         return ResourceContentEditorServiceWrapper.get().list(pattern);
+    }
+
+    @Override
+    public Promise<String> get(String uri, Options options) {
+        return ResourceContentEditorServiceWrapper.get().get(uri, options);
     }
 
 }

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/EnvelopeResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/EnvelopeResourceContentService.java
@@ -18,7 +18,7 @@ package org.appformer.kogito.bridge.client.resource.impl;
 
 import elemental2.promise.Promise;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
-import org.appformer.kogito.bridge.client.resource.interop.Options;
+import org.appformer.kogito.bridge.client.resource.interop.ResourceContentOptions;
 import org.appformer.kogito.bridge.client.resource.interop.ResourceContentEditorServiceWrapper;
 
 /**
@@ -38,7 +38,7 @@ public class EnvelopeResourceContentService implements ResourceContentService {
     }
 
     @Override
-    public Promise<String> get(String uri, Options options) {
+    public Promise<String> get(String uri, ResourceContentOptions options) {
         return ResourceContentEditorServiceWrapper.get().get(uri, options);
     }
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/NoOpResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/NoOpResourceContentService.java
@@ -18,6 +18,7 @@ package org.appformer.kogito.bridge.client.resource.impl;
 
 import elemental2.promise.Promise;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
+import org.appformer.kogito.bridge.client.resource.interop.Options;
 
 /**
  * This {@link ResourceContentService} implementation is used when the envelope API is not available
@@ -32,6 +33,11 @@ public class NoOpResourceContentService implements ResourceContentService {
     @Override
     public Promise<String[]> list(String pattern) {
         return Promise.resolve(new String[0]);
+    }
+
+    @Override
+    public Promise<String> get(String uri, Options options) {
+        return Promise.resolve("");
     }
 
 }

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/NoOpResourceContentService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/impl/NoOpResourceContentService.java
@@ -18,7 +18,7 @@ package org.appformer.kogito.bridge.client.resource.impl;
 
 import elemental2.promise.Promise;
 import org.appformer.kogito.bridge.client.resource.ResourceContentService;
-import org.appformer.kogito.bridge.client.resource.interop.Options;
+import org.appformer.kogito.bridge.client.resource.interop.ResourceContentOptions;
 
 /**
  * This {@link ResourceContentService} implementation is used when the envelope API is not available
@@ -36,7 +36,7 @@ public class NoOpResourceContentService implements ResourceContentService {
     }
 
     @Override
-    public Promise<String> get(String uri, Options options) {
+    public Promise<String> get(String uri, ResourceContentOptions options) {
         return Promise.resolve("");
     }
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/Options.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/Options.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.resource.interop;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class Options {
+
+    /**
+     * The a content type. When "text" the resource content is returned in text format. </br>
+     * When "binary" then the resource content is returned in a base64 encoded format.
+     * @param type
+     */
+    @JsProperty
+    native void setType(String type);
+
+    /**
+     * Creates an Options instance with binary type (base64 encoded binary content)
+     * 
+     * @return
+     * 
+     * Options with binary type (base64 encoded binary content)
+     */
+    @JsOverlay
+    public static Options binary() {
+        Options options = new Options();
+        options.setType("binary");
+        return options;
+    }
+
+    /**
+     * Creates an Options instance with text type
+     * 
+     * @return
+     * 
+     * Options with text type
+     */
+    @JsOverlay
+    public static Options text() {
+        Options options = new Options();
+        options.setType("text");
+        return options;
+    }
+
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentEditorServiceWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentEditorServiceWrapper.java
@@ -29,7 +29,7 @@ public class ResourceContentEditorServiceWrapper {
 
     public native Promise<String> get(String uri);
     
-    public native Promise<String> get(String uri, Options options);
+    public native Promise<String> get(String uri, ResourceContentOptions options);
 
     public native Promise<String[]> list(String pattern);
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentEditorServiceWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentEditorServiceWrapper.java
@@ -28,6 +28,8 @@ import jsinterop.annotations.JsType;
 public class ResourceContentEditorServiceWrapper {
 
     public native Promise<String> get(String uri);
+    
+    public native Promise<String> get(String uri, Options options);
 
     public native Promise<String[]> list(String pattern);
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentOptions.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/resource/interop/ResourceContentOptions.java
@@ -22,7 +22,7 @@ import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
-public class Options {
+public class ResourceContentOptions {
 
     /**
      * The a content type. When "text" the resource content is returned in text format. </br>
@@ -40,8 +40,8 @@ public class Options {
      * Options with binary type (base64 encoded binary content)
      */
     @JsOverlay
-    public static Options binary() {
-        Options options = new Options();
+    public static ResourceContentOptions binary() {
+        ResourceContentOptions options = new ResourceContentOptions();
         options.setType("binary");
         return options;
     }
@@ -54,8 +54,8 @@ public class Options {
      * Options with text type
      */
     @JsOverlay
-    public static Options text() {
-        Options options = new Options();
+    public static ResourceContentOptions text() {
+        ResourceContentOptions options = new ResourceContentOptions();
         options.setType("text");
         return options;
     }


### PR DESCRIPTION
Bridge GWT with the new ResourceContentService Options support. 

Right the only supported option is the content type, which can be `text`, the text representation of a content or `binary`, where the content binary is encoded in a base64 string. To retrieve binary content use:

~~~
resourceContentService.get("/path/to/resource", Options.binary());
~~~


Merge with: https://github.com/kiegroup/kogito-tooling/pull/60