### PR TITLE
AF-2432 :  Restoring an old asset version doesn't work outside master branch

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/version/CurrentBranch.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/version/CurrentBranch.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.editor.commons.version;
+
+public interface CurrentBranch {
+    String getName();
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/version/VersionService.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-api/src/main/java/org/uberfire/ext/editor/commons/version/VersionService.java
@@ -33,5 +33,6 @@ public interface VersionService {
     Path getPathToPreviousVersion(String uri);
 
     Path restore(final Path path,
-                 final String comment);
+                 final String comment,
+                 final String branchName);
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/version/VersionServiceImpl.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/version/VersionServiceImpl.java
@@ -53,6 +53,9 @@ public class VersionServiceImpl
     @Inject
     private PathResolver pathResolver;
 
+    @Inject
+    private VersionUtil versionUtil;
+
     @Override
     public List<VersionRecord> getVersions(final Path path) {
 
@@ -70,12 +73,13 @@ public class VersionServiceImpl
 
     @Override
     public Path restore(final Path _path,
-                        final String comment) {
+                        final String comment,
+                        final String branchName) {
         try {
             ioService.startBatch(Paths.convert(_path).getFileSystem());
 
             final org.uberfire.java.nio.file.Path path = pathResolver.resolveMainFilePath(convert(_path));
-            final org.uberfire.java.nio.file.Path target = path.getFileSystem().getPath(path.toString());
+            final org.uberfire.java.nio.file.Path target = versionUtil.getPath(path, branchName);
 
             return convert(ioService.copy(path,
                                           target,

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/version/VersionServiceImplTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/version/VersionServiceImplTest.java
@@ -48,6 +48,8 @@ public class VersionServiceImplTest {
     private SessionInfo sessionInfo;
     @Mock
     private PathResolver pathResolver;
+    @Mock
+    private VersionUtil versionUtil;
     @InjectMocks
     private VersionServiceImpl versionService;
 
@@ -69,7 +71,8 @@ public class VersionServiceImplTest {
         final InOrder order = inOrder(ioService);
 
         versionService.restore(path,
-                               "Restore comment");
+                               "Restore comment",
+                               "master");
 
         order.verify(ioService).startBatch(nioPath.getFileSystem());
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RestorePopUpPresenter.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/file/popups/RestorePopUpPresenter.java
@@ -72,9 +72,11 @@ public class RestorePopUpPresenter {
     }
 
     public void show(final ObservablePath currentPath,
-                     final String currentVersionRecordUri) {
+                     final String currentVersionRecordUri,
+                     final String branchName) {
         command = restoreCommand(currentPath,
-                                 currentVersionRecordUri);
+                                 currentVersionRecordUri,
+                                 branchName);
         view.show();
     }
 
@@ -96,12 +98,13 @@ public class RestorePopUpPresenter {
     }
 
     public ParameterizedCommand<String> restoreCommand(final ObservablePath currentPath,
-                                                final String currentVersionRecordUri) {
+                                                       final String currentVersionRecordUri,
+                                                       final String branchName) {
         return comment -> {
             busyIndicatorView.showBusyIndicator(CommonConstants.INSTANCE.Restoring());
             versionService.call(successCallback(currentVersionRecordUri),
                                 errorCallback()).restore(currentPath,
-                                                         comment);
+                                                         comment, branchName);
         };
     }
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/history/VersionRecordManager.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/history/VersionRecordManager.java
@@ -25,12 +25,14 @@ import javax.inject.Inject;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.kie.soup.commons.validation.PortablePreconditions;
+import org.uberfire.annotations.Customizable;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.editor.commons.client.file.RestoreUtil;
 import org.uberfire.ext.editor.commons.client.file.popups.RestorePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.event.VersionSelectedEvent;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
 import org.uberfire.ext.editor.commons.version.VersionService;
 import org.uberfire.ext.editor.commons.version.events.RestoreEvent;
 import org.uberfire.java.nio.base.version.VersionRecord;
@@ -52,6 +54,7 @@ public class VersionRecordManager {
     private ObservablePath pathToLatest;
     private String version;
     private SaveButton saveButton;
+    private CurrentBranch currentBranch;
 
     @Inject
     public VersionRecordManager(final VersionMenuDropDownButton versionMenuDropDownButton,
@@ -59,7 +62,8 @@ public class VersionRecordManager {
                                 final RestorePopUpPresenter restorePopUpPresenter,
                                 final RestoreUtil restoreUtil,
                                 final Event<VersionSelectedEvent> versionSelectedEvent,
-                                final Caller<VersionService> versionService) {
+                                final Caller<VersionService> versionService,
+                                @Customizable final CurrentBranch currentBranch) {
         this.restorePopUpPresenter = restorePopUpPresenter;
         this.versionMenuDropDownButton = versionMenuDropDownButton;
         this.saveButton = saveButton;
@@ -74,6 +78,7 @@ public class VersionRecordManager {
 
         this.restoreUtil = restoreUtil;
         this.versionService = versionService;
+        this.currentBranch = currentBranch;
     }
 
     private void fireVersionSelected(final VersionRecord versionRecord) {
@@ -226,10 +231,12 @@ public class VersionRecordManager {
     public void restoreToCurrentVersion(boolean withComments) {
         if (withComments)
             restorePopUpPresenter.show(getCurrentPath(),
-                                       getCurrentVersionRecordUri());
+                                       getCurrentVersionRecordUri(),
+                                       this.currentBranch.getName());
         else {
             restorePopUpPresenter.restoreCommand(getCurrentPath(),
-                                                 getCurrentVersionRecordUri())
+                                                 getCurrentVersionRecordUri(),
+                                                 this.currentBranch.getName())
                                  .execute("");
         }
     }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilder.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilder.java
@@ -17,6 +17,7 @@ package org.uberfire.ext.editor.commons.client.menu;
 
 import org.jboss.errai.common.client.api.Caller;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
@@ -77,7 +78,8 @@ public interface BasicFileMenuBuilder extends HasLockSyncMenuStateHelper {
 
     BasicFileMenuBuilder addValidate(final Command command);
 
-    BasicFileMenuBuilder addRestoreVersion(final Path path);
+    BasicFileMenuBuilder addRestoreVersion(final Path path,
+                                           final CurrentBranch currentBranch);
 
     BasicFileMenuBuilder addCommand(final String caption,
                                     final Command command);

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderImpl.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderImpl.java
@@ -37,6 +37,7 @@ import org.uberfire.ext.editor.commons.client.file.popups.CopyPopUpPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.DeletePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.menu.HasLockSyncMenuStateHelper.LockSyncMenuStateHelper.Operation;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
 import org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
@@ -343,8 +344,10 @@ public class BasicFileMenuBuilderImpl implements BasicFileMenuBuilder {
     }
 
     @Override
-    public BasicFileMenuBuilder addRestoreVersion(final Path path) {
-        this.restoreCommand = restoreVersionCommandProvider.getCommand(path);
+    public BasicFileMenuBuilder addRestoreVersion(final Path path,
+                                                  final CurrentBranch currentBranch) {
+        this.restoreCommand = restoreVersionCommandProvider.getCommand(path,
+                                                                       currentBranch);
         return this;
     }
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/RestoreVersionCommandProvider.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/RestoreVersionCommandProvider.java
@@ -23,6 +23,7 @@ import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.ext.editor.commons.client.file.popups.SavePopUpPresenter;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
 import org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants;
 import org.uberfire.ext.editor.commons.version.VersionService;
 import org.uberfire.ext.editor.commons.version.events.RestoreEvent;
@@ -45,7 +46,7 @@ public class RestoreVersionCommandProvider {
     @Inject
     private SavePopUpPresenter savePopUpPresenter;
 
-    public Command getCommand(final Path path) {
+    public Command getCommand(final Path path, final CurrentBranch currentBranch) {
         return new Command() {
 
             @Override
@@ -60,7 +61,7 @@ public class RestoreVersionCommandProvider {
                                                         getRestorationSuccessCallback(),
                                                         new HasBusyIndicatorDefaultErrorCallback(busyIndicatorView))
                                                         .restore(path,
-                                                                 comment);
+                                                                 comment, currentBranch.getName());
                                             }
                                         });
             }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/CurrentBranchProducer.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/CurrentBranchProducer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.editor.commons.client.menu.common;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.uberfire.annotations.Customizable;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
+
+public class CurrentBranchProducer {
+
+    @Inject
+    private Instance<CurrentBranch> currentBranch;
+
+    @Produces
+    @Customizable
+    public CurrentBranch currentBranchProducer() {
+        if (this.currentBranch.isUnsatisfied()) {
+            return new DefaultCurrentBranch();
+        }
+        return this.currentBranch.get();
+    }
+
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/DefaultCurrentBranch.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/common/DefaultCurrentBranch.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.editor.commons.client.menu.common;
+
+import org.uberfire.annotations.FallbackImplementation;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
+
+@FallbackImplementation
+public class DefaultCurrentBranch implements CurrentBranch {
+
+    private static final String DEFAULT_BRANCH = "master";
+
+    public DefaultCurrentBranch() {
+    }
+
+    @Override
+    public String getName() {
+        return DEFAULT_BRANCH;
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/popups/RestorePopUpPresenterTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/file/popups/RestorePopUpPresenterTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.ext.editor.commons.client.file.RestoreUtil;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
 import org.uberfire.ext.editor.commons.client.resources.i18n.CommonConstants;
 import org.uberfire.ext.editor.commons.version.VersionService;
 import org.uberfire.ext.editor.commons.version.events.RestoreEvent;
@@ -58,6 +59,9 @@ public class RestorePopUpPresenterTest {
 
     @Mock
     ParameterizedCommand<String> commandMock;
+
+    @Mock
+    CurrentBranch currentBranch;
 
     RestorePopUpPresenter presenter;
 
@@ -94,11 +98,13 @@ public class RestorePopUpPresenterTest {
         presenter = spy(presenter);
 
         presenter.show(path,
-                       "uri");
+                       "uri",
+                       currentBranch.getName());
 
         verify(view).show();
         verify(presenter).restoreCommand(path,
-                                         "uri");
+                                         "uri",
+                                         currentBranch.getName());
     }
 
     @Test

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionHistoryPresenterTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionHistoryPresenterTest.java
@@ -183,7 +183,8 @@ public class VersionHistoryPresenterTest {
                 }
 
                 public Path restore(final Path path,
-                                    final String comment) {
+                                    final String comment,
+                                    final String currentBranch) {
                     return null;
                 }
             };

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionRecordManagerOpenOlderVersionTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionRecordManagerOpenOlderVersionTest.java
@@ -25,6 +25,7 @@ import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.editor.commons.client.file.RestoreUtil;
 import org.uberfire.ext.editor.commons.client.file.popups.RestorePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.event.VersionSelectedEvent;
+import org.uberfire.ext.editor.commons.client.menu.common.DefaultCurrentBranch;
 import org.uberfire.java.nio.base.version.VersionRecord;
 
 import static org.junit.Assert.*;
@@ -67,7 +68,8 @@ public class VersionRecordManagerOpenOlderVersionTest {
                                 manager.onVersionSelectedEvent(result);
                             }
                         }),
-                new VersionServiceCallerMock(versions));
+                new VersionServiceCallerMock(versions),
+                mock(DefaultCurrentBranch.class));
     }
 
     private void setUpVersions() {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionRecordManagerTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionRecordManagerTest.java
@@ -26,7 +26,9 @@ import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.editor.commons.client.file.RestoreUtil;
 import org.uberfire.ext.editor.commons.client.file.popups.RestorePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.event.VersionSelectedEvent;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
 import org.uberfire.java.nio.base.version.VersionRecord;
+import org.uberfire.mvp.ParameterizedCommand;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -44,12 +46,14 @@ public class VersionRecordManagerTest {
     private ObservablePath pathTo222;
     private ObservablePath pathTo333;
     private VersionSelectedEventMock versionSelectedEvent;
+    private CurrentBranch currentBranch;
 
     @Before
     public void setUp() throws Exception {
         dropDownButton = mock(VersionMenuDropDownButton.class);
         saveButton = mock(SaveButton.class);
         restorePopup = mock(RestorePopUpPresenter.class);
+        currentBranch = mock(CurrentBranch.class);
 
         setUpUtil();
         setUpVersions();
@@ -65,7 +69,8 @@ public class VersionRecordManagerTest {
                                                restorePopup,
                                                util,
                                                versionSelectedEvent,
-                                               new VersionServiceCallerMock(versions)));
+                                               new VersionServiceCallerMock(versions),
+                                               currentBranch));
 
         manager.init(null,
                      pathTo333,
@@ -139,7 +144,21 @@ public class VersionRecordManagerTest {
         manager.restoreToCurrentVersion(true);
 
         verify(restorePopup).show(pathTo111,
-                                  "hehe//111");
+                                  "hehe//111",
+                                  currentBranch.getName());
+    }
+
+    @Test
+    public void testRestoreToCurrentVersionWithNoComment() {
+        manager.onVersionSelectedEvent(new VersionSelectedEvent(pathTo333,
+                                                                getVersionRecord("111")));
+        when(restorePopup.restoreCommand(pathTo111,
+                                         "hehe//111",
+                                         currentBranch.getName())).thenReturn(mock(ParameterizedCommand.class));
+        manager.restoreToCurrentVersion(false);
+        verify(restorePopup).restoreCommand(pathTo111,
+                                            "hehe//111",
+                                            currentBranch.getName());
     }
 
     @Test

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionServiceMock.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/history/VersionServiceMock.java
@@ -48,7 +48,8 @@ class VersionServiceMock
 
     @Override
     public Path restore(Path path,
-                        String comment) {
+                        String comment,
+                        String currentBranch) {
         return null;
     }
 

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderTest.java
@@ -20,6 +20,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.UpdatedLockStatusEvent;
@@ -28,6 +29,8 @@ import org.uberfire.ext.editor.commons.client.file.popups.DeletePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.SaveButton;
 import org.uberfire.ext.editor.commons.client.menu.HasLockSyncMenuStateHelper.LockSyncMenuStateHelper.Operation;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
+import org.uberfire.ext.editor.commons.client.menu.common.DefaultCurrentBranch;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
@@ -211,6 +214,18 @@ public class BasicFileMenuBuilderTest {
         verify(provider,
                times(1)).getPath();
     }
+
+    @Test
+    public void testAddRestoreVersion() {
+        CurrentBranch currentBranch = new DefaultCurrentBranch();
+        ArgumentCaptor<CurrentBranch> currentBranchCaptor = ArgumentCaptor.forClass(CurrentBranch.class);
+        builder.addRestoreVersion(mock(Path.class),
+                                  currentBranch);
+        verify(restoreVersionCommandProvider).getCommand(any(Path.class),
+                                                         currentBranchCaptor.capture());
+        assertEquals(currentBranch,
+                     currentBranchCaptor.getValue());
+    };
 
     @Test
     public void menuItemsDisabledWhenLockedByDifferentUser() {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/common/CurrentBranchProducerTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/common/CurrentBranchProducerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.editor.commons.client.menu.common;
+
+import javax.enterprise.inject.Instance;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.editor.commons.version.CurrentBranch;
+import org.uberfire.mocks.MockInstanceImpl;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CurrentBranchProducerTest {
+
+    @Mock
+    private Instance<CurrentBranch> currentBranch = new MockInstanceImpl<>();
+    @InjectMocks
+    private CurrentBranchProducer currentBranchProducer = new CurrentBranchProducer();
+
+    @Test
+    public void testCurrentBranchProducerWhenUnsatisfied() {
+        Mockito.when(currentBranch.isUnsatisfied()).thenReturn(true);
+        CurrentBranch currentBranch = currentBranchProducer.currentBranchProducer();
+        Assert.assertNotNull(currentBranch);
+        Assert.assertEquals(new DefaultCurrentBranch().getName(),
+                            currentBranch.getName());
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/common/DefaultCurrentBranchTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/common/DefaultCurrentBranchTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.uberfire.ext.editor.commons.client.menu.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultCurrentBranchTest {
+
+    private DefaultCurrentBranch currentBranch;
+
+    @Before
+    public void setup() {
+        currentBranch = Mockito.spy(new DefaultCurrentBranch());
+    }
+
+    @Test
+    public void testGetName() {
+        Assert.assertEquals("master", currentBranch.getName());
+    }
+}


### PR DESCRIPTION
 * Added CurrentBranch class to track current modifying branch in the editor  

Related PR : 
kie-wb-common [#3238](https://github.com/kiegroup/kie-wb-common/pull/3238)