### PR TITLE
RHPAM-1954 :CVE in webjars used by business-central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,10 +54,10 @@
     <version.org.kie.soup>${version.org.kie}</version.org.kie.soup>
     <version.com.google.jsinterop.base>1.0.0-beta-1</version.com.google.jsinterop.base>
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
-    <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
+    <version.org.webjars.bower.org.patternfly>3.25.0</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.bower.google-code-prettify>1.0.4</version.org.webjars.bower.google-code-prettify>
-    <version.org.webjars.bower.bootstrap-select>1.10.0</version.org.webjars.bower.bootstrap-select>
-    <version.org.webjars.bower.moment>2.14.1</version.org.webjars.bower.moment>
+    <version.org.webjars.bower.bootstrap-select>1.13.11</version.org.webjars.bower.bootstrap-select>
+    <version.org.webjars.bower.moment>2.19.3</version.org.webjars.bower.moment>
     <version.org.webjars.bower.moment-timezone>0.5.17</version.org.webjars.bower.moment-timezone>
     <version.org.webjars.bower.bluebird>3.1.1</version.org.webjars.bower.bluebird>
     <version.org.webjars.npm.monaco-editor>0.18.1</version.org.webjars.npm.monaco-editor>


### PR DESCRIPTION
- Upgraded moment, patternfly and bootstrap-select to fix the vulnerabilities in BC
- Vulnerablities were found as per this report https://snyk.io/test/npm/patternfly/3.18.1.
- We are using moment and bootstrap-select independantly in BC (not coming from patternfly), so I also upgraded them to their non-vulnerable versions.

upgraded bootstrap select to 1.13.6 (https://snyk.io/vuln/SNYK-JS-BOOTSTRAPSELECT-173741)
upgraded moment to 2.19.3 (https://snyk.io/vuln/npm:moment:20161019)