### PR TITLE
[KOGITO-1436]Remove double setContent call

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
@@ -34,7 +34,7 @@ public interface WorkbenchClientEditorActivity extends WorkbenchActivity {
      * @param value
      *  The editor content
      */
-    void setContent(String path, String value);
+    Promise<Void> setContent(String path, String value);
 
     /**
      * Get the editor content

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
@@ -49,7 +49,7 @@ public class GWTEditorNativeRegister {
         };
 
         $wnd.GWTEditor.prototype.setContent = function (path, value) {
-            this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::setContent(Ljava/lang/String;Ljava/lang/String;)(path, value);
+            return this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::setContent(Ljava/lang/String;Ljava/lang/String;)(path, value);
         };
 
         $wnd.GWTEditor.prototype.getContent = function () {

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
@@ -27,6 +27,7 @@ import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import javax.tools.Diagnostic.Kind;
 
+import elemental2.promise.Promise;
 import org.junit.Test;
 
 public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest5.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest5.java
@@ -1,5 +1,6 @@
 package org.uberfire.annotations.processors;
 
+import elemental2.promise.Promise;
 import org.uberfire.client.annotations.WorkbenchClientEditor;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.lifecycle.SetContent;
@@ -16,8 +17,8 @@ public class WorkbenchClientEditorTest5 extends Widget {
     }
     
     @SetContent
-    public void setContent(String path, String content) {
-        
+    public Promise setContent(String path, String content) {
+        return null;
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest6.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest6.java
@@ -19,8 +19,8 @@ public class WorkbenchClientEditorTest6 extends Widget {
     }
     
     @SetContent
-    public void setContent(String path, String content) {
-        
+    public Promise setContent(String path, String content) {
+        return null;
     }
     
     @GetContent

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest7.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest7.java
@@ -20,8 +20,8 @@ public class WorkbenchClientEditorTest7 extends Widget {
     }
     
     @SetContent
-    public void setContent(String path, String content) {
-        
+    public Promise setContent(String path, String content) {
+        return null;
     }
     
     @GetContent

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
@@ -63,8 +63,8 @@ public class WorkbenchClientEditorTest6Activity extends AbstractWorkbenchClientE
     }
 
     @Override
-    public void setContent(String path, String value) {
-        realPresenter.setContent(path, value);
+    public Promise<Void> setContent(String path, String value) {
+        return realPresenter.setContent(path, value);
     }
     @Override
     public Promise<String> getContent() {

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected
@@ -63,8 +63,8 @@ public class WorkbenchClientEditorTest7Activity extends AbstractWorkbenchClientE
     }
 
     @Override
-    public void setContent(String path, String value) {
-        realPresenter.setContent(path, value);
+    public Promise<Void> setContent(String path, String value) {
+        return realPresenter.setContent(path, value);
     }
     @Override
     public Promise<String> getContent() {

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
@@ -126,14 +126,13 @@ public class GeneratorUtils {
     }
 
     public static ExecutableElement getSetContentMethodName(TypeElement classElement, ProcessingEnvironment processingEnvironment) {
-        final Types typeUtils = processingEnvironment.getTypeUtils();
-        final TypeMirror requiredReturnType = typeUtils.getNoType(TypeKind.VOID);
-
         return getUniqueAnnotatedMethod(
                 classElement,
                 processingEnvironment,
                 APIModule.getSetContentClass(),
-                requiredReturnType,
+                new TypeMirror[]{
+                        processingEnvironment.getElementUtils().getTypeElement("elemental2.promise.Promise").asType()
+                },
                 new String[]{"java.lang.String", "java.lang.String"});
     }
 
@@ -146,8 +145,8 @@ public class GeneratorUtils {
                                         },
                                         NO_PARAMS);
     }
-    
-    
+
+
     public static ExecutableElement getGetPreviewMethodName(TypeElement classElement, ProcessingEnvironment processingEnvironment) {
         return getUniqueAnnotatedMethod(classElement,
                                         processingEnvironment,

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
@@ -193,8 +193,8 @@ public class ${className} extends AbstractWorkbenchClientEditorActivity {
     </#if>
     <#if setContentMethodName??>
     @Override
-    public void setContent(String path, String value) {
-        realPresenter.${setContentMethodName}(path, value);
+    public Promise<Void> setContent(String path, String value) {
+        return realPresenter.${setContentMethodName}(path, value);
     }
     </#if>
     <#if getContentMethodName??>


### PR DESCRIPTION
This PR changes the set content method to return a Promise instead of void.

The goal of this change is to be able to make the loading of editors predictable and remove the need for double set content call.

Merge together with:
https://github.com/kiegroup/kogito-tooling/pull/95
https://github.com/kiegroup/kie-wb-common/pull/3246