### PR TITLE
DROOLS-3276: [DMN Designer] All GRIDS: Add support for resizing columns using header

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDHandlersState.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDHandlersState.java
@@ -201,14 +201,16 @@ public class GridWidgetDnDHandlersState {
      * The different states of the drag operation.
      */
     public enum GridWidgetHandlersOperation {
-        NONE,
-        COLUMN_RESIZE_PENDING,
-        COLUMN_RESIZE,
-        COLUMN_MOVE_PENDING,
-        COLUMN_MOVE,
-        ROW_MOVE_PENDING,
-        ROW_MOVE,
-        GRID_MOVE_PENDING,
-        GRID_MOVE
+        NONE,                   // Nothing happening!
+        COLUMN_RESIZE_PENDING,  // The ability to resize a column has been detected.
+        COLUMN_RESIZE,          // A column is being resized
+        COLUMN_MOVE_PENDING,    // The ability to move a column has been detected.
+        COLUMN_MOVE_INITIATED,  // A column is able to move but has not _been_ moved to a new position.
+        COLUMN_MOVE,            // A column is able to move and had been moved to a new position.
+        ROW_MOVE_PENDING,       // The ability to move a row has been detected.
+        ROW_MOVE_INITIATED,     // A row is able to move but has not _been_ moved to a new position.
+        ROW_MOVE,               // A row is able to move and has been moved to a new position.
+        GRID_MOVE_PENDING,      // The ability to move a grid has been detected.
+        GRID_MOVE               // A grid has been moved.
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandler.java
@@ -74,10 +74,9 @@ public class GridWidgetDnDMouseDownHandler implements NodeMouseDownHandler {
                     return;
                 }
 
-                showColumnHighlight(state.getActiveGridWidget(),
-                                    state.getActiveGridColumns());
                 state.setEventInitialX(ap.getX());
-                state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.COLUMN_MOVE);
+                state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.COLUMN_MOVE_INITIATED);
+                showColumnHighlight(state.getActiveGridWidget(), state.getActiveGridColumns());
                 break;
 
             case ROW_MOVE_PENDING:
@@ -85,10 +84,9 @@ public class GridWidgetDnDMouseDownHandler implements NodeMouseDownHandler {
                     return;
                 }
 
-                showRowHighlight(state.getActiveGridWidget(),
-                                 state.getActiveGridRows());
                 state.setEventInitialX(ap.getX());
-                state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.ROW_MOVE);
+                state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.ROW_MOVE_INITIATED);
+                showRowHighlight(state.getActiveGridWidget(), state.getActiveGridRows());
                 break;
 
             case GRID_MOVE_PENDING:

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
@@ -68,11 +68,13 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
                 break;
 
             case COLUMN_MOVE:
+            case COLUMN_MOVE_INITIATED:
                 //If we're currently moving a column we don't need to find a column
                 handleColumnMove(event);
                 break;
 
             case ROW_MOVE:
+            case ROW_MOVE_INITIATED:
                 //If we're currently moving a row we don't need to find a row
                 handleRowMove(event);
                 break;
@@ -150,12 +152,12 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
                                 renderingInformation,
                                 cx,
                                 cy);
-
-                //Check for column resizing
-                findResizableColumn(gridWidget,
-                                    renderingInformation,
-                                    cx);
             }
+
+            //Check for column resizing
+            findResizableColumn(gridWidget,
+                                renderingInformation,
+                                cx);
 
             //If over Grid but no operation has been identified default to Grid dragging; when unpinned
             if (!layer.isGridPinned()) {
@@ -558,6 +560,7 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
                                     activeGridModel.moveColumnsTo(candidateBlockEndColumnIndex,
                                                                   activeGridColumns);
                                     state.getEventColumnHighlight().setX(activeGridWidget.getComputedLocation().getX() + rendererHelper.getColumnOffset(activeGridColumns.get(0)));
+                                    state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.COLUMN_MOVE);
                                     layer.batch();
                                     return;
                                 } else {
@@ -565,6 +568,7 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
                                     activeGridModel.moveColumnsTo(candidateBlockStartColumnIndex,
                                                                   activeGridColumns);
                                     state.getEventColumnHighlight().setX(activeGridWidget.getComputedLocation().getX() + rendererHelper.getColumnOffset(activeGridColumns.get(0)));
+                                    state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.COLUMN_MOVE);
                                     layer.batch();
                                     return;
                                 }
