### PR TITLE
KOGITO-936: Analyse why editor artefact had increased the size

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -514,7 +514,71 @@
                 <resource>
                   <directory>${project.build.directory}/monaco-editor/META-INF/resources/webjars/monaco-editor/${version.org.webjars.npm.monaco-editor}/</directory>
                   <includes>
-                    <include>**</include>
+                    <include>dev/vs/base/worker/workerMain.js</include>
+                    <include>dev/vs/basic-languages/_.contribution.js</include>
+                    <include>dev/vs/basic-languages/abap/abap.contribution.js</include>
+                    <include>dev/vs/basic-languages/apex/apex.contribution.js</include>
+                    <include>dev/vs/basic-languages/azcli/azcli.contribution.js</include>
+                    <include>dev/vs/basic-languages/bat/bat.contribution.js</include>
+                    <include>dev/vs/basic-languages/clojure/clojure.contribution.js</include>
+                    <include>dev/vs/basic-languages/coffee/coffee.contribution.js</include>
+                    <include>dev/vs/basic-languages/cpp/cpp.contribution.js</include>
+                    <include>dev/vs/basic-languages/csharp/csharp.contribution.js</include>
+                    <include>dev/vs/basic-languages/csp/csp.contribution.js</include>
+                    <include>dev/vs/basic-languages/css/css.contribution.js</include>
+                    <include>dev/vs/basic-languages/dockerfile/dockerfile.contribution.js</include>
+                    <include>dev/vs/basic-languages/fsharp/fsharp.contribution.js</include>
+                    <include>dev/vs/basic-languages/go/go.contribution.js</include>
+                    <include>dev/vs/basic-languages/graphql/graphql.contribution.js</include>
+                    <include>dev/vs/basic-languages/handlebars/handlebars.contribution.js</include>
+                    <include>dev/vs/basic-languages/html/html.contribution.js</include>
+                    <include>dev/vs/basic-languages/ini/ini.contribution.js</include>
+                    <include>dev/vs/basic-languages/java/java.contribution.js</include>
+                    <include>dev/vs/basic-languages/javascript/javascript.contribution.js</include>
+                    <include>dev/vs/basic-languages/kotlin/kotlin.contribution.js</include>
+                    <include>dev/vs/basic-languages/less/less.contribution.js</include>
+                    <include>dev/vs/basic-languages/lua/lua.contribution.js</include>
+                    <include>dev/vs/basic-languages/markdown/markdown.contribution.js</include>
+                    <include>dev/vs/basic-languages/mips/mips.contribution.js</include>
+                    <include>dev/vs/basic-languages/msdax/msdax.contribution.js</include>
+                    <include>dev/vs/basic-languages/mysql/mysql.contribution.js</include>
+                    <include>dev/vs/basic-languages/objective-c/objective-c.contribution.js</include>
+                    <include>dev/vs/basic-languages/pascal/pascal.contribution.js</include>
+                    <include>dev/vs/basic-languages/pascaligo/pascaligo.contribution.js</include>
+                    <include>dev/vs/basic-languages/perl/perl.contribution.js</include>
+                    <include>dev/vs/basic-languages/pgsql/pgsql.contribution.js</include>
+                    <include>dev/vs/basic-languages/php/php.contribution.js</include>
+                    <include>dev/vs/basic-languages/postiats/postiats.contribution.js</include>
+                    <include>dev/vs/basic-languages/powerquery/powerquery.contribution.js</include>
+                    <include>dev/vs/basic-languages/powershell/powershell.contribution.js</include>
+                    <include>dev/vs/basic-languages/pug/pug.contribution.js</include>
+                    <include>dev/vs/basic-languages/python/python.contribution.js</include>
+                    <include>dev/vs/basic-languages/r/r.contribution.js</include>
+                    <include>dev/vs/basic-languages/razor/razor.contribution.js</include>
+                    <include>dev/vs/basic-languages/redis/redis.contribution.js</include>
+                    <include>dev/vs/basic-languages/redshift/redshift.contribution.js</include>
+                    <include>dev/vs/basic-languages/ruby/ruby.contribution.js</include>
+                    <include>dev/vs/basic-languages/rust/rust.contribution.js</include>
+                    <include>dev/vs/basic-languages/sb/sb.contribution.js</include>
+                    <include>dev/vs/basic-languages/scheme/scheme.contribution.js</include>
+                    <include>dev/vs/basic-languages/scss/scss.contribution.js</include>
+                    <include>dev/vs/basic-languages/shell/shell.contribution.js</include>
+                    <include>dev/vs/basic-languages/solidity/solidity.contribution.js</include>
+                    <include>dev/vs/basic-languages/sophia/sophia.contribution.js</include>
+                    <include>dev/vs/basic-languages/sql/sql.contribution.js</include>
+                    <include>dev/vs/basic-languages/st/st.contribution.js</include>
+                    <include>dev/vs/basic-languages/swift/swift.contribution.js</include>
+                    <include>dev/vs/basic-languages/tcl/tcl.contribution.js</include>
+                    <include>dev/vs/basic-languages/twig/twig.contribution.js</include>
+                    <include>dev/vs/basic-languages/typescript/typescript.contribution.js</include>
+                    <include>dev/vs/basic-languages/vb/vb.contribution.js</include>
+                    <include>dev/vs/basic-languages/xml/xml.contribution.js</include>
+                    <include>dev/vs/basic-languages/yaml/yaml.contribution.js</include>
+                    <include>dev/vs/editor/editor.main.css</include>
+                    <include>dev/vs/editor/editor.main.js</include>
+                    <include>dev/vs/editor/editor.main.nls.js</include>
+                    <include>dev/vs/language/typescript/lib/typescriptServicesMetadata.js</include>
+                    <include>dev/vs/loader.js</include>
                   </includes>
                 </resource>
               </resources>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/PatternFly.gwt.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/PatternFly.gwt.xml
@@ -30,5 +30,5 @@
   <stylesheet src="bootstrap-select/css/bootstrap-select.min.css"/>
   <stylesheet src="prettify/bin/prettify.min.css"/>
   <stylesheet src="uberfire-patternfly.css" />
-  <stylesheet src="monaco-editor/min/vs/editor/editor.main.css"/>
+  <stylesheet src="monaco-editor/dev/vs/editor/editor.main.css"/>
 </module>


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-936

@ederign @manstis I've fixed the issue related to the assets size. However, we're still using the dev version. I've deployed a new Monaco version on [webjars.org](https://www.webjars.org) to check if the bug is fixed and if we could use the minified version, but we can't:

<img width="80%" alt="encoding-error" src="https://user-images.githubusercontent.com/1079279/74059365-a6434480-49c6-11ea-8941-5d23ad8e7742.png">

We have 3 options to handle this issue:
1. Setup an assets pipeline on BC
2. Use static files (instead of [webjars.org](https://www.webjars.org)'s)
3. Keep the dev version for now

Given the size we achieved, my proposal with this PR refers to the third option. But, please, let me know WDYT :-)

<img width="1489" alt="demo" src="https://user-images.githubusercontent.com/1079279/74059321-90ce1a80-49c6-11ea-8a45-3dab236e4d57.png">

---

PS.: There are some odd dependencies in the  `pom.xml` file. But, when we require `vs/editor/editor.main`, all these dependencies are required as well.

