### PR TITLE
Use revapi version from kie-parent

### DIFF
--- a/uberfire-rest/uberfire-rest-backend/pom.xml
+++ b/uberfire-rest/uberfire-rest-backend/pom.xml
@@ -120,7 +120,6 @@
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
-        <version>0.8.1</version>
       </plugin>
     </plugins>
   </build>

--- a/uberfire-rest/uberfire-rest-backend/src/build/revapi-config.json
+++ b/uberfire-rest/uberfire-rest-backend/src/build/revapi-config.json
@@ -17,7 +17,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.1.0.Final is available.",
+      "_comment": "Changes between 7.33.0.Final and the current branch. These changes are desired and thus ignored.",
       "ignore": []
     }
   }


### PR DESCRIPTION
@adrielparedes @ederign 

fixes https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1193

Sorry for the broken build. Here's the fix.

The issue was that some time ago guvnor was migrated to appformer/uberfire and at that time it was cut from kie-parent so revapi configuration was not inherited. Because of that, the revapi plugin was not turned on. But once the appformer [inherited from kie-parent](https://github.com/kiegroup/appformer/pull/718) it began to work, only this time it showed just warning saying:

```
[WARNING] Failed to resolve old artifacts:
Failure to find org.uberfire:uberfire-rest-backend:jar:7.26.0.Final in https://repository.jboss.org/nexus/content/groups/public/
was cached in the local repository, resolution will not be reattempted
until the update interval of jboss-public-repository-group has elapsed
or updates are forced. The API analysis will not proceed.
```

Simply because the uberfire-rest didn't have the `version.org.kie` versioning from the parent. However, with the [latest change](https://github.com/kiegroup/appformer/commit/21fb6f96ba9e4f89c5c7985f89d763b6fe873287#diff-f156f436c089dc9ce33fb4ac04397784) it started to have this versioning, so when I [raised the KIE version](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1190/files) to check against to 7.33.0.Final, it suddenly started to work, but with an outdated version of `0.8.1` which is presumably not compatible with the newer Maven, thus failing the build. Now it should be OK. I hope this explanation is enough.