### PR TITLE
DROOLS-5265: Remove unused dependencies

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
@@ -33,10 +33,6 @@
       <artifactId>errai-ioc</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-bus</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>
@@ -53,10 +49,6 @@
       <artifactId>uberfire-workbench-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
@@ -68,21 +60,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-m2repo-editor-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-preferences-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-preferences-ui-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-client</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This PR removes unused compile dependencies of 'uberfire-m2repo-editor-client' module identiefied by 'mvn dependency:analyze'

For more details see https://issues.redhat.com/browse/DROOLS-5265