### PR TITLE
AF-2424 :Issue with the group permissions for the Pages

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflow.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,6 @@
 
 package org.uberfire.ext.security.management.client.widgets.management.editor.group.workflow;
 
-import java.util.Collection;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
@@ -58,8 +57,6 @@ import org.uberfire.security.authz.AuthorizationResult;
 import org.uberfire.security.authz.Permission;
 import org.uberfire.security.authz.PermissionCollection;
 import org.uberfire.security.authz.PermissionManager;
-import org.uberfire.security.impl.authz.DefaultAuthorizationEntry;
-import org.uberfire.security.impl.authz.DotNamedPermission;
 import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.uberfire.workbench.events.NotificationEvent.NotificationType.INFO;
@@ -67,6 +64,7 @@ import static org.uberfire.workbench.events.NotificationEvent.NotificationType.S
 
 /**
  * <p>Main entry point for viewing a group instance.</p>
+ *
  * @since 0.8.0
  */
 @Dependent
@@ -174,7 +172,7 @@ public class GroupEditorWorkflow implements IsWidget {
                                  errorCallback).delete(name);
     }
 
-    protected void doDelete(){
+    protected void doDelete() {
         final String name = group.getName();
         AuthorizationPolicy authzPolicy = permissionManager.getAuthorizationPolicy();
         showLoadingBox();
@@ -264,17 +262,6 @@ public class GroupEditorWorkflow implements IsWidget {
         } else {
             throw new RuntimeException("Group must be valid before updating it.");
         }
-    }
-
-    private void grantHomePageAccess(@Observes CreateGroupEvent createGroupEvent) {
-        final String PERSPECTIVE = "perspective";
-        final String ACCESS = "read";
-        Group group = new GroupImpl(createGroupEvent.getName());
-        String permissionName = PERSPECTIVE + "." + ACCESS + "." + new DefaultAuthorizationEntry().getHomePerspective();
-        DotNamedPermission dotNamedPermission = new DotNamedPermission(permissionName, true);
-        AuthorizationPolicy authzPolicy = permissionManager.getAuthorizationPolicy();
-        authzPolicy.addPermission(group, dotNamedPermission);
-        authorizationService.call().savePolicy(authzPolicy);
     }
 
     protected void showNotification(String message) {

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationPolicy.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationPolicy.java
@@ -189,6 +189,11 @@ public interface AuthorizationPolicy {
      */
     PermissionCollection getPermissions();
 
+    /**
+     * Add a single permission entry for a group.
+     * @param group The group instance
+     * @param permission A permission instance
+     */
     void addPermission(Group group,
                        Permission permission);
 }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationPolicy.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationPolicy.java
@@ -188,4 +188,7 @@ public interface AuthorizationPolicy {
      * @return The permission collection
      */
     PermissionCollection getPermissions();
+
+    void addPermission(Group group,
+                       Permission permission);
 }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthorizationPolicy.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthorizationPolicy.java
@@ -160,6 +160,7 @@ public class DefaultAuthorizationPolicy implements AuthorizationPolicy {
         entry.getPermissions().add(permission);
     }
 
+    @Override
     public void addPermission(Group group,
                               Permission permission) {
         DefaultAuthorizationEntry entry = getAuthzEntry(group);


### PR DESCRIPTION
 - Added the grant permission for reading Home perpective when a new group is added.
 - An entry for new group will be made in security-properties.properties when a new group is created, earlier group entry was only made when that group is edited
![Peek 2020-02-14 15-23](https://user-images.githubusercontent.com/23648802/74520672-0cd3df80-4f3e-11ea-995e-5788fc60557c.gif)
