### PR TITLE
RHPAM-2721 :Clone project via http can not be re-enabled

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
@@ -17,6 +17,7 @@
 package org.uberfire.java.nio.fs.jgit;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.ReceiveCommand;
@@ -92,4 +93,7 @@ public interface JGitFileSystem extends FileSystem,
 
     void filterBranchAccess(UploadPack uploadPack,
                             User user);
+
+    void setPublicURI(Map<String, String> fullHostNames);
+
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImpl.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImpl.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.CredentialsProvider;
@@ -69,7 +70,7 @@ public class JGitFileSystemImpl implements JGitFileSystem {
                                                                                                  "version")));
     private final JGitFileSystemProvider provider;
     private final Git git;
-    private final String toStringContent;
+    private String toStringContent;
     private boolean isClosed = false;
     private final FileStore fileStore;
     private final String name;
@@ -106,20 +107,7 @@ public class JGitFileSystemImpl implements JGitFileSystem {
                                        credential);
         this.fsHooks = fsHooks;
         this.fileStore = new JGitFileStore(this.git.getRepository());
-        if (fullHostNames != null && !fullHostNames.isEmpty()) {
-            final StringBuilder sb = new StringBuilder();
-            final Iterator<Map.Entry<String, String>> iterator = fullHostNames.entrySet().iterator();
-            while (iterator.hasNext()) {
-                final Map.Entry<String, String> entry = iterator.next();
-                sb.append(entry.getKey()).append("://").append(entry.getValue()).append("/").append(name);
-                if (iterator.hasNext()) {
-                    sb.append("\n");
-                }
-            }
-            toStringContent = sb.toString();
-        } else {
-            toStringContent = "git://" + name;
-        }
+        setPublicURI(fullHostNames);
     }
 
     @Override
@@ -557,6 +545,18 @@ public class JGitFileSystemImpl implements JGitFileSystem {
             ctx.addParam(FileSystemHooksConstants.USER, user);
 
             JGitFSHooks.executeFSHooks(hook, FileSystemHooks.BranchAccessFilter, ctx);
+        }
+    }
+
+    @Override
+    public void setPublicURI(Map<String, String> fullHostNames) {
+        if (fullHostNames != null && !fullHostNames.isEmpty()) {
+            toStringContent = fullHostNames.entrySet()
+                    .stream()
+                    .map(e -> e.getKey() + "://" + e.getValue() + "/" + name)
+                    .collect(Collectors.joining("\n"));
+        } else {
+            toStringContent = "git://" + name;
         }
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -49,38 +49,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FilterOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.RandomAccessFile;
-import java.io.UnsupportedEncodingException;
-import java.net.Authenticator;
-import java.net.InetSocketAddress;
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import javax.servlet.http.HttpServletRequest;
 
 import org.eclipse.jgit.diff.DiffEntry;
@@ -94,13 +62,6 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.storage.file.WindowCacheConfig;
-import org.eclipse.jgit.transport.CredentialsProvider;
-import org.eclipse.jgit.transport.ReceiveCommand;
-import org.eclipse.jgit.transport.ReceivePack;
-import org.eclipse.jgit.transport.ServiceMayNotContinueException;
-import org.eclipse.jgit.transport.SshSessionFactory;
-import org.eclipse.jgit.transport.UploadPack;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.ReceiveCommand;
 import org.eclipse.jgit.transport.ReceivePack;
@@ -166,27 +127,15 @@ import org.uberfire.java.nio.file.StandardCopyOption;
 import org.uberfire.java.nio.file.StandardDeleteOption;
 import org.uberfire.java.nio.file.StandardOpenOption;
 import org.uberfire.java.nio.file.WatchEvent;
-import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
-import org.uberfire.java.nio.file.FileSystemNotFoundException;
-import org.uberfire.java.nio.file.LinkOption;
-import org.uberfire.java.nio.file.NoSuchFileException;
-import org.uberfire.java.nio.file.NotDirectoryException;
-import org.uberfire.java.nio.file.OpenOption;
-import org.uberfire.java.nio.file.Option;
-import org.uberfire.java.nio.file.Path;
-import org.uberfire.java.nio.file.StandardCopyOption;
-import org.uberfire.java.nio.file.StandardDeleteOption;
-import org.uberfire.java.nio.file.StandardOpenOption;
-import org.uberfire.java.nio.file.WatchEvent;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
 import org.uberfire.java.nio.file.attribute.FileAttributeView;
 import org.uberfire.java.nio.file.extensions.FileSystemHooks;
 import org.uberfire.java.nio.fs.jgit.daemon.git.Daemon;
-import org.uberfire.java.nio.fs.jgit.daemon.git.DaemonClient;
 import org.uberfire.java.nio.fs.jgit.daemon.ssh.BaseGitCommand;
 import org.uberfire.java.nio.fs.jgit.daemon.ssh.GitSSHService;
+import org.uberfire.java.nio.fs.jgit.manager.JGitFileSystemsCache;
 import org.uberfire.java.nio.fs.jgit.manager.JGitFileSystemsManager;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 import org.uberfire.java.nio.fs.jgit.util.GitHookSupport;
@@ -439,6 +388,18 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
         fullHostNames.put(protocol, s);
     }
 
