### PR TITLE
KOGITO-866: Cover ONLINE, VSCODE, DEFAULT on Context Editor unit Testing

### DIFF
--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/KogitoChannelTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/KogitoChannelTest.java
@@ -25,6 +25,9 @@ public class KogitoChannelTest {
     @Test
     public void withNameTest() {
         assertEquals(KogitoChannel.GITHUB, KogitoChannel.withName("GitHub"));
+        assertEquals(KogitoChannel.DEFAULT, KogitoChannel.withName("dEfAuLt"));
+        assertEquals(KogitoChannel.ONLINE, KogitoChannel.withName("ONLine"));
+        assertEquals(KogitoChannel.VSCODE, KogitoChannel.withName("VSCode"));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Adding test coverage for all channels.