### PR TITLE
KOGITO-1014: [DMN Designer] ACE Editor is not shown for invalid DMN content

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-ace/src/main/java/org/uberfire/ext/widgets/common/client/ace/AceEditor.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-ace/src/main/java/org/uberfire/ext/widgets/common/client/ace/AceEditor.java
@@ -188,7 +188,7 @@ public class AceEditor extends Composite implements RequiresResize,
     public native void setModeByName(String shortModeName) /*-{
         var editor = this.@org.uberfire.ext.widgets.common.client.ace.AceEditor::editor;
         var modeName = "ace/mode/" + shortModeName;
-        var TheMode = $wnd.require(modeName).Mode;
+        var TheMode = $wnd.ace.require(modeName).Mode;
         editor.getSession().setMode(new TheMode());
     }-*/;
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-1014

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/917
- https://github.com/kiegroup/kie-wb-common/pull/3204