+    public void updateCacheWithHostNames() {
+        JGitFileSystemsCache fc = fsManager.getFsCache();
+        fc.getFileSystems()
+                .stream()
+                .map(fsName -> ((JGitFileSystemProxy) fsManager.get(fsName)).getRealJGitFileSystem())
+                .forEach(fs -> {
+                    JGitFileSystemImpl fsImpl = (JGitFileSystemImpl) fs;
+                    fs.setPublicURI(fullHostNames);
+                    fsManager.updateFSCacheEntry(fs.getName(), fsImpl);
+                });
+    }
+
     public Map<String, String> getFullHostNames() {
         return new HashMap<>(fullHostNames);
     }
@@ -541,7 +502,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
                                         revCommit.getTree());
                         }
                     }
-                    });
+                });
             }
         };
     }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxy.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxy.java
@@ -17,6 +17,7 @@
 package org.uberfire.java.nio.fs.jgit;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -49,6 +50,11 @@ public class JGitFileSystemProxy implements JGitFileSystem {
         this.fsName = fsName;
 
         this.cachedSupplier = cachedSupplier;
+    }
+
+    @Override
+    public void setPublicURI(Map<String, String> fullHostNames) {
+        cachedSupplier.get().setPublicURI(fullHostNames);
     }
 
     @Override

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/http/HTTPSupport.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/http/HTTPSupport.java
@@ -35,6 +35,7 @@ public class HTTPSupport implements ServletContextListener {
                 fsProvider.addHostName("https",
                                        fsProvider.getConfig().getHttpsHostName() + ":" + fsProvider.getConfig().getHttpsPort() + servletContext.getContextPath() + "/" + GIT_PATH);
             }
+            fsProvider.updateCacheWithHostNames();
             final GitServlet gitServlet = new GitServlet();
             gitServlet.setRepositoryResolver(fsProvider.getRepositoryResolver());
             gitServlet.setAsIsFileService(null);

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManager.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManager.java
@@ -26,14 +26,13 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.uberfire.java.nio.fs.jgit.FileSystemLockManager;
+import org.uberfire.java.nio.file.extensions.FileSystemHooks;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemImpl;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemLock;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration;
 import org.uberfire.java.nio.fs.jgit.util.Git;
-import org.uberfire.java.nio.file.extensions.FileSystemHooks;
 import org.uberfire.java.nio.fs.jgit.ws.JGitFileSystemsEventsManager;
 
 import static org.eclipse.jgit.lib.Constants.DOT_GIT_EXT;
@@ -76,6 +75,14 @@ public class JGitFileSystemsManager {
         fsCache.addSupplier(fsName.get(),
                             fsSupplier);
         fileSystemsRoot.addAll(parseFSRoots(fsName.get()));
+    }
+
+    public void updateFSCacheEntry(String fsKey, JGitFileSystem jGitFileSystem) {
+        if (getFsCache().containsKey(fsKey)) {
+            this.remove(fsKey);
+            fsCache.addSupplier(fsKey, () -> jGitFileSystem);
+            fileSystemsRoot.addAll(parseFSRoots(fsKey));
+        }
     }
 
     List<String> parseFSRoots(String fsKey) {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/AbstractTestInfra.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/AbstractTestInfra.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Scanner;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -78,6 +79,8 @@ public abstract class AbstractTestInfra {
             this.content = content;
         }
     }
+
+    private static final String PROTOCOL_SEPARATOR = "://";
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractTestInfra.class);
 
