### PR TITLE
KOGITO-1236: Adding GetPreview support on editor side

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/lifecycle/GetContent.java
+++ b/uberfire-api/src/main/java/org/uberfire/lifecycle/GetContent.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Use in method that returns a {@code @WorkbenchClientEditor} content. 
+ * Used in method that returns a {@code @WorkbenchClientEditor} content. 
  */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)

--- a/uberfire-api/src/main/java/org/uberfire/lifecycle/GetPreview.java
+++ b/uberfire-api/src/main/java/org/uberfire/lifecycle/GetPreview.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.lifecycle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Use in method that returns a {@code @WorkbenchClientEditor} content preview.
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface GetPreview {
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
@@ -42,6 +42,14 @@ public interface WorkbenchClientEditorActivity extends WorkbenchActivity {
      * @return
      */
     Promise<String> getContent();
+    
+    
+    /**
+     * Get the editor content preview in SVG format
+     * 
+     * @return
+     */
+    Promise<String> getPreview();
 
     boolean isDirty();
 

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
@@ -55,6 +55,10 @@ public class GWTEditorNativeRegister {
         $wnd.GWTEditor.prototype.getContent = function () {
             return this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::getContent()();
         };
+        
+        $wnd.GWTEditor.prototype.getPreview = function () {
+            return this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::getPreview()();
+        };        
 
         $wnd.GWTEditor.prototype.getView = function () {
             return this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::getWidgetElement()();

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
@@ -118,4 +118,19 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
         assertEquals(result.getExpectedCode(),
                      result.getActualCode());
     }
+    
+    @Test
+    public void testSuccessContentWithGetPreview() throws FileNotFoundException {
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                "org/uberfire/annotations/processors/WorkbenchClientEditorTest7");
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected";
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest7.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest7.java
@@ -1,0 +1,37 @@
+package org.uberfire.annotations.processors;
+
+import org.uberfire.client.annotations.WorkbenchClientEditor;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.lifecycle.GetContent;
+import org.uberfire.lifecycle.SetContent;
+import org.uberfire.lifecycle.GetPreview;
+
+import com.google.gwt.user.client.ui.Widget;
+
+import elemental2.promise.Promise;
+
+@WorkbenchClientEditor(identifier = "editor")
+public class WorkbenchClientEditorTest7 extends Widget {
+    
+    
+    @WorkbenchPartTitle
+    public String title() {
+        return "title";
+    }
+    
+    @SetContent
+    public void setContent(String path, String content) {
+        
+    }
+    
+    @GetContent
+    public Promise getContent() {
+        return null;
+    }
+    
+    @GetPreview
+    public Promise getPreview() {
+        return null;
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected
@@ -41,14 +41,14 @@ import com.google.gwt.user.client.ui.IsWidget;
 /*
  * WARNING! This class is generated. Do not modify.
  */
-public class WorkbenchClientEditorTest6Activity extends AbstractWorkbenchClientEditorActivity {
+public class WorkbenchClientEditorTest7Activity extends AbstractWorkbenchClientEditorActivity {
 
     @Inject
-    private WorkbenchClientEditorTest6 realPresenter;
+    private WorkbenchClientEditorTest7 realPresenter;
 
     @Inject
     //Constructor injection for testing
-    public WorkbenchClientEditorTest6Activity(final PlaceManager placeManager) {
+    public WorkbenchClientEditorTest7Activity(final PlaceManager placeManager) {
         super( placeManager );
     }
 
@@ -72,7 +72,7 @@ public class WorkbenchClientEditorTest6Activity extends AbstractWorkbenchClientE
     }
     @Override
     public Promise<String> getPreview() {
-        return null;
+        return realPresenter.getPreview();
     }
     @Override
     public String getIdentifier() {

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
@@ -119,7 +119,7 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
         final String getWidgetMethodName = getWidgetMethod == null ? null : getWidgetMethod.getSimpleName().toString();
 
         final boolean isWidgetMethodReturnTypeElement = getWidgetMethod != null && GeneratorUtils.getIsElement(getWidgetMethod.getReturnType(),
-                                                                                                                processingEnvironment);
+                                                                                                               processingEnvironment);
 
         final boolean hasUberView = GeneratorUtils.hasPresenterInitMethod(classElement, processingEnvironment, getWidgetMethod);
 
@@ -138,6 +138,10 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
                                                                                           processingEnvironment);
 
         final String getContentMethodName = getContentMethod == null ? null : getContentMethod.getSimpleName().toString();
+
+        final ExecutableElement getPreviewMethod = GeneratorUtils.getGetPreviewMethodName(classElement,
+                                                                                          processingEnvironment);
+        final String getPreviewMethodName = getPreviewMethod == null ? null : getPreviewMethod.getSimpleName().toString();
 
         final List<String> qualifiers = GeneratorUtils.getAllQualifiersDeclarationFromType(classElement);
 
@@ -185,6 +189,8 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
             messager.printMessage(Kind.NOTE,
                                   "getContentMethodName: " + getContentMethodName);
             messager.printMessage(Kind.NOTE,
+                                  "getPreviewMethodName: " + getPreviewMethodName);
+            messager.printMessage(Kind.NOTE,
                                   "isDirtyMethodName: " + isDirtyMethodName);
             messager.printMessage(Kind.NOTE,
                                   "Qualifiers: " + String.join(", ",
@@ -218,7 +224,6 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
             throw new GenerationException("The WorkbenchClientEditor must provide a @GetContent annotated method to return a elemental2.promise.Promise.",
                                           packageName + "." + className);
         }
-
 
         //Setup data for template sub-system
         Map<String, Object> root = new HashMap<String, Object>();
@@ -271,7 +276,8 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
                  setContentMethodName);
         root.put("getContentMethodName",
                  getContentMethodName);
-
+        root.put("getPreviewMethodName",
+                 getPreviewMethodName);
         root.put("isDynamic",
                  isDynamic);
         root.put("qualifiers",

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
@@ -146,6 +146,17 @@ public class GeneratorUtils {
                                         },
                                         NO_PARAMS);
     }
+    
+    
+    public static ExecutableElement getGetPreviewMethodName(TypeElement classElement, ProcessingEnvironment processingEnvironment) {
+        return getUniqueAnnotatedMethod(classElement,
+                                        processingEnvironment,
+                                        APIModule.getGetPreviewClass(),
+                                        new TypeMirror[]{
+                                                processingEnvironment.getElementUtils().getTypeElement("elemental2.promise.Promise").asType()
+                                        },
+                                        NO_PARAMS);
+    }
 
     /**
      * Finds the {@code @OnStartup} method suitable for {@code @WorkbenchEditor} classes.

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/facades/APIModule.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/facades/APIModule.java
@@ -28,6 +28,7 @@ public class APIModule {
     public static final String placeRequest = "org.uberfire.mvp.PlaceRequest";
     public static final String setContent = "org.uberfire.lifecycle.SetContent";
     public static final String getContent = "org.uberfire.lifecycle.GetContent";
+    public static final String getPreview = "org.uberfire.lifecycle.GetPreview";
     public static final String isDirty = "org.uberfire.lifecycle.IsDirty";
     public static final String onClose = "org.uberfire.lifecycle.OnClose";
     public static final String onFocus = "org.uberfire.lifecycle.OnFocus";
@@ -39,8 +40,8 @@ public class APIModule {
     public static final String onStartup = "org.uberfire.lifecycle.OnStartup";
     public static final String onContextAttach = "org.uberfire.lifecycle.OnContextAttach";
     public static final String activatedBy = "org.jboss.errai.ioc.client.api.ActivatedBy";
-    private APIModule() {
-    }
+
+    private APIModule() {}
 
     public static String getPanelDefinitionClass() {
         return panelDefinition;
@@ -58,7 +59,6 @@ public class APIModule {
         return placeRequest;
     }
 
-
     public static String getIsDirtyClass() {
         return isDirty;
     }
@@ -69,6 +69,10 @@ public class APIModule {
 
     public static String getGetContentClass() {
         return getContent;
+    }
+
+    public static String getGetPreviewClass() {
+        return getPreview;
     }
 
     public static String getOnCloseClass() {

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
@@ -202,7 +202,15 @@ public class ${className} extends AbstractWorkbenchClientEditorActivity {
     public Promise<String> getContent() {
         return realPresenter.${getContentMethodName}();
     }
-    </#if>
+    </#if>    
+    @Override
+    public Promise<String> getPreview() {
+    	<#if getPreviewMethodName??>    
+        return realPresenter.${getPreviewMethodName}();
+        <#else>
+        return null;
+        </#if>
+    }
     <#if getContextIdMethodName??>
     @Override
     public String contextId() {


### PR DESCRIPTION
New annnotation `@GetPreview` to bridge GetPreview functionality in Kogito Tooling side.

The new annotation GetPreview works just like GetContent: editors must have a method that returns String, which is the SVG representation of the asset being edited. 

Part of an ensemble, merge with: 

https://github.com/kiegroup/kogito-tooling/pull/67
https://github.com/kiegroup/kie-wb-common/pull/3192