### PR TITLE
AF-2509: Remove DMR version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
     <version.org.webjars.bower.jqueryui>1.12.1</version.org.webjars.bower.jqueryui>
 
     <version.org.jboss.byteman>3.0.10</version.org.jboss.byteman>
-    <version.org.jboss.jboss-dmr>1.5.0.Final</version.org.jboss.jboss-dmr>
     <version.org.jboss.jboss-msc>1.2.7.SP1</version.org.jboss.jboss-msc>
 
     <version.org.apache.activemq.artemis>2.3.0</version.org.apache.activemq.artemis>
@@ -1292,12 +1291,6 @@
         <groupId>com.googlecode.jtype</groupId>
         <artifactId>jtype</artifactId>
         <version>${version.com.googlecode.jtype}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-dmr</artifactId>
-        <version>${version.org.jboss.jboss-dmr}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
After the update to Widlfly 18 the DMR version in `appformer/pom.xml` was not updated, which broke running some webapps in dev mode (dashbuilder and uberfire showcase). In this PR we simply remove the dmr version declaration from pom.xml (1.4.1.Final) and let appformer use the one from parent bom (1.5.0.Final)