@@ -268,8 +271,9 @@ public abstract class AbstractTestInfra {
 
     /**
      * Creates mock hook in defined hooks directory.
+     *
      * @param hooksDirectory Directory in which mock hook is created.
-     * @param hookName Name of the created hook. This is the filename of created hook file.
+     * @param hookName       Name of the created hook. This is the filename of created hook file.
      * @throws FileNotFoundException
      * @throws UnsupportedEncodingException
      */
@@ -285,10 +289,11 @@ public abstract class AbstractTestInfra {
 
     /**
      * Tests if defined hook was executed or not.
-     * @param gitRepoName Name of test git repository that is created for committing changes.
+     *
+     * @param gitRepoName    Name of test git repository that is created for committing changes.
      * @param testedHookName Tested hook name. This hook is checked for its execution.
-     * @param wasExecuted Expected hook execution state. If true, test expects that defined hook is executed.
-     * If false, test expects that defined hook is not executed.
+     * @param wasExecuted    Expected hook execution state. If true, test expects that defined hook is executed.
+     *                       If false, test expects that defined hook is not executed.
      * @throws IOException
      */
     void testHook(final String gitRepoName,
@@ -354,5 +359,12 @@ public abstract class AbstractTestInfra {
                 .map(s -> prefix + s)
                 .reduce((s1, s2) -> s1 + "\n" + s2)
                 .orElse("");
+    }
+
+    protected static boolean checkProtocolPresent(String hostNames, String protocolName) {
+        final String[] uris = hostNames.toString().split("\\r?\\n");
+        return Arrays.stream(uris)
+                .map(uri -> uri.substring(0, uri.indexOf(PROTOCOL_SEPARATOR)))
+                .anyMatch(uri -> Objects.equals(uri, protocolName));
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitUpdateFSCacheWithHostnameTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitUpdateFSCacheWithHostnameTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.junit.Test;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.fs.jgit.manager.JGitFileSystemsCache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JGitUpdateFSCacheWithHostnameTest extends AbstractTestInfra {
+
+    @Override
+    public Map<String, String> getGitPreferences() {
+        Map<String, String> gitPrefs = super.getGitPreferences();
+        gitPrefs.put(JGitFileSystemProviderConfiguration.GIT_HTTP_ENABLED, "true");
+        return gitPrefs;
+    }
+
+    @Test
+    public void testFSCacheUpdateWithHostName() {
+        final URI newRepo = URI.create("git://repo-name");
+        provider.addHostName("ssh", "localhost:8080/git");
+        provider.newFileSystem(newRepo, EMPTY_ENV);
+        JGitFileSystemsCache fileSystemsCache = provider.getFsManager().getFsCache();
+
+        final FileSystem fileSystem = fileSystemsCache.get("repo-name");
+        assertThat(fileSystem).isNotNull();
+        assertTrue(checkProtocolPresent(fileSystem.toString(), "ssh"));
+        assertFalse(checkProtocolPresent(fileSystem.toString(), "http"));
+
+        provider.addHostName("http", "localhost:8080/git");
+
+        final FileSystem fileSystem1 = fileSystemsCache.get("repo-name");
+        assertThat(fileSystem1).isNotNull();
+        assertFalse(checkProtocolPresent(fileSystem1.toString(), "http"));
+        assertThat(fileSystemsCache.getFileSystems().size()).isOne();
+
+        provider.updateCacheWithHostNames();
+
+        final FileSystem fileSystem2 = fileSystemsCache.get("repo-name");
+        assertThat(fileSystem2).isNotNull();
+        assertTrue(checkProtocolPresent(fileSystem2.toString(), "http"));
+        assertThat(fileSystemsCache.getFileSystems().size()).isOne();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManagerTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManagerTest.java
@@ -24,16 +24,22 @@ import org.eclipse.jgit.transport.CredentialsProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.soup.commons.util.Maps;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemImpl;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemLock;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 import org.uberfire.java.nio.fs.jgit.ws.JGitFileSystemsEventsManager;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JGitFileSystemsManagerTest {
@@ -154,6 +160,45 @@ public class JGitFileSystemsManagerTest {
         assertFalse(manager.containsRoot("fs1"));
     }
 
+    @Test
+    public void updateFSCacheEntryTest() {
+        final JGitFileSystemProvider fsProvider = mock(JGitFileSystemProvider.class);
+        JGitFileSystem fs = mock(JGitFileSystem.class);
+
+        when(fs.getName()).thenReturn("fs");
+
+        manager = createFSManager();
+
+        manager.newFileSystem(() -> new HashMap<>(),
+                              () -> git,
+                              () -> fs.getName(),
+                              () -> mock(CredentialsProvider.class),
+                              () -> mock(JGitFileSystemsEventsManager.class),
+                              () -> null);
+
+        assertTrue(manager.containsKey("fs"));
+        assertTrue(manager.containsRoot("fs"));
+
+        assertThat(manager.get("fs").toString()).isEqualTo("git://fs");
+
+        final JGitFileSystemImpl newFileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                        new Maps.Builder<String, String>()
+                                                                                .put("ssh", "localhost")
+                                                                                .build(),
+                                                                        git,
+                                                                        manager.createLock(git),
+                                                                        fs.getName(),
+                                                                        mock(CredentialsProvider.class),
+                                                                        null,
+                                                                        null);
+
+        manager.updateFSCacheEntry("fs", newFileSystem);
+
+        assertThat(manager.get("fs").toString()).isEqualTo("ssh://localhost/fs");
+        assertTrue(manager.containsKey("fs"));
+        assertTrue(manager.containsRoot("fs"));
+    }
+
     private void checkParse(String fsKey,
                             List<String> expected) {
         List<String> actual = manager.parseFSRoots(fsKey);
@@ -169,7 +214,7 @@ public class JGitFileSystemsManagerTest {
 
     private JGitFileSystemsManager createFSManager() {
         return new JGitFileSystemsManager(mock(JGitFileSystemProvider.class),
-                                          config){
+                                          config) {
             @Override
             JGitFileSystemLock createLock(Git git) {
                 return mock(JGitFileSystemLock.class);


### PR DESCRIPTION
- Http wasn't enabled for the repositories because the project public URI's (ssh, http) are stored at project basis. During initialisation these project info are initialised with default values (without http/https) and stored in cache. Later on http/https support was added to the provider, making the existing projects unaware of http support.
- Implemented update cache functionality, which will update all the file system caches with hostnames whenever http support is added.