@@ -640,11 +644,11 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
 
         //Move row(s) and update highlight
         destroyColumns(allGridColumns);
-        activeGridModel.moveRowsTo(uiRowIndex,
-                                   activeGridRows);
+        activeGridModel.moveRowsTo(uiRowIndex, activeGridRows);
 
         final double rowOffsetY = rendererHelper.getRowOffset(leadRow) + headerHeight;
         state.getEventColumnHighlight().setY(activeGridWidget.getComputedLocation().getY() + rowOffsetY);
+        state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.ROW_MOVE);
         layer.batch();
     }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseUpHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseUpHandler.java
@@ -17,6 +17,8 @@ package org.uberfire.ext.wires.core.grids.client.widget.dnd;
 
 import com.ait.lienzo.client.core.event.NodeMouseUpEvent;
 import com.ait.lienzo.client.core.event.NodeMouseUpHandler;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.user.client.Command;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
 /**
@@ -43,15 +45,23 @@ public class GridWidgetDnDMouseUpHandler implements NodeMouseUpHandler {
             case COLUMN_RESIZE:
                 break;
             case COLUMN_MOVE:
+            case COLUMN_MOVE_INITIATED:
             case ROW_MOVE:
+            case ROW_MOVE_INITIATED:
                 //Clean-up the GridWidgetDnDProxy
                 layer.remove(state.getEventColumnHighlight());
                 layer.batch();
                 break;
         }
 
-        //Reset state
-        state.reset();
-        layer.getViewport().getElement().getStyle().setCursor(state.getCursor());
+        //Reset state. Defer until the next browser event loop iteration to enable ClickEvents to be processed.
+        scheduleDeferred(() -> {
+            state.reset();
+            layer.getViewport().getElement().getStyle().setCursor(state.getCursor());
+        });
+    }
+
+    void scheduleDeferred(final Command command) {
+        Scheduler.get().scheduleDeferred(command::execute);
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/NodeMouseEventHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/NodeMouseEventHandler.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 
 import com.ait.lienzo.client.core.event.AbstractNodeMouseEvent;
 import com.ait.lienzo.client.core.types.Point2D;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
 /**
  * Defines a generic handler for any type of {@link AbstractNodeMouseEvent}.
@@ -80,5 +82,29 @@ public interface NodeMouseEventHandler {
                                    final int uiColumnIndex,
                                    final AbstractNodeMouseEvent event) {
         return false;
+    }
+
+    /**
+     * Returns whether the {@link AbstractNodeMouseEvent} occurred during a Drag and Drop operation.
+     * @param gridWidget The {@link GridWidget} on which the event occurred.
+     * @return true if the event occurred during a Drag and Drop operation.
+     */
+    default boolean isDNDOperationInProgress(final GridWidget gridWidget) {
+        if (!(gridWidget.getLayer() instanceof GridLayer)) {
+            return false;
+        }
+        final GridLayer gridLayer = (GridLayer) gridWidget.getLayer();
+        final GridWidgetDnDHandlersState.GridWidgetHandlersOperation operation = gridLayer.getGridWidgetHandlersState().getOperation();
+        switch (operation) {
+            case NONE:
+            case COLUMN_RESIZE_PENDING:
+            case COLUMN_MOVE_PENDING:
+            case COLUMN_MOVE_INITIATED:
+            case ROW_MOVE_PENDING:
+            case ROW_MOVE_INITIATED:
+            case GRID_MOVE_PENDING:
+                return false;
+        }
+        return true;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCellSelectorMouseEventHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCellSelectorMouseEventHandler.java
@@ -42,6 +42,10 @@ public class DefaultGridWidgetCellSelectorMouseEventHandler implements NodeMouse
                                     final Optional<Integer> uiRowIndex,
                                     final Optional<Integer> uiColumnIndex,
                                     final AbstractNodeMouseEvent event) {
+        if (isDNDOperationInProgress(gridWidget)) {
+            return false;
+        }
+
         boolean isHandled = false;
         if (uiHeaderRowIndex.isPresent() && uiHeaderColumnIndex.isPresent()) {
             isHandled = handleHeaderCell(gridWidget,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCollapsedCellMouseEventHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCollapsedCellMouseEventHandler.java
@@ -52,6 +52,10 @@ public class DefaultGridWidgetCollapsedCellMouseEventHandler implements NodeMous
                                     final Optional<Integer> uiRowIndex,
                                     final Optional<Integer> uiColumnIndex,
                                     final AbstractNodeMouseEvent event) {
+        if (isDNDOperationInProgress(gridWidget)) {
+            return false;
+        }
+
         boolean isHandled = false;
         if (uiRowIndex.isPresent() && uiColumnIndex.isPresent()) {
             isHandled = handleBodyCell(gridWidget,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetEditCellMouseEventHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetEditCellMouseEventHandler.java
@@ -39,6 +39,10 @@ public class DefaultGridWidgetEditCellMouseEventHandler implements NodeMouseEven
                                     final Optional<Integer> uiRowIndex,
                                     final Optional<Integer> uiColumnIndex,
                                     final AbstractNodeMouseEvent event) {
+        if (isDNDOperationInProgress(gridWidget)) {
+            return false;
+        }
+
         boolean isHandled = false;
         if (uiHeaderRowIndex.isPresent() && uiHeaderColumnIndex.isPresent()) {
             isHandled = handleHeaderCell(gridWidget,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetLinkedColumnMouseEventHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetLinkedColumnMouseEventHandler.java
@@ -50,6 +50,10 @@ public class DefaultGridWidgetLinkedColumnMouseEventHandler implements NodeMouse
                                     final Optional<Integer> uiRowIndex,
                                     final Optional<Integer> uiColumnIndex,
                                     final AbstractNodeMouseEvent event) {
+        if (isDNDOperationInProgress(gridWidget)) {
+            return false;
+        }
+
         boolean isHandled = false;
         if (uiHeaderRowIndex.isPresent() && uiHeaderColumnIndex.isPresent()) {
             isHandled = handleHeaderCell(gridWidget,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetPinnedModeMouseEventHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetPinnedModeMouseEventHandler.java
@@ -51,6 +51,10 @@ public class DefaultGridWidgetPinnedModeMouseEventHandler implements NodeMouseEv
                                     final Optional<Integer> uiRowIndex,
                                     final Optional<Integer> uiColumnIndex,
                                     final AbstractNodeMouseEvent event) {
+        if (isDNDOperationInProgress(gridWidget)) {
+            return false;
+        }
+
         boolean isHandled = false;
         if (uiHeaderRowIndex.isPresent() && uiHeaderColumnIndex.isPresent()) {
             isHandled = handleHeaderCell(gridWidget,

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseDownHandlerTest.java
@@ -198,7 +198,7 @@ public class GridWidgetDnDMouseDownHandlerTest {
                times(1)).showColumnHighlight(eq(gridWidget),
                                              uiColumnsArgumentCaptor.capture());
         verify(state,
-               times(1)).setOperation(GridWidgetHandlersOperation.COLUMN_MOVE);
+               times(1)).setOperation(GridWidgetHandlersOperation.COLUMN_MOVE_INITIATED);
 
         final List<GridColumn<?>> uiColumns = uiColumnsArgumentCaptor.getValue();
         assertNotNull(uiColumns);
@@ -234,7 +234,7 @@ public class GridWidgetDnDMouseDownHandlerTest {
                times(1)).showRowHighlight(eq(gridWidget),
                                           uiRowsArgumentCaptor.capture());
         verify(state,
-               times(1)).setOperation(GridWidgetHandlersOperation.ROW_MOVE);
+               times(1)).setOperation(GridWidgetHandlersOperation.ROW_MOVE_INITIATED);
 
         final List<GridRow> uiRows = uiRowsArgumentCaptor.getValue();
         assertNotNull(uiRows);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseUpHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseUpHandlerTest.java
@@ -21,6 +21,7 @@ import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Command;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +30,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlers
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
 
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -68,6 +70,11 @@ public class GridWidgetDnDMouseUpHandlerTest {
         final GridWidgetDnDMouseUpHandler wrapped = new GridWidgetDnDMouseUpHandler(layer,
                                                                                     state);
         this.handler = spy(wrapped);
+
+        doAnswer(i -> {
+            ((Command) i.getArguments()[0]).execute();
+            return null;
+        }).when(handler).scheduleDeferred(any(Command.class));
     }
 
     @Test
@@ -127,6 +134,34 @@ public class GridWidgetDnDMouseUpHandlerTest {
     @Test
     public void stateIsResetOnMouseUpWhenStateIsRowMove() {
         state.setOperation(GridWidgetHandlersOperation.ROW_MOVE);
+
+        handler.onNodeMouseUp(event);
+
+        verify(state,
+               times(1)).reset();
+        verify(layer,
+               times(1)).remove(any(IPrimitive.class));
+        verify(layer,
+               times(1)).batch();
+    }
+
+    @Test
+    public void stateIsResetOnMouseUpWhenStateIsColumnMoveInitiated() {
+        state.setOperation(GridWidgetHandlersOperation.COLUMN_MOVE_INITIATED);
+
+        handler.onNodeMouseUp(event);
+
+        verify(state,
+               times(1)).reset();
+        verify(layer,
+               times(1)).remove(any(IPrimitive.class));
+        verify(layer,
+               times(1)).batch();
+    }
+
+    @Test
+    public void stateIsResetOnMouseUpWhenStateIsRowMoveInitiated() {
+        state.setOperation(GridWidgetHandlersOperation.ROW_MOVE_INITIATED);
 
         handler.onNodeMouseUp(event);
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/NodeMouseEventHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/NodeMouseEventHandlerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.wires.core.grids.client.widget.grid;
+
+import java.util.Optional;
+
+import com.ait.lienzo.client.core.event.AbstractNodeMouseEvent;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState.GridWidgetHandlersOperation;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class NodeMouseEventHandlerTest {
+
+    @Mock
+    private GridWidget gridWidget;
+
+    @Mock
+    private DefaultGridLayer gridLayer;
+
+    @Mock
+    private GridWidgetDnDHandlersState state;
+
+    @Mock
+    private Point2D relativeLocation;
+
+    @Mock
+    private AbstractNodeMouseEvent event;
+
+    private NodeMouseEventHandler handler;
+
+    @Before
+    public void setup() {
+        this.handler = (final GridWidget gridWidget,
+                        final Point2D relativeLocation,
+                        final Optional<Integer> uiHeaderRowIndex,
+                        final Optional<Integer> uiHeaderColumnIndex,
+                        final Optional<Integer> uiRowIndex,
+                        final Optional<Integer> uiColumnIndex,
+                        final AbstractNodeMouseEvent event) -> false;
+        when(gridWidget.getLayer()).thenReturn(gridLayer);
+        when(gridLayer.getGridWidgetHandlersState()).thenReturn(state);
+    }
+
+    @Test
+    public void testHandleHeaderCell() {
+        assertFalse(handler.handleHeaderCell(gridWidget, relativeLocation, 0, 0, event));
+    }
+
+    @Test
+    public void testHandleBodyCell() {
+        assertFalse(handler.handleBodyCell(gridWidget, relativeLocation, 0, 0, event));
+    }
+
+    @Test
+    public void testIsDNDOperationInProgress() {
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
+        assertFalse(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_RESIZE_PENDING);
+        assertFalse(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_RESIZE);
+        assertTrue(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_MOVE_PENDING);
+        assertFalse(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_MOVE_INITIATED);
+        assertFalse(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.COLUMN_MOVE);
+        assertTrue(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.ROW_MOVE_PENDING);
+        assertFalse(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.ROW_MOVE_INITIATED);
+        assertFalse(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.ROW_MOVE);
+        assertTrue(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.GRID_MOVE_PENDING);
+        assertFalse(handler.isDNDOperationInProgress(gridWidget));
+
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.GRID_MOVE);
+        assertTrue(handler.isDNDOperationInProgress(gridWidget));
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseClickHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseClickHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.NodeMouseEventHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
@@ -82,6 +83,9 @@ public abstract class BaseGridWidgetMouseClickHandlerTest {
     @Mock
     private NodeMouseEventHandler eventHandler;
 
+    @Mock
+    private GridWidgetDnDHandlersState state;
+
     private BaseGridWidgetMouseClickHandler mouseClickHandler;
 
     @Before
@@ -95,6 +99,9 @@ public abstract class BaseGridWidgetMouseClickHandlerTest {
         when(renderer.getHeaderHeight()).thenReturn(64.0);
         when(renderer.getHeaderRowHeight()).thenReturn(32.0);
         when(uiModel.getHeaderRowCount()).thenReturn(2);
+
+        when(state.getOperation()).thenReturn(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.NONE);
+        when(layer.getGridWidgetHandlersState()).thenReturn(state);
 
         final BaseGridRendererHelper.RenderingInformation ri = BaseGridWidgetRenderingTestUtils.makeRenderingInformation(uiModel, Collections.emptyList());
         when(helper.getRenderingInformation()).thenReturn(ri);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandlerTest.java
@@ -32,11 +32,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.model.GridColumn;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
+import org.uberfire.ext.wires.core.grids.client.widget.dnd.GridWidgetDnDHandlersState;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.NodeMouseEventHandler;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
-import org.uberfire.ext.wires.core.grids.client.widget.layer.GridSelectionManager;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
 
 import static org.mockito.Matchers.any;
@@ -57,9 +57,6 @@ public abstract class BaseGridWidgetMouseDoubleClickHandlerTest {
 
     @Mock
     protected DefaultGridLayer layer;
-
-    @Mock
-    protected GridSelectionManager selectionManager;
 
     @Mock
     protected GridData uiModel;
@@ -85,6 +82,9 @@ public abstract class BaseGridWidgetMouseDoubleClickHandlerTest {
     @Mock
     private NodeMouseEventHandler eventHandler;
 
+    @Mock
+    private GridWidgetDnDHandlersState state;
+
     protected NodeMouseDoubleClickEvent event;
 
     private BaseGridWidgetMouseDoubleClickHandler mouseDoubleClickHandler;
@@ -107,6 +107,9 @@ public abstract class BaseGridWidgetMouseDoubleClickHandlerTest {
         when(uiModel.getColumns()).thenReturn(new ArrayList<GridColumn<?>>() {{
             add(uiColumn);
         }});
+
+        when(state.getOperation()).thenReturn(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.NONE);
+        when(layer.getGridWidgetHandlersState()).thenReturn(state);
 
         final BaseGridRendererHelper.RenderingInformation ri = BaseGridWidgetRenderingTestUtils.makeRenderingInformation(uiModel, Collections.emptyList());
         when(helper.getRenderingInformation()).thenReturn(ri);

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCellSelectorMouseEventHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCellSelectorMouseEventHandlerTest.java
@@ -23,7 +23,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -101,5 +103,18 @@ public class DefaultGridWidgetCellSelectorMouseEventHandlerTest extends BaseGrid
                                     eq(false));
         verify(layer).batch();
         verify(selectionManager).select(eq(gridWidget));
+    }
+
+    @Test
+    public void checkOnNodeMouseEventDuringDragOperation() {
+        doReturn(true).when(handler).isDNDOperationInProgress(eq(gridWidget));
+
+        assertFalse(handler.onNodeMouseEvent(gridWidget,
+                                             relativeLocation,
+                                             Optional.empty(),
+                                             Optional.empty(),
+                                             Optional.of(0),
+                                             Optional.of(1),
+                                             event));
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCollapsedCellMouseEventHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetCollapsedCellMouseEventHandlerTest.java
@@ -29,11 +29,13 @@ import org.uberfire.ext.wires.core.grids.client.model.GridRow;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -211,5 +213,18 @@ public class DefaultGridWidgetCollapsedCellMouseEventHandlerTest extends BaseGri
                                    eq(0),
                                    eq(0),
                                    eq(2));
+    }
+
+    @Test
+    public void checkOnNodeMouseEventDuringDragOperation() {
+        doReturn(true).when(handler).isDNDOperationInProgress(eq(gridWidget));
+
+        assertFalse(handler.onNodeMouseEvent(gridWidget,
+                                             relativeLocation,
+                                             Optional.empty(),
+                                             Optional.empty(),
+                                             Optional.of(0),
+                                             Optional.of(1),
+                                             event));
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetEditCellMouseEventHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetEditCellMouseEventHandlerTest.java
@@ -30,9 +30,11 @@ import org.uberfire.ext.wires.core.grids.client.model.GridCellEditAction;
 import org.uberfire.ext.wires.core.grids.client.model.GridData;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -133,5 +135,18 @@ public class DefaultGridWidgetEditCellMouseEventHandlerTest extends BaseGridWidg
 
         verify(gridWidget, never()).startEditingCell(anyInt(), anyInt());
         verify(gridWidget, never()).startEditingCell(any(Point2D.class));
+    }
+
+    @Test
+    public void checkOnNodeMouseEventDuringDragOperation() {
+        doReturn(true).when(handler).isDNDOperationInProgress(eq(gridWidget));
+
+        assertFalse(handler.onNodeMouseEvent(gridWidget,
+                                             relativeLocation,
+                                             Optional.empty(),
+                                             Optional.empty(),
+                                             Optional.of(0),
+                                             Optional.of(1),
+                                             event));
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetLinkedColumnMouseEventHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetLinkedColumnMouseEventHandlerTest.java
@@ -25,7 +25,9 @@ import org.junit.runner.RunWith;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.impl.BaseGridRendererHelper;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -117,5 +119,18 @@ public class DefaultGridWidgetLinkedColumnMouseEventHandlerTest extends BaseGrid
                never()).select(any(GridWidget.class));
         verify(selectionManager,
                times(1)).selectLinkedColumn(eq(uiLinkedColumn));
+    }
+
+    @Test
+    public void checkOnNodeMouseEventDuringDragOperation() {
+        doReturn(true).when(handler).isDNDOperationInProgress(eq(gridWidget));
+
+        assertFalse(handler.onNodeMouseEvent(gridWidget,
+                                             relativeLocation,
+                                             Optional.empty(),
+                                             Optional.empty(),
+                                             Optional.of(0),
+                                             Optional.of(1),
+                                             event));
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetPinnedModeMouseEventHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/DefaultGridWidgetPinnedModeMouseEventHandlerTest.java
@@ -27,7 +27,9 @@ import org.mockito.Mock;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -113,5 +115,18 @@ public class DefaultGridWidgetPinnedModeMouseEventHandlerTest extends BaseGridWi
                                         any(Command.class));
         verify(pinnedModeManager,
                times(1)).exitPinnedMode(any(Command.class));
+    }
+
+    @Test
+    public void checkOnNodeMouseEventDuringDragOperation() {
+        doReturn(true).when(handler).isDNDOperationInProgress(eq(gridWidget));
+
+        assertFalse(handler.onNodeMouseEvent(gridWidget,
+                                             relativeLocation,
+                                             Optional.empty(),
+                                             Optional.empty(),
+                                             Optional.of(0),
+                                             Optional.of(1),
+                                             event));
     }
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/DROOLS-3276

This PR adds support for resizing columns in the header too (currently you can only resize columns in the body). It also improves use by not selecting the cell next to the pointer when resizing a column (currently after the column resize drag ends a cell is often selected next to the pointer).