### PR TITLE
AF-2474: Add Remote dataset type (kie server) for Dashbuilder Webapp and Standalone

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2014 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under 
+	the Apache License, Version 2.0 (the "License"); ~ you may not use this file 
+	except in compliance with the License. ~ You may obtain a copy of the License 
+	at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by 
+	applicable law or agreed to in writing, software ~ distributed under the 
+	License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. ~ See the License for the specific 
+	language governing permissions and ~ limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.dashbuilder</groupId>
+		<artifactId>dashbuilder-backend</artifactId>
+		<version>7.38.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>dashbuilder-kie-server-backend</artifactId>
+	<packaging>jar</packaging>
+	<name>Dashbuilder Kie Server Backend</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-kie-server-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.errai</groupId>
+			<artifactId>errai-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.resteasy</groupId>
+			<artifactId>resteasy-client</artifactId>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dashbuilder</groupId>
 		<artifactId>dashbuilder-backend</artifactId>
-		<version>7.38.0-SNAPSHOT</version>
+		<version>7.39.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>dashbuilder-kie-server-backend</artifactId>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -95,8 +96,8 @@ public class KieServerConnectionInfoProviderImpl implements KieServerConnectionI
             throw new RuntimeException(missingUrlError);
         }
 
-        if ((!connectionInfo.getUser().isPresent()) &&
-            (!connectionInfo.getToken().isPresent())) {
+        if (!connectionInfo.getUser().isPresent() &&
+            !connectionInfo.getToken().isPresent()) {
             throw new RuntimeException(missingAuthError);
         }
         return connectionInfo;
@@ -142,14 +143,13 @@ public class KieServerConnectionInfoProviderImpl implements KieServerConnectionI
         Optional<String> token = propertyProvider.apply(confType, KieServerConfigurationKey.TOKEN);
         Optional<String> replaceQueryOp = propertyProvider.apply(confType, KieServerConfigurationKey.REPLACE_QUERY);
 
-        if (!url.isPresent() &&
-            !user.isPresent() &&
-            !password.isPresent() &&
-            !token.isPresent() &&
-            !replaceQueryOp.isPresent()) {
+        boolean noPropertyFound = Stream.of(url, user, password, token, replaceQueryOp)
+                                        .noneMatch(Optional::isPresent);
+
+        if (noPropertyFound) {
             return Optional.empty();
         }
-        
+
         boolean replaceQuery = replaceQueryOp.isPresent() && Boolean.TRUE.toString().equalsIgnoreCase(replaceQueryOp.get());
 
         return Optional.of(new KieServerConnectionInfo(url, user, password, token, replaceQuery));

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImpl.java
@@ -56,6 +56,7 @@ public class KieServerConnectionInfoProviderImpl implements KieServerConnectionI
         LOCATION("location"),
         USER("user"),
         PASSWORD("password"),
+        REPLACE_QUERY("replace_query"),
         TOKEN("token");
 
         private KieServerConfigurationKey(String value) {
@@ -139,15 +140,19 @@ public class KieServerConnectionInfoProviderImpl implements KieServerConnectionI
         Optional<String> user = propertyProvider.apply(confType, KieServerConfigurationKey.USER);
         Optional<String> password = propertyProvider.apply(confType, KieServerConfigurationKey.PASSWORD);
         Optional<String> token = propertyProvider.apply(confType, KieServerConfigurationKey.TOKEN);
+        Optional<String> replaceQueryOp = propertyProvider.apply(confType, KieServerConfigurationKey.REPLACE_QUERY);
 
         if (!url.isPresent() &&
             !user.isPresent() &&
             !password.isPresent() &&
-            !token.isPresent()) {
+            !token.isPresent() &&
+            !replaceQueryOp.isPresent()) {
             return Optional.empty();
         }
+        
+        boolean replaceQuery = replaceQueryOp.isPresent() && Boolean.TRUE.toString().equalsIgnoreCase(replaceQueryOp.get());
 
-        return Optional.of(new KieServerConnectionInfo(url, user, password, token));
+        return Optional.of(new KieServerConnectionInfo(url, user, password, token, replaceQuery));
     }
 
 }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImpl.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.dashbuilder.kieserver.KieServerConnectionInfo;
+import org.dashbuilder.kieserver.KieServerConnectionInfoProvider;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.jboss.errai.bus.server.annotations.Service;
+
+/**
+ * Provide access to user configured connection provider
+ *
+ */
+@Service
+@ApplicationScoped
+public class KieServerConnectionInfoProviderImpl implements KieServerConnectionInfoProvider {
+
+    static final String CONFIGURATION_NOT_FOUND_MESSAGE = "Configuration for dataset %s / server template %s not found";
+    static final String MISSING_URL_MESSAGE = "URL configuration for dataset %s / server template %s is missing";
+    static final String MISSING_AUTH_MESSAGE = "Auth configuration for dataset %s / server template %s is missing." +
+                                               "You should provide user/password or token authentication";
+
+    private static final String SERVER_TEMPLATE_SEPARATOR = ",";
+    static final String SERVER_TEMPLATE_LIST_PROPERTY = "org.dashbuilder.kieserver.serverTemplates";
+    static final String SERVER_TEMPLATE_PROP_PREFFIX = "org.dashbuilder.kieserver.serverTemplate";
+    static final String DATASET_PROP_PREFFIX = "org.dashbuilder.kieserver.dataset";
+
+    private static final String SERVER_TEMPLATE_PROPERTY_TEMPLATE = SERVER_TEMPLATE_PROP_PREFFIX + ".%s.%s";
+    private static final String REMOTE_DATASET_PROPERTY_TEMPLATE = DATASET_PROP_PREFFIX + ".%s.%s";
+
+    public static enum KieServerConfigurationKey {
+
+        LOCATION("location"),
+        USER("user"),
+        PASSWORD("password"),
+        TOKEN("token");
+
+        private KieServerConfigurationKey(String value) {
+            this.value = value;
+        }
+
+        private String value;
+
+        public String getValue() {
+            return this.value;
+        }
+
+    }
+
+    @Override
+    public List<String> serverTemplates() {
+        return Optional.ofNullable(System.getProperty(SERVER_TEMPLATE_LIST_PROPERTY))
+                       .map(templates -> templates.split(SERVER_TEMPLATE_SEPARATOR))
+                       .map(template -> Arrays.stream(template)
+                                              .map(String::trim)
+                                              .filter(s -> !s.isEmpty())
+                                              .collect(Collectors.toList()))
+                       .orElse(Collections.emptyList());
+    }
+
+    @Override
+    public KieServerConnectionInfo verifiedConnectionInfo(RemoteDataSetDef def) {
+        String name = def.getName();
+        String serverTemplateId = def.getServerTemplateId();
+        String missingConfigError = String.format(CONFIGURATION_NOT_FOUND_MESSAGE, name, serverTemplateId);
+        String missingUrlError = String.format(MISSING_URL_MESSAGE, name, serverTemplateId);
+        String missingAuthError = String.format(MISSING_AUTH_MESSAGE, name, serverTemplateId);
+        KieServerConnectionInfo connectionInfo = get(name, serverTemplateId).orElseThrow(() -> new RuntimeException(missingConfigError));
+
+        if (!connectionInfo.getLocation().isPresent()) {
+            throw new RuntimeException(missingUrlError);
+        }
+
+        if ((!connectionInfo.getUser().isPresent()) &&
+            (!connectionInfo.getToken().isPresent())) {
+            throw new RuntimeException(missingAuthError);
+        }
+        return connectionInfo;
+    }
+
+    @Override
+    public Optional<KieServerConnectionInfo> get(String name,
+                                                 String serverTemplate) {
+
+        Optional<KieServerConnectionInfo> optional = get(name, this::remoteDatasetProperty);
+        if (!optional.isPresent()) {
+            optional = get(serverTemplate, this::serverTemplateProperty);
+        }
+        return optional;
+    }
+
+    public Optional<String> serverTemplateProperty(String serverTemplate,
+                                                   KieServerConfigurationKey configurationKey) {
+        String property = String.format(SERVER_TEMPLATE_PROPERTY_TEMPLATE,
+                                        serverTemplate,
+                                        configurationKey.value);
+        return filteredProperty(property);
+    }
+
+    public Optional<String> remoteDatasetProperty(String datasetUUID,
+                                                  KieServerConfigurationKey configurationKey) {
+        String property = String.format(REMOTE_DATASET_PROPERTY_TEMPLATE,
+                                        datasetUUID,
+                                        configurationKey.value);
+        return filteredProperty(property);
+    }
+
+    private Optional<String> filteredProperty(String property) {
+        return Optional.ofNullable(System.getProperty(property)).filter(v -> !v.trim().isEmpty());
+    }
+
+    private Optional<KieServerConnectionInfo> get(String confType,
+                                                  BiFunction<String, KieServerConfigurationKey, Optional<String>> propertyProvider) {
+
+        Optional<String> url = propertyProvider.apply(confType, KieServerConfigurationKey.LOCATION);
+        Optional<String> user = propertyProvider.apply(confType, KieServerConfigurationKey.USER);
+        Optional<String> password = propertyProvider.apply(confType, KieServerConfigurationKey.PASSWORD);
+        Optional<String> token = propertyProvider.apply(confType, KieServerConfigurationKey.TOKEN);
+
+        if (!url.isPresent() &&
+            !user.isPresent() &&
+            !password.isPresent() &&
+            !token.isPresent()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new KieServerConnectionInfo(url, user, password, token));
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerDataSetListener.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerDataSetListener.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Keeps Kie Server ups to date with remote dataset changes
+ * Keeps Kie Server up to date with remote dataset changes
  *
  */
 @ApplicationScoped

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerDataSetListener.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/KieServerDataSetListener.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.dashbuilder.dataset.def.DataSetDef;
+import org.dashbuilder.dataset.events.DataSetDefModifiedEvent;
+import org.dashbuilder.dataset.events.DataSetDefRegisteredEvent;
+import org.dashbuilder.dataset.events.DataSetDefRemovedEvent;
+import org.dashbuilder.kieserver.KieServerConnectionInfo;
+import org.dashbuilder.kieserver.KieServerConnectionInfoProvider;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.dashbuilder.kieserver.backend.rest.KieServerQueryClient;
+import org.dashbuilder.kieserver.backend.rest.QueryDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Keeps Kie Server ups to date with remote dataset changes
+ *
+ */
+@ApplicationScoped
+public class KieServerDataSetListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KieServerDataSetListener.class);
+
+    @Inject
+    KieServerQueryClient queryClient;
+
+    @Inject
+    KieServerConnectionInfoProvider connectionInfoProvider;
+
+    void onDataSetDefRegisteredEvent(@Observes DataSetDefRegisteredEvent event) {
+        DataSetDef def = event.getDataSetDef();
+        replaceQueryInKieServers(def);
+    }
+
+    void onDataSetDefModifiedEvent(@Observes DataSetDefModifiedEvent event) {
+        DataSetDef def = event.getNewDataSetDef();
+        replaceQueryInKieServers(def);
+    }
+
+    void onDataSetDefRemovedEvent(@Observes DataSetDefRemovedEvent event) {
+        DataSetDef def = event.getDataSetDef();
+        if (def instanceof RemoteDataSetDef) {
+            try {
+                KieServerConnectionInfo connectionInfo = connectionInfoProvider.verifiedConnectionInfo((RemoteDataSetDef) def);
+                queryClient.unregisterQuery(connectionInfo, def.getUUID());
+                LOGGER.info("Data set definition {} ({}) deletion event processed", def.getUUID(), def.getName());
+            } catch (Exception e) {
+                LOGGER.warn("Not able to delete query in server for removed dataset definition {} ", def.getName());
+                LOGGER.debug("Not able to delete query in server for removed dataset definition {}", def.getName(), e);
+            }
+        }
+    }
+
+    protected void replaceQueryInKieServers(DataSetDef def) {
+        if (def instanceof RemoteDataSetDef && ((RemoteDataSetDef) def).getServerTemplateId() != null) {
+            try {
+                KieServerConnectionInfo connectionInfo = connectionInfoProvider.verifiedConnectionInfo((RemoteDataSetDef) def);
+                QueryDefinition queryDefinition = QueryDefinition.builder()
+                                                                 .name(def.getUUID())
+                                                                 .source(((RemoteDataSetDef) def).getDataSource())
+                                                                 .target(((RemoteDataSetDef) def).getQueryTarget())
+                                                                 .expression(((RemoteDataSetDef) def).getDbSQL())
+                                                                 .build();
+
+                queryClient.replaceQuery(connectionInfo, queryDefinition);
+                LOGGER.info("Data set definition {} ({}) modification event processed", def.getUUID(), def.getName());
+            } catch (Exception e) {
+                LOGGER.warn("Not able to replace query in server for dataset definition {} ", def.getName());
+                LOGGER.debug("Not able to replace query in server for dataset definition {} ", def.getName(), e);
+            }
+        }
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProvider.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProvider.java
@@ -215,7 +215,7 @@ public class RuntimeKieServerDataSetProvider implements DataSetProvider {
                                       QueryFilterSpec filterSpec) {
         KieServerConnectionInfo connectionInfo = connectionInfoProvider.verifiedConnectionInfo(def);
         int pageNumber = lookup.getRowOffset() / lookup.getNumberOfRows();
-        if (lookup.testMode()) {
+        if (lookup.testMode() || connectionInfo.isReplaceQuery()) {
             QueryDefinition queryDefinition = QueryDefinition.builder()
                                                              .name(lookup.getDataSetUUID())
                                                              .source(def.getDataSource())

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProvider.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProvider.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map.Entry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.dashbuilder.dataprovider.DataSetProvider;
+import org.dashbuilder.dataprovider.DataSetProviderType;
+import org.dashbuilder.dataset.ColumnType;
+import org.dashbuilder.dataset.DataColumn;
+import org.dashbuilder.dataset.DataSet;
+import org.dashbuilder.dataset.DataSetFactory;
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetMetadata;
+import org.dashbuilder.dataset.def.DataColumnDef;
+import org.dashbuilder.dataset.def.DataSetDef;
+import org.dashbuilder.dataset.filter.ColumnFilter;
+import org.dashbuilder.dataset.filter.CoreFunctionFilter;
+import org.dashbuilder.dataset.filter.DataSetFilter;
+import org.dashbuilder.dataset.filter.FilterFactory;
+import org.dashbuilder.dataset.filter.LogicalExprFilter;
+import org.dashbuilder.dataset.group.ColumnGroup;
+import org.dashbuilder.dataset.group.DataSetGroup;
+import org.dashbuilder.dataset.group.GroupFunction;
+import org.dashbuilder.dataset.group.Interval;
+import org.dashbuilder.dataset.impl.DataColumnImpl;
+import org.dashbuilder.dataset.impl.DataSetMetadataImpl;
+import org.dashbuilder.dataset.sort.ColumnSort;
+import org.dashbuilder.dataset.sort.DataSetSort;
+import org.dashbuilder.dataset.sort.SortOrder;
+import org.dashbuilder.kieserver.ConsoleDataSetLookup;
+import org.dashbuilder.kieserver.KieServerConnectionInfo;
+import org.dashbuilder.kieserver.KieServerConnectionInfoProvider;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.dashbuilder.kieserver.RuntimeKieServerDataSetProviderType;
+import org.dashbuilder.kieserver.backend.rest.KieServerQueryClient;
+import org.dashbuilder.kieserver.backend.rest.QueryDefinition;
+import org.dashbuilder.kieserver.backend.rest.QueryFilterSpec;
+import org.dashbuilder.kieserver.backend.rest.QueryParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class RuntimeKieServerDataSetProvider implements DataSetProvider {
+
+    public static final DataSetProviderType TYPE = new RuntimeKieServerDataSetProviderType();
+    private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeKieServerDataSetProvider.class);
+
+    @Inject
+    KieServerQueryClient queryClient;
+
+    @Inject
+    KieServerConnectionInfoProvider connectionInfoProvider;
+
+    @Override
+    public DataSetProviderType getType() {
+        return TYPE;
+    }
+
+    @Override
+    public DataSetMetadata getDataSetMetadata(DataSetDef def) throws Exception {
+        List<String> columnNames = new ArrayList<>();
+        List<ColumnType> columnTypes = new ArrayList<>();
+        if (def.getColumns() == null && def instanceof RemoteDataSetDef) {
+            KieServerConnectionInfo connectionInfo = connectionInfoProvider.verifiedConnectionInfo((RemoteDataSetDef) def);
+            QueryDefinition definition = queryClient.getQuery(connectionInfo, def.getUUID());
+            if (definition.getColumns() != null) {
+                addColumnsToDefinition(def, definition);
+            }
+        }
+        def.getColumns().forEach(column -> {
+            columnNames.add(column.getId());
+            columnTypes.add(column.getColumnType());
+        });
+        return new DataSetMetadataImpl(def,
+                                       def.getUUID(),
+                                       -1,
+                                       def.getColumns().size(),
+                                       columnNames,
+                                       columnTypes,
+                                       -1);
+    }
+
+    @Override
+    public DataSet lookupDataSet(DataSetDef def,
+                                 DataSetLookup lookup) throws Exception {
+
+        ConsoleDataSetLookup dataSetLookup = adoptLookup(def,
+                                                         lookup);
+
+        LOGGER.debug("Data Set lookup using Server Template Id: {}",
+                     dataSetLookup.getServerTemplateId());
+        if (dataSetLookup.getServerTemplateId() == null || dataSetLookup.getServerTemplateId().isEmpty()) {
+            return buildDataSet(def,
+                                new ArrayList<>(),
+                                new ArrayList<>());
+        }
+
+        List<QueryParam> filterParams = new ArrayList<>();
+        QueryFilterSpec filterSpec = new QueryFilterSpec();
+        // apply filtering
+
+        for (DataSetFilter filter : dataSetLookup.getOperationList(DataSetFilter.class)) {
+            if (filter != null) {
+
+                for (ColumnFilter cFilter : filter.getColumnFilterList()) {
+                    if (cFilter instanceof CoreFunctionFilter) {
+
+                        CoreFunctionFilter coreFunctionFilter = (CoreFunctionFilter) cFilter;
+
+                        filterParams.add(new QueryParam(coreFunctionFilter.getColumnId(),
+                                                        coreFunctionFilter.getType().toString(),
+                                                        coreFunctionFilter.getParameters()));
+                    } else if (cFilter instanceof LogicalExprFilter) {
+                        LogicalExprFilter logicalExprFilter = (LogicalExprFilter) cFilter;
+                        filterParams.add(new QueryParam(logicalExprFilter.getColumnId(),
+                                                        logicalExprFilter.getLogicalOperator().toString(),
+                                                        logicalExprFilter.getLogicalTerms()));
+                    }
+                }
+            }
+        }
+        List<DataColumn> extraColumns = new ArrayList<DataColumn>();
+
+        List<DataSetGroup> dataSetGroups = lookup.getFirstGroupOpSelections();
+        for (DataSetGroup group : dataSetGroups) {
+            if (group.getSelectedIntervalList() != null && group.getSelectedIntervalList().size() > 0) {
+                appendIntervalSelection(group,
+                                        filterParams);
+            }
+        }
+
+        DataSetGroup dataSetGroup = dataSetLookup.getLastGroupOp();
+        handleDataSetGroup(def,
+                           dataSetGroup,
+                           filterParams,
+                           extraColumns);
+
+        if (!filterParams.isEmpty()) {
+            filterSpec.setParameters(filterParams.toArray(new QueryParam[filterParams.size()]));
+        }
+
+        // apply sorting
+        DataSetSort sort = dataSetLookup.getFirstSortOp();
+        if (sort != null) {
+            SortOrder sortOrder = SortOrder.UNSPECIFIED;
+            StringBuilder orderBy = new StringBuilder();
+            for (ColumnSort cSort : sort.getColumnSortList()) {
+                orderBy.append(cSort.getColumnId()).append(",");
+                sortOrder = cSort.getOrder();
+            }
+            // remove last ,
+            orderBy.deleteCharAt(orderBy.length() - 1);
+
+            filterSpec.setOrderBy(orderBy.toString());
+            filterSpec.setAscending(sortOrder.equals(SortOrder.ASCENDING));
+        }
+        final List<List> instances = performQuery((RemoteDataSetDef) def,
+                                                  dataSetLookup,
+                                                  filterSpec);
+        LOGGER.debug("Query client returned {} row(s)",
+                     instances.size());
+
+        return buildDataSet(def,
+                            instances,
+                            extraColumns);
+    }
+
+    protected ConsoleDataSetLookup adoptLookup(DataSetDef def,
+                                               DataSetLookup lookup) {
+        ConsoleDataSetLookup dataSetLookup = null;
+        if (!(lookup instanceof ConsoleDataSetLookup)) {
+
+            if (def instanceof RemoteDataSetDef) {
+                dataSetLookup = (ConsoleDataSetLookup) ConsoleDataSetLookup.fromInstance(lookup,
+                                                                                         ((RemoteDataSetDef) def).getServerTemplateId());
+                DataSetFilter filter = def.getDataSetFilter();
+                if (filter != null) {
+                    dataSetLookup.addOperation(filter);
+                }
+            } else {
+                throw new IllegalArgumentException("DataSetLookup is of incorrect type " + lookup.getClass().getName());
+            }
+        } else {
+            dataSetLookup = (ConsoleDataSetLookup) lookup;
+        }
+
+        return dataSetLookup;
+    }
+
+    protected List<List> performQuery(RemoteDataSetDef def,
+                                      ConsoleDataSetLookup lookup,
+                                      QueryFilterSpec filterSpec) {
+        KieServerConnectionInfo connectionInfo = connectionInfoProvider.verifiedConnectionInfo(def);
+        int pageNumber = lookup.getRowOffset() / lookup.getNumberOfRows();
+        if (lookup.testMode()) {
+            QueryDefinition queryDefinition = QueryDefinition.builder()
+                                                             .name(lookup.getDataSetUUID())
+                                                             .source(def.getDataSource())
+                                                             .target(def.getQueryTarget())
+                                                             .expression(def.getDbSQL())
+                                                             .build();
+            QueryDefinition registered = queryClient.replaceQuery(connectionInfo, queryDefinition);
+            if (registered.getColumns() != null) {
+                addColumnsToDefinition(def, registered);
+            }
+
+            try {
+                return queryClient.query(connectionInfo,
+                                         lookup.getDataSetUUID(),
+                                         filterSpec,
+                                         pageNumber,
+                                         lookup.getNumberOfRows());
+            } catch (Exception e) {
+                queryClient.unregisterQuery(connectionInfo, lookup.getDataSetUUID());
+                throw new RuntimeException(e);
+            }
+        } else {
+            if (def.getColumns() != null && def.getColumns().isEmpty()) {
+                QueryDefinition query = queryClient.getQuery(connectionInfo, def.getUUID());
+                addColumnsToDefinition(def, query);
+            }
+            return queryClient.query(connectionInfo,
+                                     lookup.getDataSetUUID(),
+                                     filterSpec,
+                                     pageNumber,
+                                     lookup.getNumberOfRows());
+        }
+    }
+
+    @Override
+    public boolean isDataSetOutdated(DataSetDef def) {
+        return false;
+    }
+
+    protected DataSet buildDataSet(DataSetDef def,
+                                   List<List> instances,
+                                   List<DataColumn> extraColumns) throws Exception {
+        DataSet dataSet = DataSetFactory.newEmptyDataSet();
+        dataSet.setUUID(def.getUUID());
+        dataSet.setDefinition(def);
+
+        if (extraColumns != null && !extraColumns.isEmpty()) {
+
+            for (DataColumn extraColumn : extraColumns) {
+                dataSet.addColumn(extraColumn);
+            }
+        } else {
+
+            for (DataColumnDef column : def.getColumns()) {
+                DataColumn numRows = new DataColumnImpl(column.getId(),
+                                                        column.getColumnType());
+                dataSet.addColumn(numRows);
+            }
+        }
+
+        for (List<Object> row : instances) {
+
+            int columnIndex = 0;
+            for (Object value : row) {
+                DataColumn intervalBuilder = dataSet.getColumnByIndex(columnIndex);
+                ColumnType columnType = intervalBuilder.getColumnType();
+                if (columnType.equals(ColumnType.DATE) && isNumberValue(value)) {
+                    Number dateNumber = NumberFormat.getInstance().parse(value.toString());
+                    Date dateValue = new Date(dateNumber.longValue());
+                    intervalBuilder.getValues().add(dateValue);
+                } else {
+                    intervalBuilder.getValues().add(value);
+                }
+                columnIndex++;
+            }
+        }
+        // set size of the results to allow paging to be more then the actual size
+        //        dataSet.setRowCountNonTrimmed(instances.size() == 0 ? 0 : instances.size() + 1);
+        dataSet.setRowCountNonTrimmed(instances.size());
+        return dataSet;
+    }
+
+    private boolean isNumberValue(Object value) {
+        try {
+            NumberFormat.getInstance().parse(value.toString());
+            return true;
+        } catch (Exception e) {
+            LOGGER.debug("Date value is not parseable to number", e);
+        }
+        return false;
+    }
+
+    protected void appendIntervalSelection(DataSetGroup intervalSel,
+                                           List<QueryParam> filterParams) {
+        if (intervalSel != null && intervalSel.isSelect()) {
+            ColumnGroup cg = intervalSel.getColumnGroup();
+            List<Interval> intervalList = intervalSel.getSelectedIntervalList();
+
+            // Get the filter values
+            List<Comparable> names = new ArrayList<Comparable>();
+            Comparable min = null;
+            Comparable max = null;
+            for (Interval interval : intervalList) {
+                names.add(interval.getName());
+                Comparable intervalMin = (Comparable) interval.getMinValue();
+                Comparable intervalMax = (Comparable) interval.getMaxValue();
+
+                if (intervalMin != null) {
+                    if (min == null) {
+                        min = intervalMin;
+                    } else if (min.compareTo(intervalMin) > 0) {
+                        min = intervalMin;
+                    }
+                }
+                if (intervalMax != null) {
+                    if (max == null) {
+                        max = intervalMax;
+                    } else if (max.compareTo(intervalMax) > 0) {
+                        max = intervalMax;
+                    }
+                }
+            }
+            // Min can't be greater than max.
+            if (min != null && max != null && min.compareTo(max) > 0) {
+                min = max;
+            }
+
+            ColumnFilter filter;
+            if (min != null && max != null) {
+                filter = FilterFactory.between(cg.getSourceId(),
+                                               min,
+                                               max);
+            } else if (min != null) {
+                filter = FilterFactory.greaterOrEqualsTo(cg.getSourceId(),
+                                                         min);
+            } else if (max != null) {
+                filter = FilterFactory.lowerOrEqualsTo(cg.getSourceId(),
+                                                       max);
+            } else {
+                filter = FilterFactory.equalsTo(cg.getSourceId(),
+                                                names);
+            }
+
+            CoreFunctionFilter coreFunctionFilter = (CoreFunctionFilter) filter;
+            filterParams.add(new QueryParam(coreFunctionFilter.getColumnId(),
+                                            coreFunctionFilter.getType().toString(),
+                                            coreFunctionFilter.getParameters()));
+        }
+    }
+
+    protected void handleDataSetGroup(final DataSetDef def,
+                                      final DataSetGroup dataSetGroup,
+                                      final List<QueryParam> filterParams,
+                                      final List<DataColumn> extraColumns) {
+        if (dataSetGroup != null) {
+            if (dataSetGroup.getColumnGroup() != null) {
+                // handle group
+                if (dataSetGroup.getColumnGroup().getIntervalSize() != null) {
+                    filterParams.add(new QueryParam(dataSetGroup.getColumnGroup().getSourceId(),
+                                                    "group",
+                                                    Arrays.asList(dataSetGroup.getColumnGroup().getColumnId(),
+                                                                  dataSetGroup.getColumnGroup().getIntervalSize(),
+                                                                  dataSetGroup.getColumnGroup().getMaxIntervals())));
+                } else {
+                    filterParams.add(new QueryParam(dataSetGroup.getColumnGroup().getSourceId(),
+                                                    "group",
+                                                    Arrays.asList(dataSetGroup.getColumnGroup().getColumnId())));
+                }
+            }
+
+            // handle additional columns
+            for (GroupFunction groupFunction : dataSetGroup.getGroupFunctions()) {
+                if (groupFunction.getFunction() != null) {
+                    filterParams.add(new QueryParam(groupFunction.getSourceId(),
+                                                    groupFunction.getFunction().toString(),
+                                                    Arrays.asList(groupFunction.getColumnId())));
+                    extraColumns.add(new DataColumnImpl(groupFunction.getSourceId(),
+                                                        ColumnType.NUMBER));
+                } else {
+                    filterParams.add(new QueryParam(groupFunction.getSourceId(),
+                                                    null,
+                                                    Arrays.asList(groupFunction.getColumnId())));
+                    extraColumns.add(new DataColumnImpl(groupFunction.getSourceId(),
+                                                        getGroupFunctionColumnType(def,
+                                                                                   dataSetGroup.getColumnGroup(),
+                                                                                   groupFunction)));
+                }
+            }
+        }
+    }
+
+    protected ColumnType getGroupFunctionColumnType(final DataSetDef def,
+                                                    final ColumnGroup columnGroup,
+                                                    final GroupFunction groupFunction) {
+        ColumnType type = def.getColumnById(groupFunction.getColumnId()).getColumnType();
+        if (type != ColumnType.DATE || columnGroup == null || groupFunction == null) {
+            return type;
+        } else {
+            return columnGroup.getSourceId().equals(groupFunction.getSourceId()) ? ColumnType.LABEL : type;
+        }
+    }
+
+    private void addColumnsToDefinition(DataSetDef def, QueryDefinition queryDef) {
+        if (queryDef.getColumns() == null) {
+            return;
+        }
+        for (Entry<String, String> entry : queryDef.getColumns().entrySet()) {
+            String columnId = entry.getKey();
+            if (def.getColumnById(columnId) == null) {
+                def.addColumn(columnId, ColumnType.valueOf(entry.getValue()));
+            }
+        }
+    }
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/BasicAuthFilter.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/BasicAuthFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend.rest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.jboss.resteasy.util.Base64;
+
+public class BasicAuthFilter implements ClientRequestFilter {
+
+    private final String user;
+    private final String password;
+
+    public BasicAuthFilter(String user, String password) {
+        this.user = user;
+        this.password = password;
+    }
+
+    @Override
+    public void filter(ClientRequestContext ctx) throws IOException {
+        final String basicAuthToken = getEncodedToken();
+        ctx.getHeaders().add(HttpHeaders.AUTHORIZATION, basicAuthToken);
+
+    }
+
+    private String getEncodedToken() {
+        String token = this.user + ":" + this.password;
+        return "Basic " + Base64.encodeBytes(token.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
@@ -34,7 +34,7 @@ import org.dashbuilder.kieserver.KieServerConnectionInfo;
 @ApplicationScoped
 public class KieServerQueryClient {
 
-    private static final String MEDIA_TYPE = MediaType.APPLICATION_JSON;
+    private static final String REQUEST_MEDIA_TYPE = MediaType.APPLICATION_JSON;
 
     public static final String QUERY_MAP_RAW = "RawList";
 
@@ -46,7 +46,7 @@ public class KieServerQueryClient {
         WebTarget target = requestForQueryDefinition(connectionInfo, uuid, client);
 
         QueryDefinition queryDefinition = target.request()
-                                                .accept(MEDIA_TYPE)
+                                                .accept(REQUEST_MEDIA_TYPE)
                                                 .get(QueryDefinition.class);
         client.close();
         return queryDefinition;
@@ -70,8 +70,8 @@ public class KieServerQueryClient {
         addAuth(connectionInfo, target);
 
         List<List> response = target.request()
-                                    .accept(MEDIA_TYPE)
-                                    .post(Entity.entity(filterSpec, MEDIA_TYPE), List.class);
+                                    .accept(REQUEST_MEDIA_TYPE)
+                                    .post(Entity.entity(filterSpec, REQUEST_MEDIA_TYPE), List.class);
         client.close();
         return response;
     }
@@ -79,9 +79,11 @@ public class KieServerQueryClient {
     public QueryDefinition replaceQuery(KieServerConnectionInfo connectionInfo, QueryDefinition queryDefinition) {
         Client client = ClientBuilder.newClient();
         WebTarget target = requestForQueryDefinition(connectionInfo, queryDefinition.getName(), client);
-        return target.request()
-                     .accept(MEDIA_TYPE)
-                     .put(Entity.entity(queryDefinition, MEDIA_TYPE), QueryDefinition.class);
+        QueryDefinition def = target.request()
+                     .accept(REQUEST_MEDIA_TYPE)
+                     .put(Entity.entity(queryDefinition, REQUEST_MEDIA_TYPE), QueryDefinition.class);
+        client.close();
+        return def;
 
     }
 
@@ -89,6 +91,7 @@ public class KieServerQueryClient {
         Client client = ClientBuilder.newClient();
         WebTarget target = requestForQueryDefinition(connectionInfo, dataSetUUID, client);
         target.request().delete();
+        client.close();
     }
 
     private WebTarget requestForQueryDefinition(KieServerConnectionInfo connectionInfo,

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend.rest;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.dashbuilder.kieserver.KieServerConnectionInfo;
+
+/**
+ * Run queries on Kie Server using its REST API
+ * 
+ */
+@ApplicationScoped
+public class KieServerQueryClient {
+
+    private static final String MEDIA_TYPE = MediaType.APPLICATION_JSON;
+
+    public static final String QUERY_MAP_RAW = "RawList";
+
+    public static final String QUERY_DEFINITION_URI = "queries/definitions/{id}";
+    public static final String QUERY_EXECUTION_URI = QUERY_DEFINITION_URI + "/filtered-data";
+
+    public QueryDefinition getQuery(KieServerConnectionInfo connectionInfo, String uuid) {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = requestForQueryDefinition(connectionInfo, uuid, client);
+
+        QueryDefinition queryDefinition = target.request()
+                                                .accept(MEDIA_TYPE)
+                                                .get(QueryDefinition.class);
+        client.close();
+        return queryDefinition;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public List<List> query(KieServerConnectionInfo connectionInfo,
+                            String uuid,
+                            QueryFilterSpec filterSpec,
+                            int i,
+                            int numberOfRows) {
+
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(connectionInfo.getLocation().get())
+                                 .path(QUERY_EXECUTION_URI)
+                                 .resolveTemplate("id", uuid)
+                                 .queryParam("mapper", QUERY_MAP_RAW)
+                                 .queryParam("page", i)
+                                 .queryParam("pageSize", numberOfRows);
+
+        addAuth(connectionInfo, target);
+
+        List<List> response = target.request()
+                                    .accept(MEDIA_TYPE)
+                                    .post(Entity.entity(filterSpec, MEDIA_TYPE), List.class);
+        client.close();
+        return response;
+    }
+
+    public QueryDefinition replaceQuery(KieServerConnectionInfo connectionInfo, QueryDefinition queryDefinition) {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = requestForQueryDefinition(connectionInfo, queryDefinition.getName(), client);
+        return target.request()
+                     .accept(MEDIA_TYPE)
+                     .put(Entity.entity(queryDefinition, MEDIA_TYPE), QueryDefinition.class);
+
+    }
+
+    public void unregisterQuery(KieServerConnectionInfo connectionInfo, String dataSetUUID) {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = requestForQueryDefinition(connectionInfo, dataSetUUID, client);
+        target.request().delete();
+    }
+
+    private WebTarget requestForQueryDefinition(KieServerConnectionInfo connectionInfo,
+                                                String dataSetUUID,
+                                                Client client) {
+        WebTarget target = client.target(connectionInfo.getLocation().get())
+                                 .path(QUERY_DEFINITION_URI)
+                                 .resolveTemplate("id", dataSetUUID);
+
+        addAuth(connectionInfo, target);
+        return target;
+    }
+
+    private void addAuth(KieServerConnectionInfo connectionInfo, WebTarget target) {
+        if (connectionInfo.getUser().isPresent()) {
+            String user = connectionInfo.getUser().get();
+            String password = connectionInfo.getPassword().orElse("");
+            target.register(new BasicAuthFilter(user, password));
+        }
+
+        if (connectionInfo.getToken().isPresent()) {
+            target.register(new TokenFilter(connectionInfo.getToken().get()));
+        }
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/QueryDefinition.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/QueryDefinition.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend.rest;
+
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "query-definition")
+public class QueryDefinition {
+
+    @XmlElement(name = "query-name")
+    private String name;
+    @XmlElement(name = "query-source")
+    private String source;
+    @XmlElement(name = "query-expression")
+    private String expression;
+    @XmlElement(name = "query-target")
+    private String target;
+    @XmlElement(name = "query-columns")
+    private Map<String, String> columns;
+
+    public QueryDefinition() {
+
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public void setExpression(String expression) {
+        this.expression = expression;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public Map<String, String> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(Map<String, String> columns) {
+        this.columns = columns;
+    }
+
+    public static class Builder {
+
+        private QueryDefinition definition = new QueryDefinition();
+
+        public QueryDefinition build() {
+            return definition;
+        }
+
+        public Builder name(String name) {
+            definition.setName(name);
+
+            return this;
+        }
+
+        public Builder source(String source) {
+            definition.setSource(source);
+
+            return this;
+        }
+
+        public Builder expression(String expression) {
+            definition.setExpression(expression);
+
+            return this;
+        }
+
+        public Builder target(String target) {
+            definition.setTarget(target);
+
+            return this;
+        }
+
+        public Builder columns(Map<String, String> columns) {
+            definition.setColumns(columns);
+
+            return this;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "QueryDefinition{" +
+               "name='" + name + '\'' +
+               ", source='" + source + '\'' +
+               ", expression='" + expression + '\'' +
+               ", target='" + target + '\'' +
+               '}';
+    }
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/QueryFilterSpec.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/QueryFilterSpec.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.kieserver.backend.rest;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "query-filter-spec")
+public class QueryFilterSpec {
+
+    @XmlElement(name = "order-by")
+    private String orderBy;
+    @XmlElement(name = "order-asc")
+    private boolean ascending;
+    @XmlElement(name = "query-params")
+    private QueryParam[] parameters;
+    @XmlElement(name = "result-column-mapping")
+    private Map<String, String> columnMapping;
+    @XmlElement(name = "order-by-clause")
+    private String orderByClause;
+
+
+    public QueryFilterSpec() {
+    }
+
+    public String getOrderBy() {
+        return orderBy;
+    }
+
+    public void setOrderBy(String orderBy) {
+        this.orderBy = orderBy;
+    }
+
+    public boolean isAscending() {
+        return ascending;
+    }
+
+    public void setAscending(boolean ascending) {
+        this.ascending = ascending;
+    }
+
+    public QueryParam[] getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(QueryParam[] parameters) {
+        this.parameters = parameters;
+    }
+
+    public Map<String, String> getColumnMapping() {
+        return columnMapping;
+    }
+
+    public void setColumnMapping(Map<String, String> columnMapping) {
+        this.columnMapping = columnMapping;
+    }
+
+    public String getOrderByClause() {
+        return this.orderByClause;
+    }
+
+    public void setOrderByClause(String orderByClause) {
+        this.orderByClause = orderByClause;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryFilterSpec{" + "orderBy='" + orderBy + '\'' + ", ascending=" + ascending + ", parameters=" + Arrays.toString(parameters) + '}';
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/QueryParam.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/QueryParam.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.kieserver.backend.rest;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "query-param")
+public class QueryParam {
+
+    @XmlElement(name = "cond-column")
+    private String column;
+    @XmlElement(name = "cond-operator")
+    private String operator;
+    @XmlElement(name = "cond-values")
+    private List<?> value;
+
+    public QueryParam() {
+
+    }
+
+    public QueryParam(String column, String operator, List<?> value) {
+        this.column = column;
+        this.operator = operator;
+        this.value = value;
+    }
+
+    public String getColumn() {
+        return column;
+    }
+
+    public void setColumn(String column) {
+        this.column = column;
+    }
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public void setOperator(String operator) {
+        this.operator = operator;
+    }
+
+    public List<?> getValue() {
+        return value;
+    }
+
+    public void setValue(List<?> value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryParam{" +
+               ((column != null) ? "column='" + column + "\'," : "") +
+               " operator='" + operator + '\'' +
+               ", value=" + value +
+               '}';
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/TokenFilter.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/TokenFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend.rest;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+
+public class TokenFilter implements ClientRequestFilter {
+
+    private String token;
+
+    public TokenFilter(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public void filter(ClientRequestContext ctx) throws IOException {
+        ctx.getHeaders().add("Bearer ", token);
+    }
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import static org.dashbuilder.kieserver.backend.KieServerConnectionInfoProviderImpl.DATASET_PROP_PREFFIX;
 import static org.dashbuilder.kieserver.backend.KieServerConnectionInfoProviderImpl.SERVER_TEMPLATE_PROP_PREFFIX;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class KieServerConnectionInfoProviderImplTest {
@@ -106,6 +107,7 @@ public class KieServerConnectionInfoProviderImplTest {
         assertEquals(DS_LOCATION, connectionInfo.getLocation().get());
         assertEquals(DS_USER, connectionInfo.getUser().get());
         assertEquals(DS_PASSWORD, connectionInfo.getPassword().get());
+        assertFalse(connectionInfo.isReplaceQuery());
     }
 
     @Test
@@ -119,6 +121,7 @@ public class KieServerConnectionInfoProviderImplTest {
         assertEquals(SERVER_LOCATION, connectionInfo.getLocation().get());
         assertEquals(SERVER_USER, connectionInfo.getUser().get());
         assertEquals(SERVER_PASSWORD, connectionInfo.getPassword().get());
+        assertFalse(connectionInfo.isReplaceQuery());
     }
 
     @Test
@@ -143,6 +146,26 @@ public class KieServerConnectionInfoProviderImplTest {
 
         assertEquals(SERVER_LOCATION, connectionInfo.getLocation().get());
         assertEquals(SERVER_TOKEN, connectionInfo.getToken().get());
+    }
+    
+    @Test
+    public void testReplaceQuery() {
+        setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
+        setServerProp(KieServerConfigurationKey.USER, SERVER_USER);
+        setServerProp(KieServerConfigurationKey.PASSWORD, SERVER_PASSWORD);
+        setServerProp(KieServerConfigurationKey.REPLACE_QUERY, "True");
+        KieServerConnectionInfo connectionInfo = kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+        assertTrue(connectionInfo.isReplaceQuery());
+    }
+    
+    @Test
+    public void testReplaceQueryFalse() {
+        setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
+        setServerProp(KieServerConfigurationKey.USER, SERVER_USER);
+        setServerProp(KieServerConfigurationKey.PASSWORD, SERVER_PASSWORD);
+        setServerProp(KieServerConfigurationKey.REPLACE_QUERY, "false");
+        KieServerConnectionInfo connectionInfo = kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+        assertFalse(connectionInfo.isReplaceQuery());
     }
 
     private void setDataSetProp(KieServerConfigurationKey key, String value) {

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.dashbuilder.kieserver.KieServerConnectionInfo;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.dashbuilder.kieserver.backend.KieServerConnectionInfoProviderImpl.KieServerConfigurationKey;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.dashbuilder.kieserver.backend.KieServerConnectionInfoProviderImpl.DATASET_PROP_PREFFIX;
+import static org.dashbuilder.kieserver.backend.KieServerConnectionInfoProviderImpl.SERVER_TEMPLATE_PROP_PREFFIX;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KieServerConnectionInfoProviderImplTest {
+
+    private static final String SERVER_USER = "serveruser";
+    private static final String SERVER_PASSWORD = "serverpassword";
+    private static final String SERVER_TOKEN = "servertoken";
+    private static final String SERVER_LOCATION = "serverlocation";
+    private static final String DS_USER = "dsuser";
+    private static final String DS_PASSWORD = "dspassword";
+    private static final String DS_TOKEN = "dstoken";
+    private static final String DS_LOCATION = "dslocation";
+
+    private KieServerConnectionInfoProviderImpl kieServerConnectionInfoProvider;
+
+    private final static String SERVER_ID = "server1";
+    private final static String DATASET_NAME = "ds1";
+    private final static String SERVER_TEMPLATE_PROP = SERVER_TEMPLATE_PROP_PREFFIX + "." + SERVER_ID + ".";
+    private final static String DATASET_PROP = DATASET_PROP_PREFFIX + "." + DATASET_NAME + ".";
+
+    private RemoteDataSetDef def;
+
+    @Before
+    public void init() {
+        kieServerConnectionInfoProvider = new KieServerConnectionInfoProviderImpl();
+        def = new RemoteDataSetDef();
+        def.setName(DATASET_NAME);
+        def.setServerTemplateId(SERVER_ID);
+        clearProperties();
+    }
+
+    @Test
+    public void serverListTest() {
+        System.setProperty(KieServerConnectionInfoProviderImpl.SERVER_TEMPLATE_LIST_PROPERTY, "server1, server2, server3");
+        List<String> serverTemplates = kieServerConnectionInfoProvider.serverTemplates();
+        assertEquals(3, serverTemplates.size());
+        List<String> expectedList = Arrays.asList("server1", "server2", "server3");
+        assertEquals(expectedList, serverTemplates);
+    }
+
+    @Test
+    public void emptyServerListTest() {
+        System.setProperty(KieServerConnectionInfoProviderImpl.SERVER_TEMPLATE_LIST_PROPERTY, "");
+        List<String> serverTemplates = kieServerConnectionInfoProvider.serverTemplates();
+        assertTrue(serverTemplates.isEmpty());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void absentConfigurationErrorTest() {
+        kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testServerMissingAuth() {
+        setServerProp(KieServerConfigurationKey.LOCATION, "somelocation");
+        kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testDataSetMissingAuth() {
+        setDataSetProp(KieServerConfigurationKey.LOCATION, "somelocation");
+        kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+    }
+
+    @Test
+    public void testDsPropsPrecedence() {
+        setDataSetProp(KieServerConfigurationKey.LOCATION, DS_LOCATION);
+        setDataSetProp(KieServerConfigurationKey.USER, DS_USER);
+        setDataSetProp(KieServerConfigurationKey.PASSWORD, DS_PASSWORD);
+
+        setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
+        setServerProp(KieServerConfigurationKey.USER, SERVER_USER);
+        setServerProp(KieServerConfigurationKey.PASSWORD, SERVER_PASSWORD);
+        KieServerConnectionInfo connectionInfo = kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+
+        assertEquals(DS_LOCATION, connectionInfo.getLocation().get());
+        assertEquals(DS_USER, connectionInfo.getUser().get());
+        assertEquals(DS_PASSWORD, connectionInfo.getPassword().get());
+    }
+
+    @Test
+    public void testServerTemplateProps() {
+
+        setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
+        setServerProp(KieServerConfigurationKey.USER, SERVER_USER);
+        setServerProp(KieServerConfigurationKey.PASSWORD, SERVER_PASSWORD);
+        KieServerConnectionInfo connectionInfo = kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+
+        assertEquals(SERVER_LOCATION, connectionInfo.getLocation().get());
+        assertEquals(SERVER_USER, connectionInfo.getUser().get());
+        assertEquals(SERVER_PASSWORD, connectionInfo.getPassword().get());
+    }
+
+    @Test
+    public void testDsTokenPropPrecedence() {
+        setDataSetProp(KieServerConfigurationKey.LOCATION, DS_LOCATION);
+        setDataSetProp(KieServerConfigurationKey.TOKEN, DS_TOKEN);
+
+        setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
+        setServerProp(KieServerConfigurationKey.TOKEN, SERVER_TOKEN);
+        KieServerConnectionInfo connectionInfo = kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+
+        assertEquals(DS_LOCATION, connectionInfo.getLocation().get());
+        assertEquals(DS_TOKEN, connectionInfo.getToken().get());
+    }
+
+    @Test
+    public void testServerToken() {
+
+        setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
+        setServerProp(KieServerConfigurationKey.TOKEN, SERVER_TOKEN);
+        KieServerConnectionInfo connectionInfo = kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
+
+        assertEquals(SERVER_LOCATION, connectionInfo.getLocation().get());
+        assertEquals(SERVER_TOKEN, connectionInfo.getToken().get());
+    }
+
+    private void setDataSetProp(KieServerConfigurationKey key, String value) {
+        System.setProperty(DATASET_PROP + key.getValue(), value);
+    }
+
+    private void setServerProp(KieServerConfigurationKey key, String value) {
+        System.setProperty(SERVER_TEMPLATE_PROP + key.getValue(), value);
+    }
+
+    private void clearProperties() {
+        System.setProperty(KieServerConnectionInfoProviderImpl.SERVER_TEMPLATE_LIST_PROPERTY, "");
+        for (KieServerConfigurationKey key : KieServerConfigurationKey.values()) {
+            System.setProperty(DATASET_PROP + key.getValue(), "");
+            System.setProperty(SERVER_TEMPLATE_PROP + key.getValue(), "");
+        }
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
@@ -112,7 +112,6 @@ public class KieServerConnectionInfoProviderImplTest {
 
     @Test
     public void testServerTemplateProps() {
-
         setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
         setServerProp(KieServerConfigurationKey.USER, SERVER_USER);
         setServerProp(KieServerConfigurationKey.PASSWORD, SERVER_PASSWORD);

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProviderTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProviderTest.java
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.dashbuilder.dataset.ColumnType;
+import org.dashbuilder.dataset.DataColumn;
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.def.DataSetDef;
+import org.dashbuilder.dataset.filter.ColumnFilter;
+import org.dashbuilder.dataset.filter.CoreFunctionFilter;
+import org.dashbuilder.dataset.filter.DataSetFilter;
+import org.dashbuilder.dataset.group.ColumnGroup;
+import org.dashbuilder.dataset.group.DataSetGroup;
+import org.dashbuilder.dataset.group.DateIntervalType;
+import org.dashbuilder.dataset.group.GroupFunction;
+import org.dashbuilder.dataset.group.GroupStrategy;
+import org.dashbuilder.dataset.group.Interval;
+import org.dashbuilder.dataset.impl.DataSetImpl;
+import org.dashbuilder.kieserver.ConsoleDataSetLookup;
+import org.dashbuilder.kieserver.KieServerConnectionInfo;
+import org.dashbuilder.kieserver.KieServerConnectionInfoProvider;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.dashbuilder.kieserver.backend.rest.KieServerQueryClient;
+import org.dashbuilder.kieserver.backend.rest.QueryDefinition;
+import org.dashbuilder.kieserver.backend.rest.QueryFilterSpec;
+import org.dashbuilder.kieserver.backend.rest.QueryParam;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.dashbuilder.dataset.filter.FilterFactory.OR;
+import static org.dashbuilder.dataset.filter.FilterFactory.likeTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RuntimeKieServerDataSetProviderTest {
+
+    private static final String SERVER_TEMPLATE = "serverTemplate";
+
+    public static String COLUMN_TEST = "columTest";
+
+    @InjectMocks
+    RuntimeKieServerDataSetProvider kieServerDataSetProvider;
+
+    @Mock
+    KieServerQueryClient queryClient;
+
+    @Mock
+    DataSetImpl dataSet;
+
+    @Mock
+    KieServerConnectionInfoProvider kieServerConnectionInfoProvider;
+
+    @Mock
+    RemoteDataSetDef dataSetDef;
+
+    private KieServerConnectionInfo connectionInfo;
+
+    private KieServerConnectionInfo connectionInfoWithQueryReplace;
+
+    private QueryDefinition definition;
+
+    @Before
+    public void setUp() {
+        connectionInfo = new KieServerConnectionInfo(Optional.of("location"),
+                                                     Optional.of("user"),
+                                                     Optional.of("password"),
+                                                     Optional.of("token"),
+                                                     false);
+        connectionInfoWithQueryReplace = new KieServerConnectionInfo(Optional.of("location"),
+                                                                     Optional.of("user"),
+                                                                     Optional.of("password"),
+                                                                     Optional.of("token"),
+                                                                     true);
+        
+        Map<String, String> columns = new HashMap<>();
+        columns.put("test", "NUMBER");
+        definition = QueryDefinition.builder()
+                                                    .name("q1")
+                                                    .columns(columns)
+                                                    .build();
+    }
+
+    @Test
+    public void appendEqualToIntervalSelectionTest() {
+        String filterValue = "testValue";
+
+        DataSetGroup dataSetGroup = new DataSetGroup();
+        dataSetGroup.setColumnGroup(new ColumnGroup(COLUMN_TEST,
+                                                    COLUMN_TEST,
+                                                    GroupStrategy.DYNAMIC));
+        List<Interval> intervalList = new ArrayList<Interval>();
+        Interval interval = new Interval(filterValue);
+        intervalList.add(interval);
+        dataSetGroup.setSelectedIntervalList(intervalList);
+
+        List<QueryParam> filterParams = new ArrayList<>();
+        kieServerDataSetProvider.appendIntervalSelection(dataSetGroup,
+                                                         filterParams);
+
+        assertEquals(1,
+                     filterParams.size());
+        assertEquals(COLUMN_TEST,
+                     filterParams.get(0).getColumn());
+        assertEquals("EQUALS_TO",
+                     filterParams.get(0).getOperator());
+        assertEquals(filterValue,
+                     filterParams.get(0).getValue().get(0));
+    }
+
+    @Test
+    public void appendBetweenIntervalSelectionTest() {
+        String filterValue = "testValue";
+        Long minValue = Long.valueOf(0);
+        Long maxValue = Long.valueOf(2);
+
+        DataSetGroup dataSetGroup = new DataSetGroup();
+        dataSetGroup.setColumnGroup(new ColumnGroup(COLUMN_TEST,
+                                                    COLUMN_TEST,
+                                                    GroupStrategy.DYNAMIC));
+        List<Interval> intervalList = new ArrayList<Interval>();
+        Interval interval = new Interval(filterValue);
+        interval.setMinValue(minValue);
+        interval.setMaxValue(maxValue);
+        intervalList.add(interval);
+        dataSetGroup.setSelectedIntervalList(intervalList);
+        List<QueryParam> filterParams = new ArrayList<>();
+
+        kieServerDataSetProvider.appendIntervalSelection(dataSetGroup,
+                                                         filterParams);
+
+        assertEquals(1,
+                     filterParams.size());
+        assertEquals(COLUMN_TEST,
+                     filterParams.get(0).getColumn());
+        assertEquals("BETWEEN",
+                     filterParams.get(0).getOperator());
+        assertEquals(Double.valueOf(minValue),
+                     filterParams.get(0).getValue().get(0));
+        assertEquals(Double.valueOf(maxValue),
+                     filterParams.get(0).getValue().get(1));
+    }
+
+    @Test
+    public void lookupDataSetLogicalExprTest() throws Exception {
+        DataSetLookup lookup = new DataSetLookup();
+        lookup.setDataSetUUID("");
+        when(dataSetDef.getUUID()).thenReturn("");
+
+        when(kieServerConnectionInfoProvider.verifiedConnectionInfo(dataSetDef)).thenReturn(connectionInfo);
+
+        final ColumnFilter testFilter = OR(likeTo("column1",
+                                                  "%value%"),
+                                           likeTo("column2",
+                                                  "%value%"));
+
+        DataSetFilter filter = new DataSetFilter();
+        filter.addFilterColumn(testFilter);
+        lookup.addOperation(filter);
+        
+        when(queryClient.replaceQuery(eq(connectionInfo), any())).thenReturn(definition);
+
+        when(queryClient.getQuery(eq(connectionInfo), any())).thenReturn(definition);
+        
+        kieServerDataSetProvider.lookupDataSet(dataSetDef,
+                                               ConsoleDataSetLookup.fromInstance(lookup,
+                                                                                 SERVER_TEMPLATE));
+
+        final ArgumentCaptor<QueryFilterSpec> captorEdit = ArgumentCaptor.forClass(QueryFilterSpec.class);
+        verify(queryClient).query(eq(connectionInfo),
+                                  anyString(),
+                                  captorEdit.capture(),
+                                  anyInt(),
+                                  anyInt());
+
+        assertNotNull(captorEdit.getValue());
+        QueryParam[] parameters = captorEdit.getValue().getParameters();
+        assertEquals(1,
+                     parameters.length);
+
+        List<CoreFunctionFilter> expr = (List<CoreFunctionFilter>) parameters[0].getValue();
+        assertEquals("OR",
+                     parameters[0].getOperator());
+
+        assertEquals("column1 like %value%, true",
+                     expr.get(0).toString());
+        assertEquals("column2 like %value%, true",
+                     expr.get(1).toString());
+    }
+
+    @Test
+    public void testGroupWithInterval() {
+
+        DataSetGroup dataSetGroup = new DataSetGroup();
+        dataSetGroup.setColumnGroup(new ColumnGroup(COLUMN_TEST,
+                                                    COLUMN_TEST,
+                                                    GroupStrategy.DYNAMIC,
+                                                    30,
+                                                    DateIntervalType.DAY.name()));
+
+        List<QueryParam> filterParams = new ArrayList<>();
+        List<DataColumn> extraColumns = new ArrayList<>();
+        kieServerDataSetProvider.handleDataSetGroup(dataSetDef,
+                                                    dataSetGroup,
+                                                    filterParams,
+                                                    extraColumns);
+
+        assertEquals(1,
+                     filterParams.size());
+        assertEquals(COLUMN_TEST,
+                     filterParams.get(0).getColumn());
+        assertEquals("group",
+                     filterParams.get(0).getOperator());
+
+        assertEquals(3,
+                     filterParams.get(0).getValue().size());
+        assertEquals(COLUMN_TEST,
+                     filterParams.get(0).getValue().get(0));
+        assertEquals(DateIntervalType.DAY.name(),
+                     filterParams.get(0).getValue().get(1));
+        assertEquals(30,
+                     filterParams.get(0).getValue().get(2));
+    }
+
+    @Test
+    public void testGroupWithNotSetInterval() {
+
+        DataSetGroup dataSetGroup = new DataSetGroup();
+        dataSetGroup.setColumnGroup(new ColumnGroup(COLUMN_TEST,
+                                                    COLUMN_TEST,
+                                                    GroupStrategy.DYNAMIC));
+
+        List<QueryParam> filterParams = new ArrayList<>();
+        List<DataColumn> extraColumns = new ArrayList<>();
+        kieServerDataSetProvider.handleDataSetGroup(dataSetDef,
+                                                    dataSetGroup,
+                                                    filterParams,
+                                                    extraColumns);
+
+        assertEquals(1,
+                     filterParams.size());
+        assertEquals(COLUMN_TEST,
+                     filterParams.get(0).getColumn());
+        assertEquals("group",
+                     filterParams.get(0).getOperator());
+
+        assertEquals(1,
+                     filterParams.get(0).getValue().size());
+        assertEquals(COLUMN_TEST,
+                     filterParams.get(0).getValue().get(0));
+    }
+
+    @Test
+    public void testPerformQueryTestMode() {
+        QueryFilterSpec filterSpec = new QueryFilterSpec();
+
+        ConsoleDataSetLookup dataSetLookup = Mockito.mock(ConsoleDataSetLookup.class);
+        when(dataSetLookup.testMode()).thenReturn(true);
+        when(dataSetLookup.getNumberOfRows()).thenReturn(10);
+        when(dataSetLookup.getRowOffset()).thenReturn(1);
+        when(dataSetLookup.getDataSetUUID()).thenReturn("");
+
+        when(kieServerConnectionInfoProvider.verifiedConnectionInfo(dataSetDef)).thenReturn(connectionInfo);
+
+        when(queryClient.replaceQuery(eq(connectionInfo), any())).thenReturn(definition);
+        kieServerDataSetProvider.performQuery(dataSetDef, dataSetLookup, filterSpec);
+
+        verify(dataSetLookup, times(1)).testMode();
+
+        verify(queryClient).replaceQuery(eq(connectionInfo), any());
+
+        verify(queryClient).query(eq(connectionInfo),
+                                  anyString(),
+                                  any(QueryFilterSpec.class),
+                                  anyInt(),
+                                  anyInt());
+    }
+
+    @Test
+    public void testPerformQueryWithReplace() {
+        QueryFilterSpec filterSpec = new QueryFilterSpec();
+
+        ConsoleDataSetLookup dataSetLookup = Mockito.mock(ConsoleDataSetLookup.class);
+        when(dataSetLookup.testMode()).thenReturn(true);
+        when(dataSetLookup.getNumberOfRows()).thenReturn(10);
+        when(dataSetLookup.getRowOffset()).thenReturn(1);
+        when(dataSetLookup.getDataSetUUID()).thenReturn("");
+
+        when(kieServerConnectionInfoProvider.verifiedConnectionInfo(dataSetDef)).thenReturn(connectionInfoWithQueryReplace);
+        when(queryClient.replaceQuery(eq(connectionInfoWithQueryReplace), any())).thenReturn(definition);
+
+        kieServerDataSetProvider.performQuery(dataSetDef, dataSetLookup, filterSpec);
+
+        verify(dataSetLookup, times(1)).testMode();
+
+        verify(queryClient).replaceQuery(eq(connectionInfoWithQueryReplace), any());
+
+        verify(queryClient).query(eq(connectionInfoWithQueryReplace),
+                                  anyString(),
+                                  any(QueryFilterSpec.class),
+                                  anyInt(),
+                                  anyInt());
+    }
+
+    @Test
+    public void testPerformQueryRegularMode() {
+        QueryFilterSpec filterSpec = new QueryFilterSpec();
+
+        ConsoleDataSetLookup dataSetLookup = Mockito.mock(ConsoleDataSetLookup.class);
+        when(dataSetLookup.testMode()).thenReturn(false);
+        when(dataSetLookup.getNumberOfRows()).thenReturn(10);
+        when(dataSetLookup.getRowOffset()).thenReturn(1);
+        when(dataSetLookup.getDataSetUUID()).thenReturn("");
+        
+        when(queryClient.replaceQuery(eq(connectionInfo), any())).thenReturn(definition);
+        when(queryClient.getQuery(eq(connectionInfo), any())).thenReturn(definition);
+
+        when(kieServerConnectionInfoProvider.verifiedConnectionInfo(dataSetDef)).thenReturn(connectionInfo);
+
+        kieServerDataSetProvider.performQuery(dataSetDef, dataSetLookup, filterSpec);
+
+        verify(dataSetLookup, times(1)).testMode();
+        
+        verify(queryClient, times(0)).replaceQuery(eq(connectionInfo), any());
+
+        verify(queryClient).query(eq(connectionInfo),
+                                  anyString(),
+                                  any(QueryFilterSpec.class),
+                                  anyInt(),
+                                  anyInt());
+    }
+
+    @Test
+    public void testDataSetMetaData() throws Exception {
+        when(kieServerConnectionInfoProvider.verifiedConnectionInfo(dataSetDef)).thenReturn(connectionInfo);
+
+
+        when(dataSetDef.getColumns()).thenReturn(null, new ArrayList<>());
+        when(dataSetDef.getServerTemplateId()).thenReturn(SERVER_TEMPLATE);
+        when(queryClient.getQuery(eq(connectionInfo), anyString())).thenReturn(definition);
+
+        kieServerDataSetProvider.getDataSetMetadata(dataSetDef);
+
+        verify(dataSetDef, times(1)).addColumn(eq("test"), eq(ColumnType.NUMBER));
+
+        verify(queryClient).getQuery(eq(connectionInfo), anyString());
+    }
+
+    @Test
+    public void testNoAdoptLookup() throws Exception {
+        ConsoleDataSetLookup dataSetLookup = Mockito.mock(ConsoleDataSetLookup.class);
+
+        kieServerDataSetProvider.adoptLookup(dataSetDef, dataSetLookup);
+
+        verify(dataSetDef, times(0)).getServerTemplateId();
+    }
+
+    @Test
+    public void testAdoptLookup() throws Exception {
+        DataSetLookup dataSetLookup = Mockito.mock(DataSetLookup.class);
+        when(dataSetDef.getDataSetFilter()).thenReturn(Mockito.mock(DataSetFilter.class));
+        when(dataSetDef.getServerTemplateId()).thenReturn("servereTemplateId");
+        when(dataSetLookup.cloneInstance()).thenReturn(dataSetLookup);
+
+        ConsoleDataSetLookup adopted = kieServerDataSetProvider.adoptLookup(dataSetDef, dataSetLookup);
+
+        verify(dataSetDef, times(1)).getServerTemplateId();
+        assertNotNull(adopted.getOperationList());
+        assertEquals(1, adopted.getOperationList().size());
+    }
+
+    @Test
+    public void testGroupFunctionColumnType() {
+        for (ColumnType type : ColumnType.values()) {
+            assertGroupFuntionColumnType(type,
+                                         type == ColumnType.DATE ? ColumnType.LABEL : type);
+        }
+    }
+
+    protected void assertGroupFuntionColumnType(final ColumnType source,
+                                                final ColumnType expected) {
+        final DataSetDef def = new DataSetDef();
+        def.addColumn("columnId",
+                      source);
+        final ColumnGroup columnGroup = new ColumnGroup("sourceId",
+                                                        "columnId");
+        final GroupFunction groupFunction = new GroupFunction("sourceId",
+                                                              "columnId",
+                                                              null);
+
+        assertEquals(expected,
+                     kieServerDataSetProvider.getGroupFunctionColumnType(def,
+                                                                         columnGroup,
+                                                                         groupFunction));
+    }
+}

--- a/dashbuilder/dashbuilder-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/pom.xml
@@ -18,6 +18,7 @@
     <module>dashbuilder-dataset-cdi</module>
     <module>dashbuilder-navigation-backend</module>
     <module>dashbuilder-services</module>
+    <module>dashbuilder-kie-server-backend</module>
   </modules>
 
 </project>

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/perspective/ContentManagerPerspective.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/perspective/ContentManagerPerspective.java
@@ -26,6 +26,7 @@ import org.dashbuilder.client.cms.screen.explorer.PerspectivesExplorerScreen;
 import org.dashbuilder.client.cms.screen.explorer.NavigationExplorerScreen;
 import org.dashbuilder.client.cms.screen.home.ContentManagerHomeScreen;
 import org.gwtbootstrap3.client.ui.constants.IconType;
+import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.uberfire.client.annotations.Perspective;
 import org.uberfire.client.annotations.WorkbenchPerspective;
 import org.uberfire.client.workbench.docks.UberfireDock;
@@ -77,7 +78,7 @@ public class ContentManagerPerspective {
         return perspective;
     }
 
-    @PostConstruct
+    @AfterInitialization
     public void init() {
         perspectivesExplorerDock = new UberfireDock(UberfireDockPosition.WEST,
                 IconType.FILE_TEXT_O.toString(),

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/.gitignore
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/.gitignore
@@ -1,0 +1,17 @@
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+/**/.*
+!.gitignore
+/nbproject
+*.ipr
+*.iws
+*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store
+
+# Bitronix transactin logs
+*.tlog

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.dashbuilder</groupId>
 		<artifactId>dashbuilder-client</artifactId>
-		<version>7.38.0-SNAPSHOT</version>
+		<version>7.39.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>dashbuilder-kie-server-client</artifactId>
 	<packaging>jar</packaging>

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/pom.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+		<groupId>org.dashbuilder</groupId>
+		<artifactId>dashbuilder-client</artifactId>
+		<version>7.38.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>dashbuilder-kie-server-client</artifactId>
+	<packaging>jar</packaging>
+
+	<name>Dashbuilder Kie Server Client</name>
+
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-kie-server-api</artifactId>
+		</dependency>
+		<!-- Dashbuilder -->
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-client-all</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-common-client</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.kie.soup</groupId>
+			<artifactId>kie-soup-dataset-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-dataset-client</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-dataset-client</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-displayer-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-displayer-client</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-displayer-screen</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-renderer-default</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-validations</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.dashbuilder</groupId>
+			<artifactId>dashbuilder-widgets</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Uberfire -->
+
+		<dependency>
+			<groupId>org.uberfire</groupId>
+			<artifactId>uberfire-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.uberfire</groupId>
+			<artifactId>uberfire-commons</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.kie.soup</groupId>
+			<artifactId>kie-soup-commons</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.uberfire</groupId>
+			<artifactId>uberfire-client-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.uberfire</groupId>
+			<artifactId>uberfire-workbench-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.uberfire</groupId>
+			<artifactId>uberfire-workbench-processors</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.uberfire</groupId>
+			<artifactId>uberfire-widgets-commons</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Errai -->
+
+		<dependency>
+			<groupId>org.jboss.errai</groupId>
+			<artifactId>errai-ui</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.errai</groupId>
+			<artifactId>errai-ioc</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.errai</groupId>
+			<artifactId>errai-common</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jboss.errai</groupId>
+			<artifactId>errai-data-binding</artifactId>
+		</dependency>
+
+		<!-- GWT and GWT Extensions -->
+
+		<dependency>
+			<groupId>com.google.gwt</groupId>
+			<artifactId>gwt-user</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/RemoteDataSetDefAttributesEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/RemoteDataSetDefAttributesEditor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor;
+
+import com.google.gwt.editor.client.ValueAwareEditor;
+import org.dashbuilder.common.client.editor.LeafAttributeEditor;
+import org.dashbuilder.common.client.editor.ValueBoxEditor;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+
+/**
+ * <p>The GWT editor contract for the specific attributes of type <code>org.jbpm.workbench.ks.integration.RemoteDataSetDef</code>.</p>
+ * <p>Used to to edit the following sub-set of attributes:</p>
+ * <ul>
+ *     <li>queryTarget</li>
+ *     <li>dataSource</li>
+ *     <li>dbSQL</li>
+ * </ul>
+ */
+public interface RemoteDataSetDefAttributesEditor extends ValueAwareEditor<RemoteDataSetDef> {
+
+    LeafAttributeEditor<String> queryTarget();
+    LeafAttributeEditor<String> serverTemplateId();
+    public ValueBoxEditor<String> dataSource();
+    LeafAttributeEditor<String> dbSQL();
+   
+    
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/RemoteDataSetDefEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/RemoteDataSetDefEditor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor;
+
+import org.dashbuilder.common.client.editor.LeafAttributeEditor;
+import org.dashbuilder.common.client.editor.ValueBoxEditor;
+import org.dashbuilder.dataset.client.editor.DataSetDefEditor;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+
+public interface RemoteDataSetDefEditor extends DataSetDefEditor<RemoteDataSetDef> {
+
+    LeafAttributeEditor<String> queryTarget();
+    LeafAttributeEditor<String> serverTemplateId();
+    public ValueBoxEditor<String> dataSource();
+    LeafAttributeEditor<String> dbSQL();
+    
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/RemoteDataSetEditorDriverFactory.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/RemoteDataSetEditorDriverFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import com.google.gwt.core.client.GWT;
+import org.dashbuilder.client.kieserver.dataset.editor.driver.RemoteDataSetDefAttributesDriver;
+import org.dashbuilder.client.kieserver.dataset.editor.driver.RemoteDataSetDefDriver;
+
+
+@ApplicationScoped
+public class RemoteDataSetEditorDriverFactory {
+
+    final RemoteDataSetDefAttributesDriver remoteDataSetDefAttributesDriver = GWT.create(RemoteDataSetDefAttributesDriver.class);
+
+    final RemoteDataSetDefDriver remoteDataSetDefDriver = GWT.create(RemoteDataSetDefDriver.class);
+
+    @Produces
+    public RemoteDataSetDefDriver remoteDataSetDefDriver() {
+        return remoteDataSetDefDriver;
+    }
+
+    @Produces
+    public RemoteDataSetDefAttributesDriver remoteDataSetDefAttributesDriver() {
+        return remoteDataSetDefAttributesDriver;
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/driver/RemoteDataSetDefAttributesDriver.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/driver/RemoteDataSetDefAttributesDriver.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor.driver;
+
+import com.google.gwt.editor.client.SimpleBeanEditorDriver;
+import org.dashbuilder.client.kieserver.dataset.editor.RemoteDataSetDefAttributesEditor;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+
+/**
+ * <p>Driver for RemoteDataSetDefAttributesEditor.</p>
+ * 
+ */
+public interface RemoteDataSetDefAttributesDriver extends SimpleBeanEditorDriver<RemoteDataSetDef, RemoteDataSetDefAttributesEditor> {
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/driver/RemoteDataSetDefDriver.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/driver/RemoteDataSetDefDriver.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor.driver;
+
+import com.google.gwt.editor.client.SimpleBeanEditorDriver;
+import org.dashbuilder.client.kieserver.dataset.editor.RemoteDataSetDefEditor;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+
+/**
+ * <p>Driver for RemoteDataSetDefEditor.</p>
+ * 
+ */
+public interface RemoteDataSetDefDriver extends SimpleBeanEditorDriver<RemoteDataSetDef, RemoteDataSetDefEditor> {
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorImpl.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorImpl.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.editor.client.EditorDelegate;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import org.dashbuilder.client.kieserver.dataset.editor.RemoteDataSetDefAttributesEditor;
+import org.dashbuilder.client.kieserver.resources.i18n.KieServerClientConstants;
+import org.dashbuilder.common.client.editor.ValueBoxEditor;
+import org.dashbuilder.common.client.editor.list.DropDownEditor;
+import org.dashbuilder.kieserver.KieServerConnectionInfoProvider;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.gwtbootstrap3.client.ui.constants.Placement;
+import org.jboss.errai.common.client.api.Caller;
+import org.uberfire.client.mvp.UberView;
+
+/**
+ * <p>KIE Server/Remote Data Set specific attributes editor presenter.</p>
+ */
+@Dependent
+public class RemoteDataSetDefAttributesEditorImpl implements IsWidget, RemoteDataSetDefAttributesEditor {
+
+    public interface View extends UberView<RemoteDataSetDefAttributesEditorImpl> {
+
+        /**
+         * <p>Specify the views to use for each sub-editor before calling <code>initWidget</code>.</p>
+         */
+        void initWidgets(DropDownEditor.View queryTarget,
+                         DropDownEditor.View serverTemplateId,
+                         ValueBoxEditor.View dbSourceName,
+                         ValueBoxEditor.View dbSQL);
+
+    }
+
+    DropDownEditor queryTarget;
+    DropDownEditor serverTemplateId;
+    ValueBoxEditor<String> dataSource;
+
+    ValueBoxEditor<String> dbSQL;
+    public View view;
+
+    private Caller<KieServerConnectionInfoProvider> kieServerConnectionInfoProvider;
+
+    @Inject
+    public RemoteDataSetDefAttributesEditorImpl(final DropDownEditor queryTarget,
+                                                final DropDownEditor serverTemplateId,
+                                                final ValueBoxEditor<String> dataSource,
+                                                final ValueBoxEditor<String> dbSQL,
+                                                final View view,
+                                                final Caller<KieServerConnectionInfoProvider> specManagementService) {
+        this.queryTarget = queryTarget;
+        this.serverTemplateId = serverTemplateId;
+        this.dataSource = dataSource;
+        this.dbSQL = dbSQL;
+        this.view = view;
+
+        this.kieServerConnectionInfoProvider = specManagementService;
+    }
+
+    @PostConstruct
+    public void init() {
+        view.init(this);
+        view.initWidgets(queryTarget.view, serverTemplateId.view, dataSource.view, dbSQL.view);
+
+        queryTarget.setSelectHint(KieServerClientConstants.INSTANCE.remote_query_target_hint());
+        List<DropDownEditor.Entry> entries = Stream.of("CUSTOM",
+                                                       "PROCESS",
+                                                       "TASK",
+                                                       "BA_TASK",
+                                                       "PO_TASK",
+                                                       "JOBS",
+                                                       "FILTERED_PROCESS",
+                                                       "FILTERED_BA_TASK",
+                                                       "FILTERED_PO_TASK")
+                                                   .map(s -> queryTarget.newEntry(s, s)).collect(Collectors.toList());
+        queryTarget.setEntries(entries);
+
+        queryTarget.addHelpContent(KieServerClientConstants.INSTANCE.remote_query_target(),
+                                   KieServerClientConstants.INSTANCE.remote_query_target_description(),
+                                   Placement.RIGHT); //bottom placement would interfere with the dropdown
+
+        serverTemplateId.setSelectHint(KieServerClientConstants.INSTANCE.remote_server_template_hint());
+
+        kieServerConnectionInfoProvider.call((List<String> serverTemplates) -> onServerTemplateLoad(serverTemplates)).serverTemplates();
+
+        serverTemplateId.addHelpContent(KieServerClientConstants.INSTANCE.remote_server_template(),
+                                        KieServerClientConstants.INSTANCE.remote_server_template_description(),
+                                        Placement.RIGHT);
+
+        dataSource.addHelpContent(KieServerClientConstants.INSTANCE.remote_data_set_editor(),
+                                  KieServerClientConstants.INSTANCE.remote_datasource_description(),
+                                  Placement.BOTTOM);
+
+        dbSQL.addHelpContent(KieServerClientConstants.INSTANCE.remote_data_set_editor(),
+                             KieServerClientConstants.INSTANCE.remote_datasource_description(),
+                             Placement.BOTTOM);
+    }
+
+    private void onServerTemplateLoad(List<String> templates) {
+        List<DropDownEditor.Entry> entries = templates.stream().map(st -> serverTemplateId.newEntry(st, st)).collect(Collectors.toList());
+        serverTemplateId.setEntries(entries);
+    }
+
+    /*************************************************************
+     ** GWT EDITOR CONTRACT METHODS **
+     *************************************************************/
+
+    @Override
+    public Widget asWidget() {
+        return view.asWidget();
+    }
+
+    @Override
+    public DropDownEditor queryTarget() {
+        return queryTarget;
+    }
+
+    @Override
+    public DropDownEditor serverTemplateId() {
+        return serverTemplateId;
+    }
+
+    @Override
+    public ValueBoxEditor<String> dataSource() {
+        return dataSource;
+    }
+
+    @Override
+    public ValueBoxEditor<String> dbSQL() {
+        return dbSQL;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public void onPropertyChange(final String... paths) {
+
+    }
+
+    @Override
+    public void setDelegate(final EditorDelegate<RemoteDataSetDef> delegate) {
+        // No delegation required.
+    }
+
+    @Override
+    public void setValue(RemoteDataSetDef value) {
+        queryTarget.setValue(value.getQueryTarget());
+        serverTemplateId.setValue(value.getServerTemplateId());
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorImpl.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorImpl.java
@@ -85,7 +85,7 @@ public class RemoteDataSetDefAttributesEditorImpl implements IsWidget, RemoteDat
         view.init(this);
         view.initWidgets(queryTarget.view, serverTemplateId.view, dataSource.view, dbSQL.view);
 
-        queryTarget.setSelectHint(KieServerClientConstants.INSTANCE.remote_query_target_hint());
+        queryTarget.setSelectHint(KieServerClientConstants.INSTANCE.remoteQueryTargetHint());
         List<DropDownEditor.Entry> entries = Stream.of("CUSTOM",
                                                        "PROCESS",
                                                        "TASK",
@@ -98,24 +98,24 @@ public class RemoteDataSetDefAttributesEditorImpl implements IsWidget, RemoteDat
                                                    .map(s -> queryTarget.newEntry(s, s)).collect(Collectors.toList());
         queryTarget.setEntries(entries);
 
-        queryTarget.addHelpContent(KieServerClientConstants.INSTANCE.remote_query_target(),
-                                   KieServerClientConstants.INSTANCE.remote_query_target_description(),
+        queryTarget.addHelpContent(KieServerClientConstants.INSTANCE.remoteQueryTarget(),
+                                   KieServerClientConstants.INSTANCE.remoteQueryTargetDescription(),
                                    Placement.RIGHT); //bottom placement would interfere with the dropdown
 
-        serverTemplateId.setSelectHint(KieServerClientConstants.INSTANCE.remote_server_template_hint());
+        serverTemplateId.setSelectHint(KieServerClientConstants.INSTANCE.remoteServerTemplateHint());
 
         kieServerConnectionInfoProvider.call((List<String> serverTemplates) -> onServerTemplateLoad(serverTemplates)).serverTemplates();
 
-        serverTemplateId.addHelpContent(KieServerClientConstants.INSTANCE.remote_server_template(),
-                                        KieServerClientConstants.INSTANCE.remote_server_template_description(),
+        serverTemplateId.addHelpContent(KieServerClientConstants.INSTANCE.remoteServerTemplate(),
+                                        KieServerClientConstants.INSTANCE.remoteServerTemplateDescription(),
                                         Placement.RIGHT);
 
-        dataSource.addHelpContent(KieServerClientConstants.INSTANCE.remote_data_set_editor(),
-                                  KieServerClientConstants.INSTANCE.remote_datasource_description(),
+        dataSource.addHelpContent(KieServerClientConstants.INSTANCE.remoteDataSetEditor(),
+                                  KieServerClientConstants.INSTANCE.remoteDatasourceDescription(),
                                   Placement.BOTTOM);
 
-        dbSQL.addHelpContent(KieServerClientConstants.INSTANCE.remote_data_set_editor(),
-                             KieServerClientConstants.INSTANCE.remote_datasource_description(),
+        dbSQL.addHelpContent(KieServerClientConstants.INSTANCE.remoteDataSetEditor(),
+                             KieServerClientConstants.INSTANCE.remoteDatasourceDescription(),
                              Placement.BOTTOM);
     }
 
@@ -155,12 +155,12 @@ public class RemoteDataSetDefAttributesEditorImpl implements IsWidget, RemoteDat
 
     @Override
     public void flush() {
-
+        // empty
     }
 
     @Override
     public void onPropertyChange(final String... paths) {
-
+        // empty
     }
 
     @Override

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorView.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor.impl;
+
+import javax.enterprise.context.Dependent;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.dashbuilder.common.client.editor.ValueBoxEditor;
+import org.dashbuilder.common.client.editor.list.DropDownEditor;
+
+/**
+ * <p>The KIE Server/Remote Data Set attributes editor view.</p>
+ *
+ */
+@Dependent
+public class RemoteDataSetDefAttributesEditorView extends Composite implements RemoteDataSetDefAttributesEditorImpl.View {
+
+    interface Binder extends UiBinder<Widget, RemoteDataSetDefAttributesEditorView> {
+        Binder BINDER = GWT.create(Binder.class);
+    }
+
+    RemoteDataSetDefAttributesEditorImpl presenter;
+
+    @UiField(provided = true)
+    DropDownEditor.View queryTarget;
+    
+    @UiField(provided = true)
+    DropDownEditor.View serverTemplateId;
+
+    @UiField(provided = true)
+    ValueBoxEditor.View dataSource;
+
+    @UiField
+    FlowPanel dbSQLPanel;
+
+    @UiField(provided = true)
+    ValueBoxEditor.View dbSQL;
+
+    @Override
+    public void init(final RemoteDataSetDefAttributesEditorImpl presenter) {
+        this.presenter = presenter;
+    }
+    
+    @Override
+    public void initWidgets(final DropDownEditor.View queryTarget, final DropDownEditor.View serverTemplateId, final ValueBoxEditor.View dataSource,
+                            final ValueBoxEditor.View dbSQL) {
+        this.queryTarget = queryTarget;
+        this.serverTemplateId = serverTemplateId;
+        this.dataSource = dataSource;
+        this.dbSQL = dbSQL;
+        initWidget(Binder.BINDER.createAndBindUi(this));
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorView.ui.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorView.ui.xml
@@ -1,0 +1,95 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+             xmlns:g="urn:import:com.google.gwt.user.client.ui"
+             xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+             xmlns:editor="urn:import:org.dashbuilder.common.client.editor"
+             xmlns:ddwn="urn:import:org.dashbuilder.common.client.editor.list">
+
+  <ui:with field="i18n" type="org.dashbuilder.client.kieserver.resources.i18n.KieServerClientConstants"/>
+
+  <ui:style>
+    .sourceSelectorButton {
+      float: left;
+      margin-right: 10px;
+    }
+    .queryBox {
+      height: 200px;
+    }
+    .row {
+      margin-bottom: 5px;
+    }
+    .attr {
+      float: left;
+      margin-right: 5px;
+    }
+  </ui:style>
+
+  <b:Container fluid="true">
+
+    <!-- source -->
+    <b:Row addStyleNames="{style.row}">
+      <b:Column size="MD_3">
+        <g:HTML text="{i18n.remote_sql_datasource}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_datasource_description}">
+          <b:Icon type="QUESTION_CIRCLE" />
+        </b:Tooltip>
+      </b:Column>
+      <b:Column size="MD_9">
+        <editor:ValueBoxEditor.View ui:field="dataSource">
+          <editor:valuebox>
+            <b:TextBox />
+          </editor:valuebox>
+        </editor:ValueBoxEditor.View>
+      </b:Column>
+    </b:Row>
+    
+    <!-- server template id -->
+    <b:Row addStyleNames="{style.row}">
+      <b:Column size="MD_3">
+        <g:HTML text="{i18n.remote_server_template}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_server_template_description}">
+          <b:Icon type="QUESTION_CIRCLE" />
+        </b:Tooltip>
+      </b:Column>
+      <b:Column size="MD_9">
+        <ddwn:DropDownEditor.View ui:field="serverTemplateId" />
+      </b:Column>
+    </b:Row>
+    
+    <!-- target -->
+    <b:Row addStyleNames="{style.row}">
+      <b:Column size="MD_3">
+        <g:HTML text="{i18n.remote_query_target}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_query_target_description}">
+          <b:Icon type="QUESTION_CIRCLE" />
+        </b:Tooltip>
+      </b:Column>
+      <b:Column size="MD_9">
+        <ddwn:DropDownEditor.View ui:field="queryTarget" />
+      </b:Column>
+    </b:Row>
+
+    <!-- Source selector (table or query). -->
+    <b:Row addStyleNames="{style.row}">
+      <b:Column size="MD_3">
+        <g:HTML text="{i18n.remote_sql_source}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_source_description}">
+          <b:Icon type="QUESTION_CIRCLE" />
+        </b:Tooltip>
+      </b:Column>
+      <b:Column size="MD_9">
+
+        <g:FlowPanel ui:field="dbSQLPanel">
+          <editor:ValueBoxEditor.View ui:field="dbSQL">
+            <editor:valuebox>
+              <b:TextArea placeholder="{i18n.remote_query_placeHolder}" addStyleNames="{style.queryBox}"/>
+            </editor:valuebox>
+          </editor:ValueBoxEditor.View>
+        </g:FlowPanel>
+
+      </b:Column>
+    </b:Row>
+    
+  </b:Container>
+  
+</ui:UiBinder>

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorView.ui.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetDefAttributesEditorView.ui.xml
@@ -29,8 +29,8 @@
     <!-- source -->
     <b:Row addStyleNames="{style.row}">
       <b:Column size="MD_3">
-        <g:HTML text="{i18n.remote_sql_datasource}" addStyleNames="{style.attr}"/>
-        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_datasource_description}">
+        <g:HTML text="{i18n.remoteSqlDatasource}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remoteDatasourceDescription}">
           <b:Icon type="QUESTION_CIRCLE" />
         </b:Tooltip>
       </b:Column>
@@ -46,8 +46,8 @@
     <!-- server template id -->
     <b:Row addStyleNames="{style.row}">
       <b:Column size="MD_3">
-        <g:HTML text="{i18n.remote_server_template}" addStyleNames="{style.attr}"/>
-        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_server_template_description}">
+        <g:HTML text="{i18n.remoteServerTemplate}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remoteServerTemplateDescription}">
           <b:Icon type="QUESTION_CIRCLE" />
         </b:Tooltip>
       </b:Column>
@@ -59,8 +59,8 @@
     <!-- target -->
     <b:Row addStyleNames="{style.row}">
       <b:Column size="MD_3">
-        <g:HTML text="{i18n.remote_query_target}" addStyleNames="{style.attr}"/>
-        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_query_target_description}">
+        <g:HTML text="{i18n.remoteQueryTarget}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remoteQueryTargetDescription}">
           <b:Icon type="QUESTION_CIRCLE" />
         </b:Tooltip>
       </b:Column>
@@ -72,8 +72,8 @@
     <!-- Source selector (table or query). -->
     <b:Row addStyleNames="{style.row}">
       <b:Column size="MD_3">
-        <g:HTML text="{i18n.remote_sql_source}" addStyleNames="{style.attr}"/>
-        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remote_source_description}">
+        <g:HTML text="{i18n.remoteSqlSource}" addStyleNames="{style.attr}"/>
+        <b:Tooltip isAnimated="true" placement="BOTTOM" title="{i18n.remoteSourceDescription}">
           <b:Icon type="QUESTION_CIRCLE" />
         </b:Tooltip>
       </b:Column>
@@ -82,7 +82,7 @@
         <g:FlowPanel ui:field="dbSQLPanel">
           <editor:ValueBoxEditor.View ui:field="dbSQL">
             <editor:valuebox>
-              <b:TextArea placeholder="{i18n.remote_query_placeHolder}" addStyleNames="{style.queryBox}"/>
+              <b:TextArea placeholder="{i18n.remoteQueryPlaceHolder}" addStyleNames="{style.queryBox}"/>
             </editor:valuebox>
           </editor:ValueBoxEditor.View>
         </g:FlowPanel>

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.client.kieserver.dataset.editor.impl;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.dashbuilder.client.kieserver.dataset.editor.RemoteDataSetDefEditor;
+import org.dashbuilder.client.widgets.common.LoadingBox;
+import org.dashbuilder.client.widgets.dataset.editor.DataSetDefColumnsFilterEditor;
+import org.dashbuilder.client.widgets.dataset.editor.DataSetDefPreviewTable;
+import org.dashbuilder.client.widgets.dataset.editor.DataSetEditor;
+import org.dashbuilder.client.widgets.dataset.editor.attributes.DataSetDefBackendCacheAttributesEditor;
+import org.dashbuilder.client.widgets.dataset.editor.attributes.DataSetDefBasicAttributesEditor;
+import org.dashbuilder.client.widgets.dataset.editor.attributes.DataSetDefClientCacheAttributesEditor;
+import org.dashbuilder.client.widgets.dataset.editor.attributes.DataSetDefRefreshAttributesEditor;
+import org.dashbuilder.client.widgets.dataset.event.ErrorEvent;
+import org.dashbuilder.client.widgets.dataset.event.TabChangedEvent;
+import org.dashbuilder.common.client.editor.ValueBoxEditor;
+import org.dashbuilder.common.client.editor.list.DropDownEditor;
+import org.dashbuilder.dataset.client.DataSetClientServices;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+
+/**
+ * <p>KIE Server/Remote Data Set editor presenter.</p>
+ * 
+ */
+@Dependent
+public class RemoteDataSetEditor extends DataSetEditor<RemoteDataSetDef> implements RemoteDataSetDefEditor {
+
+    RemoteDataSetDefAttributesEditorImpl attributesEditor;
+    
+    @Inject
+    public RemoteDataSetEditor(final DataSetDefBasicAttributesEditor basicAttributesEditor,
+                            final RemoteDataSetDefAttributesEditorImpl attributesEditor,
+                            final DataSetDefColumnsFilterEditor columnsAndFilterEditor,
+                            final DataSetDefPreviewTable previewTable,
+                            final DataSetDefBackendCacheAttributesEditor backendCacheAttributesEditor,
+                            final DataSetDefClientCacheAttributesEditor clientCacheAttributesEditor,
+                            final DataSetDefRefreshAttributesEditor refreshEditor,
+                            final DataSetClientServices clientServices,
+                            final LoadingBox loadingBox,
+                            final Event<ErrorEvent> errorEvent,
+                            final Event<TabChangedEvent> tabChangedEvent,
+                            final View view) {
+        super(basicAttributesEditor, attributesEditor.view, columnsAndFilterEditor, 
+                previewTable, backendCacheAttributesEditor, clientCacheAttributesEditor,
+                refreshEditor, clientServices, loadingBox, errorEvent, tabChangedEvent, view);
+        this.attributesEditor = attributesEditor;
+    }
+
+    @PostConstruct
+    public void init() {
+        // Initialize the generic data set editor view.
+        super.init();
+    }
+
+    public RemoteDataSetDefAttributesEditorImpl getAttributesEditor() {
+        return attributesEditor;
+    }
+
+    /*************************************************************
+     ** GWT EDITOR CONTRACT METHODS **
+     *************************************************************/
+
+    @Override
+    public DropDownEditor queryTarget() {
+        return attributesEditor.queryTarget();
+    }
+
+    @Override
+    public ValueBoxEditor<String> dataSource() {
+        return attributesEditor.dataSource();
+    }
+
+    @Override
+    public ValueBoxEditor<String> dbSQL() {
+        return attributesEditor.dbSQL();
+    }
+
+    @Override
+    public DropDownEditor serverTemplateId() {
+        return attributesEditor.serverTemplateId();
+    }
+
+    @Override
+    public void setValue(RemoteDataSetDef value) {       
+        super.setValue(value);
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditor.java
@@ -44,23 +44,23 @@ import org.dashbuilder.kieserver.RemoteDataSetDef;
 public class RemoteDataSetEditor extends DataSetEditor<RemoteDataSetDef> implements RemoteDataSetDefEditor {
 
     RemoteDataSetDefAttributesEditorImpl attributesEditor;
-    
+
     @Inject
     public RemoteDataSetEditor(final DataSetDefBasicAttributesEditor basicAttributesEditor,
-                            final RemoteDataSetDefAttributesEditorImpl attributesEditor,
-                            final DataSetDefColumnsFilterEditor columnsAndFilterEditor,
-                            final DataSetDefPreviewTable previewTable,
-                            final DataSetDefBackendCacheAttributesEditor backendCacheAttributesEditor,
-                            final DataSetDefClientCacheAttributesEditor clientCacheAttributesEditor,
-                            final DataSetDefRefreshAttributesEditor refreshEditor,
-                            final DataSetClientServices clientServices,
-                            final LoadingBox loadingBox,
-                            final Event<ErrorEvent> errorEvent,
-                            final Event<TabChangedEvent> tabChangedEvent,
-                            final View view) {
-        super(basicAttributesEditor, attributesEditor.view, columnsAndFilterEditor, 
-                previewTable, backendCacheAttributesEditor, clientCacheAttributesEditor,
-                refreshEditor, clientServices, loadingBox, errorEvent, tabChangedEvent, view);
+                               final RemoteDataSetDefAttributesEditorImpl attributesEditor,
+                               final DataSetDefColumnsFilterEditor columnsAndFilterEditor,
+                               final DataSetDefPreviewTable previewTable,
+                               final DataSetDefBackendCacheAttributesEditor backendCacheAttributesEditor,
+                               final DataSetDefClientCacheAttributesEditor clientCacheAttributesEditor,
+                               final DataSetDefRefreshAttributesEditor refreshEditor,
+                               final DataSetClientServices clientServices,
+                               final LoadingBox loadingBox,
+                               final Event<ErrorEvent> errorEvent,
+                               final Event<TabChangedEvent> tabChangedEvent,
+                               final View view) {
+        super(basicAttributesEditor, attributesEditor.view, columnsAndFilterEditor,
+              previewTable, backendCacheAttributesEditor, clientCacheAttributesEditor,
+              refreshEditor, clientServices, loadingBox, errorEvent, tabChangedEvent, view);
         this.attributesEditor = attributesEditor;
     }
 
@@ -99,7 +99,7 @@ public class RemoteDataSetEditor extends DataSetEditor<RemoteDataSetDef> impleme
     }
 
     @Override
-    public void setValue(RemoteDataSetDef value) {       
+    public void setValue(RemoteDataSetDef value) {
         super.setValue(value);
     }
 

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditorPlugin.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditorPlugin.java
@@ -34,12 +34,12 @@ public class RemoteDataSetEditorPlugin implements DataSetEditorPlugin {
     
     @Override
     public String getTypeSelectorTitle() {
-        return KieServerClientConstants.INSTANCE.remote_data_set_editor();
+        return KieServerClientConstants.INSTANCE.remoteDataSetEditor();
     }
 
     @Override
     public String getTypeSelectorText() {
-        return KieServerClientConstants.INSTANCE.remote_data_set_editor_description();
+        return KieServerClientConstants.INSTANCE.remoteDataSetEditorDescription();
     }
 
     @Override

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditorPlugin.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/impl/RemoteDataSetEditorPlugin.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor.impl;
+
+import javax.enterprise.context.Dependent;
+
+import com.google.gwt.safehtml.shared.SafeUri;
+import org.dashbuilder.client.kieserver.dataset.editor.workflow.RemoteDataSetBasicAttributesWorkflow;
+import org.dashbuilder.client.kieserver.dataset.editor.workflow.RemoteDataSetEditWorkflow;
+import org.dashbuilder.client.kieserver.resources.i18n.KieServerClientConstants;
+import org.dashbuilder.client.widgets.common.DataSetEditorPlugin;
+import org.dashbuilder.dataprovider.DataSetProviderType;
+import org.dashbuilder.dataset.client.resources.bundles.DataSetClientResources;
+import org.dashbuilder.kieserver.RuntimeKieServerDataSetProviderType;
+
+@Dependent
+public class RemoteDataSetEditorPlugin implements DataSetEditorPlugin {
+
+    private static DataSetProviderType TYPE = new RuntimeKieServerDataSetProviderType();
+    
+    @Override
+    public String getTypeSelectorTitle() {
+        return KieServerClientConstants.INSTANCE.remote_data_set_editor();
+    }
+
+    @Override
+    public String getTypeSelectorText() {
+        return KieServerClientConstants.INSTANCE.remote_data_set_editor_description();
+    }
+
+    @Override
+    public SafeUri getTypeSelectorImageUri() {
+        return DataSetClientResources.INSTANCE.images().sqlIcon160().getSafeUri();
+    }
+
+    @Override
+    public DataSetProviderType getProviderType() {
+        return TYPE;
+    }
+
+    @Override
+    public Class<?> getBasicAttributesWorkflowClass() {
+        return RemoteDataSetBasicAttributesWorkflow.class;
+    }
+
+    @Override
+    public Class<?> getWorkflowClass() {
+        return RemoteDataSetEditWorkflow.class;
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/validator/RemoteDataSetDefValidator.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/validator/RemoteDataSetDefValidator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.dataset.editor.validator;
+
+import java.util.Set;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+
+import org.dashbuilder.dataprovider.DataSetProviderType;
+import org.dashbuilder.dataset.validation.groups.SQLDataSetDefDbSQLValidation;
+import org.dashbuilder.dataset.validation.groups.SQLDataSetDefValidation;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.dashbuilder.kieserver.RemoteDataSetDefValidation;
+import org.dashbuilder.kieserver.RuntimeKieServerDataSetProviderType;
+import org.dashbuilder.validations.dataset.AbstractDataSetDefValidator;
+
+/**
+ * <p>The singleton application Remote data set definition validator.</p>
+ */
+@Dependent
+public class RemoteDataSetDefValidator extends AbstractDataSetDefValidator<RemoteDataSetDef> {
+
+    @Inject
+    public RemoteDataSetDefValidator(Validator validator) {
+        super(validator);
+    }
+
+    @Override
+    public DataSetProviderType getSupportedProvider() {
+        return new RuntimeKieServerDataSetProviderType();
+    }
+
+    @Override
+    public Iterable<ConstraintViolation<?>> validateCustomAttributes(RemoteDataSetDef dataSetDef, Object... params) {
+
+        Set<ConstraintViolation<RemoteDataSetDef>> _violations = validator.validate(dataSetDef,
+                                                                                    RemoteDataSetDefValidation.class,
+                                                                                    SQLDataSetDefValidation.class,
+                                                                                    SQLDataSetDefDbSQLValidation.class);
+        return toIterable(_violations);
+    }
+
+    @Override
+    public Iterable<ConstraintViolation<?>> validate(RemoteDataSetDef dataSetDef,
+                                                     boolean isCacheEnabled,
+                                                     boolean isPushEnabled,
+                                                     boolean isRefreshEnabled,
+                                                     Object... params) {
+
+        Set<ConstraintViolation<RemoteDataSetDef>> _violations = validator.validate(dataSetDef,
+                                                                                    getValidationGroups(isCacheEnabled,
+                                                                                                        isPushEnabled,
+                                                                                                        isRefreshEnabled,
+                                                                                                        RemoteDataSetDefValidation.class,
+                                                                                                        SQLDataSetDefValidation.class,
+                                                                                                        SQLDataSetDefDbSQLValidation.class));
+        return toIterable(_violations);
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/validator/RemoteDataSetDefValidator.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/validator/RemoteDataSetDefValidator.java
@@ -50,11 +50,11 @@ public class RemoteDataSetDefValidator extends AbstractDataSetDefValidator<Remot
     @Override
     public Iterable<ConstraintViolation<?>> validateCustomAttributes(RemoteDataSetDef dataSetDef, Object... params) {
 
-        Set<ConstraintViolation<RemoteDataSetDef>> _violations = validator.validate(dataSetDef,
+        Set<ConstraintViolation<RemoteDataSetDef>> violations = validator.validate(dataSetDef,
                                                                                     RemoteDataSetDefValidation.class,
                                                                                     SQLDataSetDefValidation.class,
                                                                                     SQLDataSetDefDbSQLValidation.class);
-        return toIterable(_violations);
+        return toIterable(violations);
     }
 
     @Override

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/workflow/RemoteDataSetBasicAttributesWorkflow.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/workflow/RemoteDataSetBasicAttributesWorkflow.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.client.kieserver.dataset.editor.workflow;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+
+import com.google.gwt.editor.client.SimpleBeanEditorDriver;
+import org.dashbuilder.client.kieserver.dataset.editor.RemoteDataSetDefAttributesEditor;
+import org.dashbuilder.client.kieserver.dataset.editor.driver.RemoteDataSetDefAttributesDriver;
+import org.dashbuilder.client.widgets.dataset.editor.attributes.DataSetDefBasicAttributesEditor;
+import org.dashbuilder.client.widgets.dataset.editor.workflow.create.DataSetBasicAttributesWorkflow;
+import org.dashbuilder.client.widgets.dataset.event.CancelRequestEvent;
+import org.dashbuilder.client.widgets.dataset.event.SaveRequestEvent;
+import org.dashbuilder.client.widgets.dataset.event.TestDataSetRequestEvent;
+import org.dashbuilder.client.widgets.resources.i18n.DataSetEditorConstants;
+import org.dashbuilder.common.client.error.ClientRuntimeError;
+import org.dashbuilder.dataset.DataSet;
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetLookupFactory;
+import org.dashbuilder.dataset.client.DataSetClientServices;
+import org.dashbuilder.dataset.client.DataSetReadyCallback;
+import org.dashbuilder.dataset.def.DataSetDef;
+import org.dashbuilder.displayer.client.DataSetEditHandler;
+import org.dashbuilder.displayer.client.DataSetHandler;
+import org.dashbuilder.kieserver.ConsoleDataSetLookup;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.dashbuilder.validations.DataSetValidatorProvider;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+
+/**
+ * <p>SQL Data Set Editor workflow presenter for setting data set definition basic attributes.</p>
+ */
+@Dependent
+public class RemoteDataSetBasicAttributesWorkflow extends DataSetBasicAttributesWorkflow<RemoteDataSetDef, RemoteDataSetDefAttributesEditor> {
+
+    @Inject
+    public RemoteDataSetBasicAttributesWorkflow(final DataSetClientServices clientServices,
+                                                final DataSetValidatorProvider validatorProvider,
+                                                final SyncBeanManager beanManager,
+                                                final DataSetDefBasicAttributesEditor basicAttributesEditor,
+                                                final Event<SaveRequestEvent> saveRequestEvent,
+                                                final Event<TestDataSetRequestEvent> testDataSetEvent,
+                                                final Event<CancelRequestEvent> cancelRequestEvent,
+                                                final View view) {
+
+        super(clientServices,
+              validatorProvider,
+              beanManager,
+              basicAttributesEditor,
+              saveRequestEvent,
+              testDataSetEvent,
+              cancelRequestEvent,
+              view);
+    }
+
+    @Override
+    protected Class<? extends SimpleBeanEditorDriver<RemoteDataSetDef, RemoteDataSetDefAttributesEditor>> getDriverClass() {
+        return RemoteDataSetDefAttributesDriver.class;
+    }
+
+    @Override
+    protected Class<? extends RemoteDataSetDefAttributesEditor> getEditorClass() {
+        return RemoteDataSetDefAttributesEditor.class;
+    }
+
+    @Override
+    protected Iterable<ConstraintViolation<?>> validate() {
+        return validatorProvider.validateAttributes(getDataSetDef());
+    }
+
+    @Override
+    public void testDataSet(org.dashbuilder.client.widgets.dataset.editor.workflow.DataSetEditorWorkflow.TestDataSetCallback testDataSetCallback) {
+        checkDataSetDefNotNull();
+
+        // Reset columns and filter configuration.
+        getDataSetDef().setAllColumnsEnabled(true);
+        getDataSetDef().setColumns(null);
+        getDataSetDef().setDataSetFilter(null);
+
+        DataSetDef editCloneWithoutCacheSettings = getDataSetDef().clone();
+        editCloneWithoutCacheSettings.setCacheEnabled(false);
+
+        final DataSetLookup lookup = DataSetLookupFactory.newDataSetLookupBuilder()
+                                                         .dataset(dataSetDef.getUUID())
+                                                         .rowOffset(0)
+                                                         .rowNumber(10)
+                                                         .buildLookup();
+
+        try {
+            DataSetHandler editHandler = new DataSetEditHandler(clientServices,
+                                                                ConsoleDataSetLookup.fromInstance(lookup, getDataSetDef().getServerTemplateId()),
+                                                                editCloneWithoutCacheSettings);
+            editHandler.lookupDataSet(new DataSetReadyCallback() {
+
+                @Override
+                public void callback(final DataSet dataSet) {
+                    getDataSetDef().setColumns(dataSet.getDefinition().getColumns());
+                    testDataSetCallback.onSuccess(dataSet);
+                }
+
+                @Override
+                public void notFound() {
+                    testDataSetCallback.onError(new ClientRuntimeError(DataSetEditorConstants.INSTANCE.defNotFound()));
+                }
+
+                @Override
+                public boolean onError(final ClientRuntimeError error) {
+                    testDataSetCallback.onError(error);
+                    return false;
+                }
+            });
+        } catch (final Exception e) {
+            testDataSetCallback.onError(new ClientRuntimeError(e));
+        }
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/workflow/RemoteDataSetEditWorkflow.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/dataset/editor/workflow/RemoteDataSetEditWorkflow.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.client.kieserver.dataset.editor.workflow;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+
+import com.google.gwt.editor.client.SimpleBeanEditorDriver;
+import org.dashbuilder.client.kieserver.dataset.editor.RemoteDataSetDefEditor;
+import org.dashbuilder.client.kieserver.dataset.editor.driver.RemoteDataSetDefDriver;
+import org.dashbuilder.client.widgets.dataset.editor.workflow.edit.DataSetEditWorkflow;
+import org.dashbuilder.client.widgets.dataset.event.CancelRequestEvent;
+import org.dashbuilder.client.widgets.dataset.event.SaveRequestEvent;
+import org.dashbuilder.client.widgets.dataset.event.TestDataSetRequestEvent;
+import org.dashbuilder.client.widgets.resources.i18n.DataSetEditorConstants;
+import org.dashbuilder.common.client.error.ClientRuntimeError;
+import org.dashbuilder.dataset.DataSet;
+import org.dashbuilder.dataset.DataSetFactory;
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.client.DataSetClientServices;
+import org.dashbuilder.dataset.client.DataSetReadyCallback;
+import org.dashbuilder.dataset.def.DataSetDef;
+import org.dashbuilder.displayer.client.DataSetEditHandler;
+import org.dashbuilder.displayer.client.DataSetHandler;
+import org.dashbuilder.kieserver.ConsoleDataSetLookup;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
+import org.dashbuilder.validations.DataSetValidatorProvider;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+
+/**
+ * <p>SQL Data Set Editor workflow presenter for editing a data set definition instance.</p>
+ * <p>This class is the main entry point for editing an existing data set definition instance. It links the gwt editors with the given driver to perform flushing and validations.</p>
+ * @since 0.4.0
+ */
+@Dependent
+public class RemoteDataSetEditWorkflow extends DataSetEditWorkflow<RemoteDataSetDef, RemoteDataSetDefEditor> {
+
+    @Inject
+    public RemoteDataSetEditWorkflow(final DataSetClientServices clientServices,
+                                     final DataSetValidatorProvider validatorProvider,
+                                     final SyncBeanManager beanManager,
+                                     final Event<SaveRequestEvent> saveRequestEvent,
+                                     final Event<TestDataSetRequestEvent> testDataSetEvent,
+                                     final Event<CancelRequestEvent> cancelRequestEvent,
+                                     final View view) {
+        super(clientServices,
+              validatorProvider,
+              beanManager,
+              saveRequestEvent,
+              testDataSetEvent,
+              cancelRequestEvent,
+              view);
+    }
+
+    @Override
+    public void testDataSet(TestDataSetCallback testDataSetCallback) {
+        checkDataSetDefNotNull();
+
+        // Reset columns and filter configuration.
+        getDataSetDef().setAllColumnsEnabled(true);
+        getDataSetDef().setColumns(null);
+        getDataSetDef().setDataSetFilter(null);
+
+        DataSetDef editCloneWithoutCacheSettings = getDataSetDef().clone();
+        editCloneWithoutCacheSettings.setCacheEnabled(false);
+
+        final DataSetLookup lookup = DataSetFactory.newDataSetLookupBuilder()
+                                                   .dataset(dataSetDef.getUUID())
+                                                   .rowOffset(0)
+                                                   .rowNumber(10)
+                                                   .buildLookup();
+
+        try {
+            DataSetHandler editHandler = new DataSetEditHandler(clientServices,
+                                                                ConsoleDataSetLookup.fromInstance(lookup, getDataSetDef().getServerTemplateId()),
+                                                                editCloneWithoutCacheSettings);
+            editHandler.lookupDataSet(new DataSetReadyCallback() {
+
+                @Override
+                public void callback(final DataSet dataSet) {
+                    getDataSetDef().setColumns(dataSet.getDefinition().getColumns());
+                    testDataSetCallback.onSuccess(dataSet);
+                }
+
+                @Override
+                public void notFound() {
+                    testDataSetCallback.onError(new ClientRuntimeError(DataSetEditorConstants.INSTANCE.defNotFound()));
+                }
+
+                @Override
+                public boolean onError(final ClientRuntimeError error) {
+                    testDataSetCallback.onError(error);
+                    return false;
+                }
+            });
+        } catch (final Exception e) {
+            testDataSetCallback.onError(new ClientRuntimeError(e));
+        }
+    }
+
+    @Override
+    protected Class<? extends SimpleBeanEditorDriver<RemoteDataSetDef, RemoteDataSetDefEditor>> getDriverClass() {
+        return RemoteDataSetDefDriver.class;
+    }
+
+    @Override
+    protected Class<? extends RemoteDataSetDefEditor> getEditorClass() {
+        return RemoteDataSetDefEditor.class;
+    }
+
+    @Override
+    protected Iterable<ConstraintViolation<?>> validate(boolean isCacheEnabled,
+                                                        boolean isPushEnabled,
+                                                        boolean isRefreshEnabled) {
+
+        return validatorProvider.validate(dataSetDef,
+                                          isCacheEnabled,
+                                          isPushEnabled,
+                                          isRefreshEnabled);
+    }
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.java
@@ -23,30 +23,30 @@ public interface KieServerClientConstants extends Messages {
 
     public static final KieServerClientConstants INSTANCE = GWT.create(KieServerClientConstants.class);
 
-    public String remote_data_set_editor();
+    public String remoteDataSetEditor();
 
-    public String remote_data_set_editor_description();
+    public String remoteDataSetEditorDescription();
 
-    public String remote_query_target_hint();
+    public String remoteQueryTarget();
 
-    public String remote_query_target();
+    public String remoteQueryTargetHint();
 
-    public String remote_server_template_hint();
+    public String remoteServerTemplateHint();
 
-    public String remote_server_template();
+    public String remoteServerTemplate();
 
-    public String remote_server_template_description();
+    public String remoteServerTemplateDescription();
 
-    public String remote_datasource_description();
+    public String remoteDatasourceDescription();
 
-    public String remote_query_target_description();
+    public String remoteQueryTargetDescription();
 
-    public String remote_source_description();
+    public String remoteSourceDescription();
     
-    public String remote_query_placeHolder();
+    public String remoteQueryPlaceHolder();
     
-    public String remote_sql_source();
+    public String remoteSqlSource();
     
-    public String remote_sql_datasource();
+    public String remoteSqlDatasource();
 
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/java/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.kieserver.resources.i18n;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.i18n.client.Messages;
+
+public interface KieServerClientConstants extends Messages {
+
+    public static final KieServerClientConstants INSTANCE = GWT.create(KieServerClientConstants.class);
+
+    public String remote_data_set_editor();
+
+    public String remote_data_set_editor_description();
+
+    public String remote_query_target_hint();
+
+    public String remote_query_target();
+
+    public String remote_server_template_hint();
+
+    public String remote_server_template();
+
+    public String remote_server_template_description();
+
+    public String remote_datasource_description();
+
+    public String remote_query_target_description();
+
+    public String remote_source_description();
+    
+    public String remote_query_placeHolder();
+    
+    public String remote_sql_source();
+    
+    public String remote_sql_datasource();
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/META-INF/ErraiApp.properties
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/META-INF/ErraiApp.properties
@@ -1,0 +1,31 @@
+#
+# Copyright 2012 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/META-INF/beans.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="none">
+  <scan>
+    <exclude name="org.jbpm.dashboard.renderer.client.**"/>
+  </scan>
+</beans>

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/META-INF/beans.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" bean-discovery-mode="none">
-  <scan>
-    <exclude name="org.jbpm.dashboard.renderer.client.**"/>
-  </scan>
 </beans>

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/org/dashbuilder/DashbuilderKieServerClient.gwt.xml
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/org/dashbuilder/DashbuilderKieServerClient.gwt.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+~ Copyright 2012 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~       http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+
+  <!-- Inherit the core Web Toolkit stuff. -->
+  <inherits name="com.google.gwt.i18n.I18N"/>
+  <inherits name="com.google.gwt.http.HTTP"/>
+  <inherits name="com.google.gwt.user.User"/>
+
+  <inherits name="org.gwtbootstrap3.GwtBootstrap3NoTheme"/>
+
+  <inherits name="org.jboss.errai.ui.UI"/>
+
+  <inherits name="org.uberfire.UberfireWorkbench"/>
+  <inherits name="org.dashbuilder.DashbuilderKieServerAPI" />
+  
+  <inherits name="org.dashbuilder.DashbuilderClientAll"/>
+  
+  <source path="client"/>
+
+</module>

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.properties
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.properties
@@ -1,0 +1,28 @@
+#
+# Copyright 2020 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+remote_data_set_editor=Execution Server
+remote_data_set_editor_description=Execution Server provider allows to consume data via custom queries feature of the Execution Server
+remote_query_target=Remote query target
+remote_query_target_hint=Select query target
+remote_query_target_description=Query target
+remote_server_template=Remote Server Template
+remote_server_template_hint=Select server configuration
+remote_datasource_description=Data source
+remote_server_template_description=Server configuration
+remote_source_description=Custom query
+remote_query_placeHolder=select * from ProcessInstanceLog
+remote_sql_source=Source
+remote_sql_datasource=Datasource

--- a/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.properties
+++ b/dashbuilder/dashbuilder-client/dashbuilder-kie-server-client/src/main/resources/org/dashbuilder/client/kieserver/resources/i18n/KieServerClientConstants.properties
@@ -13,16 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-remote_data_set_editor=Execution Server
-remote_data_set_editor_description=Execution Server provider allows to consume data via custom queries feature of the Execution Server
-remote_query_target=Remote query target
-remote_query_target_hint=Select query target
-remote_query_target_description=Query target
-remote_server_template=Remote Server Template
-remote_server_template_hint=Select server configuration
-remote_datasource_description=Data source
-remote_server_template_description=Server configuration
-remote_source_description=Custom query
-remote_query_placeHolder=select * from ProcessInstanceLog
-remote_sql_source=Source
-remote_sql_datasource=Datasource
+remoteDataSetEditor=Execution Server
+remoteDataSetEditorDescription=Execution Server provider allows to consume data via custom queries feature of the Execution Server
+remoteQueryTarget=Remote query target
+remoteQueryTargetHint=Select query target
+remoteServerTemplateHint=Select server configuration
+remoteServerTemplate=Remote Server Template
+remoteServerTemplateDescription=Server configuration
+remoteDatasourceDescription=Data source
+remoteQueryTargetDescription=Query target that will be executed on Kie Server
+remoteSourceDescription=The source
+remoteQueryPlaceHolder=select * from ProcessInstanceLog
+remoteSqlSource=Source
+remoteSqlDatasource=Datasource used to run queries

--- a/dashbuilder/dashbuilder-client/pom.xml
+++ b/dashbuilder/dashbuilder-client/pom.xml
@@ -40,6 +40,7 @@
     <module>dashbuilder-renderers</module>
     <module>dashbuilder-navigation-client</module>
     <module>dashbuilder-cms-client</module>
+    <module>dashbuilder-kie-server-client</module>
   </modules>
 
   <dependencyManagement>

--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -229,6 +229,16 @@
 			<groupId>org.dashbuilder</groupId>
 			<artifactId>dashbuilder-services-api</artifactId>
 		</dependency>
+		<!-- Kie Server Support -->
+		<dependency>
+		    <groupId>org.dashbuilder</groupId>
+		    <artifactId>dashbuilder-kie-server-api</artifactId>
+		 </dependency>
+		    
+		    <dependency>
+		      <groupId>org.dashbuilder</groupId>
+		      <artifactId>dashbuilder-kie-server-backend</artifactId>
+		    </dependency>
 
 		<!-- UberFire -->
 		<dependency>
@@ -718,6 +728,7 @@
 						<compileSourcesArtifact>org.dashbuilder:dashbuilder-renderer-c3</compileSourcesArtifact>
 						<compileSourcesArtifact>org.dashbuilder:dashbuilder-navigation-api</compileSourcesArtifact>
 						<compileSourcesArtifact>org.dashbuilder:dashbuilder-navigation-client</compileSourcesArtifact>
+						<compileSourcesArtifact>org.dashbuilder:dashbuilder-kie-server-api</compileSourcesArtifact>
 
 						<!-- Uberfire ext -->
 						<compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-api</compileSourcesArtifact>

--- a/dashbuilder/dashbuilder-runtime/src/main/resources/org/dashbuilder/DashbuilderRuntime.gwt.xml
+++ b/dashbuilder/dashbuilder-runtime/src/main/resources/org/dashbuilder/DashbuilderRuntime.gwt.xml
@@ -31,6 +31,7 @@
 	<inherits name="org.dashbuilder.DisplayerEditor" />
 	<inherits name="org.dashbuilder.renderer.DefaultRenderer" />
 	<inherits name="org.dashbuilder.renderer.C3Renderer" />
+  <inherits name="org.dashbuilder.DashbuilderKieServerAPI"/>
 
 	<source path='client' />
 	<source path='shared' />

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2014 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under 
+	the Apache License, Version 2.0 (the "License"); ~ you may not use this file 
+	except in compliance with the License. ~ You may obtain a copy of the License 
+	at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by 
+	applicable law or agreed to in writing, software ~ distributed under the 
+	License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. ~ See the License for the specific 
+	language governing permissions and ~ limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.dashbuilder</groupId>
+		<artifactId>dashbuilder-shared</artifactId>
+		<version>7.38.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>dashbuilder-kie-server-api</artifactId>
+	<packaging>jar</packaging>
+
+	<name>Dashbuilder Kie Server API</name>
+	<description>Dashbuilder Kie Server API without BC dependencies</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.kie.soup</groupId>
+			<artifactId>kie-soup-dataset-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.kie.soup</groupId>
+			<artifactId>kie-soup-dataset-sql</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.errai</groupId>
+			<artifactId>errai-bus</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.errai</groupId>
+			<artifactId>errai-common</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.dashbuilder</groupId>
 		<artifactId>dashbuilder-shared</artifactId>
-		<version>7.38.0-SNAPSHOT</version>
+		<version>7.39.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>dashbuilder-kie-server-api</artifactId>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/ConsoleDataSetLookup.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/ConsoleDataSetLookup.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver;
+
+import org.dashbuilder.dataset.DataSetLookup;
+import org.dashbuilder.dataset.DataSetOp;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ConsoleDataSetLookup extends DataSetLookup {
+
+    private String serverTemplateId;
+
+    public static DataSetLookup fromInstance(DataSetLookup orig,
+                                             String serverTemplateId) {
+        ConsoleDataSetLookup clone = new ConsoleDataSetLookup();
+        clone.setDataSetUUID(orig.getDataSetUUID());
+        clone.setRowOffset(orig.getRowOffset());
+        clone.setNumberOfRows(orig.getNumberOfRows());
+        for (DataSetOp dataSetOp : orig.getOperationList()) {
+            clone.getOperationList().add(dataSetOp.cloneInstance());
+        }
+        clone.setServerTemplateId(serverTemplateId);
+        return clone;
+    }
+
+    public String getServerTemplateId() {
+        return serverTemplateId;
+    }
+
+    public void setServerTemplateId(String serverTemplateId) {
+        this.serverTemplateId = serverTemplateId;
+    }
+
+    @Override
+    public DataSetLookup cloneInstance() {
+        return fromInstance(super.cloneInstance(),
+                            getServerTemplateId());
+    }
+}

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/KieServerConnectionInfo.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/KieServerConnectionInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver;
+
+import java.util.Optional;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+/**
+ * Kie Server Connection information
+ *
+ */
+@Portable
+public class KieServerConnectionInfo {
+
+    private Optional<String> location;
+    private Optional<String> user;
+    private Optional<String> password;
+    private Optional<String> token;
+
+    public KieServerConnectionInfo(@MapsTo("location") Optional<String> location,
+                                   @MapsTo("user") Optional<String> user,
+                                   @MapsTo("password") Optional<String> password,
+                                   @MapsTo("token") Optional<String> token) {
+        this.location = location;
+        this.user = user;
+        this.password = password;
+        this.token = token;
+    }
+
+    public Optional<String> getLocation() {
+        return location;
+    }
+
+    public Optional<String> getUser() {
+        return user;
+    }
+
+    public Optional<String> getPassword() {
+        return password;
+    }
+
+    public Optional<String> getToken() {
+        return token;
+    }
+
+}

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/KieServerConnectionInfo.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/KieServerConnectionInfo.java
@@ -32,15 +32,18 @@ public class KieServerConnectionInfo {
     private Optional<String> user;
     private Optional<String> password;
     private Optional<String> token;
+    private boolean replaceQuery;
 
     public KieServerConnectionInfo(@MapsTo("location") Optional<String> location,
                                    @MapsTo("user") Optional<String> user,
                                    @MapsTo("password") Optional<String> password,
-                                   @MapsTo("token") Optional<String> token) {
+                                   @MapsTo("token") Optional<String> token,
+                                   @MapsTo("replaceQuery") boolean replaceQuery) {
         this.location = location;
         this.user = user;
         this.password = password;
         this.token = token;
+        this.replaceQuery = replaceQuery;
     }
 
     public Optional<String> getLocation() {
@@ -57,6 +60,10 @@ public class KieServerConnectionInfo {
 
     public Optional<String> getToken() {
         return token;
+    }
+    
+    public boolean isReplaceQuery() {
+        return replaceQuery;
     }
 
 }

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/KieServerConnectionInfoProvider.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/KieServerConnectionInfoProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+
+@Remote
+public interface KieServerConnectionInfoProvider {
+
+    Optional<KieServerConnectionInfo> get(String name, String serverTemplate);
+
+    List<String> serverTemplates();
+
+    KieServerConnectionInfo verifiedConnectionInfo(RemoteDataSetDef def);
+
+}

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDataSetDef.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDataSetDef.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.dashbuilder.dataset.def.DataSetDef;
+import org.dashbuilder.dataset.def.SQLDataSetDef;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class RemoteDataSetDef extends SQLDataSetDef {
+
+    @NotNull(groups = {RemoteDataSetDefValidation.class})
+    @Size(min = 1, groups = {RemoteDataSetDefValidation.class})
+    protected String queryTarget;
+
+    @NotNull(groups = {RemoteDataSetDefValidation.class})
+    @Size(min = 1, groups = {RemoteDataSetDefValidation.class})
+    protected String serverTemplateId;
+
+    public RemoteDataSetDef() {
+        super.setProvider(new RuntimeKieServerDataSetProviderType());
+    }
+
+    public String getQueryTarget() {
+        return queryTarget;
+    }
+
+    public void setQueryTarget(String queryTarget) {
+        this.queryTarget = queryTarget;
+    }
+
+    public String getServerTemplateId() {
+        return serverTemplateId;
+    }
+
+    public void setServerTemplateId(String serverTemplateId) {
+        this.serverTemplateId = serverTemplateId;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((queryTarget == null) ? 0 : queryTarget.hashCode());
+        result = prime * result + ((serverTemplateId == null) ? 0 : serverTemplateId.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!super.equals(obj))
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        RemoteDataSetDef other = (RemoteDataSetDef) obj;
+        if (queryTarget == null) {
+            if (other.queryTarget != null)
+                return false;
+        } else if (!queryTarget.equals(other.queryTarget))
+            return false;
+        if (serverTemplateId == null) {
+            if (other.serverTemplateId != null)
+                return false;
+        } else if (!serverTemplateId.equals(other.serverTemplateId))
+            return false;
+        return true;
+    }
+
+    @Override
+    public DataSetDef clone() {
+        RemoteDataSetDef def = new RemoteDataSetDef();
+        clone(def);
+        def.setQueryTarget(getQueryTarget());
+        def.setServerTemplateId(getServerTemplateId());
+        def.setDbSQL(getDbSQL());
+        def.setDataSource(getDataSource());
+        return def;
+    }
+
+    public String toString() {
+        StringBuilder out = new StringBuilder();
+        out.append("UUID=").append(UUID).append("\n");
+        out.append("Provider=").append(provider).append("\n");
+        out.append("Public=").append(isPublic).append("\n");
+        out.append("Push enabled=").append(pushEnabled).append("\n");
+        out.append("Push max size=").append(pushMaxSize).append(" Kb\n");
+        if (refreshTime != null) {
+            out.append("Refresh time=").append(refreshTime).append("\n");
+            out.append("Refresh always=").append(refreshAlways).append("\n");
+        }
+        out.append("Data source=").append(dataSource).append("\n");
+        out.append("Query target=").append(queryTarget).append("\n");
+        out.append("Server template id=").append(serverTemplateId).append("\n");
+        out.append("DB SQL=").append(dbSQL).append("\n");
+        out.append("Get all columns=").append(allColumnsEnabled).append("\n");
+        out.append("Cache enabled=").append(cacheEnabled).append("\n");
+        out.append("Cache max rows=").append(cacheMaxRows).append(" Kb\n");
+        return out.toString();
+    }
+
+}

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDataSetDefValidation.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDataSetDefValidation.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver;
+
+public interface RemoteDataSetDefValidation {
+}

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDefJSONMarshaller.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDefJSONMarshaller.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver;
+
+import org.dashbuilder.dataset.json.DataSetDefJSONMarshallerExt;
+import org.dashbuilder.json.JsonObject;
+
+import static org.dashbuilder.dataset.json.DataSetDefJSONMarshaller.ALL_COLUMNS;
+import static org.dashbuilder.dataset.json.DataSetDefJSONMarshaller.isBlank;
+
+public class RemoteDefJSONMarshaller implements DataSetDefJSONMarshallerExt<RemoteDataSetDef> {
+
+    public static RemoteDefJSONMarshaller INSTANCE = new RemoteDefJSONMarshaller();
+
+    public static final String QUERY_TARGET = "queryTarget";
+    public static final String SERVER_TEMPLATE_ID = "serverTemplateId";
+    public static final String DATA_SOURCE = "dataSource";
+    public static final String DB_SCHEMA = "dbSchema";
+    public static final String DB_SQL = "dbSQL";
+
+
+    @Override
+    public void fromJson(RemoteDataSetDef def, JsonObject json) {
+        String queryTarget = json.getString(QUERY_TARGET);
+        String serverTemplateId = json.getString(SERVER_TEMPLATE_ID);
+        String dataSource = json.getString(DATA_SOURCE);
+        String dbSchema = json.getString(DB_SCHEMA);
+        String dbSQL = json.getString(DB_SQL);
+
+        if (!isBlank(queryTarget)) {
+            def.setQueryTarget(queryTarget);
+        }
+        if (!isBlank(serverTemplateId)) {
+            def.setServerTemplateId(serverTemplateId);
+        }
+        if (!isBlank(dataSource)) {
+            def.setDataSource(dataSource);
+        }
+        if (!isBlank(dbSchema)) {
+            def.setDbSchema(dbSchema);
+        }
+        if (!isBlank(dbSQL)) {
+            def.setDbSQL(dbSQL);
+        }
+    }
+
+    @Override
+    public void toJson(RemoteDataSetDef dataSetDef, JsonObject json) {
+        // Data source.
+        json.put(DATA_SOURCE, dataSetDef.getDataSource());
+
+        // Schema.
+        json.put(DB_SCHEMA, dataSetDef.getDbSchema());
+
+        // Query.
+        if (dataSetDef.getDbSQL() != null) {
+            json.put(DB_SQL, dataSetDef.getDbSQL());
+        }
+
+        json.put(QUERY_TARGET, dataSetDef.getQueryTarget());
+        
+        json.put(SERVER_TEMPLATE_ID, dataSetDef.getServerTemplateId());
+        
+        // All columns flag.
+        json.put(ALL_COLUMNS, dataSetDef.isAllColumnsEnabled());
+    }
+}

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RuntimeKieServerDataSetProviderType.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RuntimeKieServerDataSetProviderType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver;
+
+import org.dashbuilder.dataprovider.DataSetProviderType;
+import org.dashbuilder.dataset.json.DataSetDefJSONMarshallerExt;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class RuntimeKieServerDataSetProviderType implements DataSetProviderType<RemoteDataSetDef> {
+
+    public RuntimeKieServerDataSetProviderType() {
+
+    }
+
+    @Override
+    public String getName() {
+        return "REMOTE";
+    }
+
+    @Override
+    public RemoteDataSetDef createDataSetDef() {
+        RemoteDataSetDef def = new RemoteDataSetDef();
+        def.setProvider(this);
+        def.setDataSource("${org.kie.server.persistence.ds}");
+        return def;
+    }
+
+    @Override
+    public DataSetDefJSONMarshallerExt<RemoteDataSetDef> getJsonMarshaller() {
+        return RemoteDefJSONMarshaller.INSTANCE;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof RuntimeKieServerDataSetProviderType)) {
+            return false;
+        }
+        return getName().equals(((RuntimeKieServerDataSetProviderType) obj).getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return getName().hashCode();
+    }
+}

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/resources/META-INF/ErraiApp.properties
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/resources/META-INF/ErraiApp.properties
@@ -1,0 +1,17 @@
+#
+# ErraiApp.properties
+#
+# Do not remove, even if empty!
+#
+
+# This is a marker file. When it is detected inside a JAR or at the
+# top of any classpath, the subdirectories are scanned for deployable
+# components. As such, all Errai application modules in a project
+# should contain an ErraiApp.properties at the root of all classpaths
+# that you wish to be scanned.
+#
+# There are also some configuration options that can be set in this
+# file, although it is rarely necessary. See the documentation at
+# https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
+# for details.
+

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/resources/org/dashbuilder/DashbuilderKieServerAPI.gwt.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/resources/org/dashbuilder/DashbuilderKieServerAPI.gwt.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ~ Copyright 2014 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under 
+	the Apache License, Version 2.0 (the "License"); ~ you may not use this file 
+	except in compliance with the License. ~ You may obtain a copy of the License 
+	at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by 
+	applicable law or agreed to in writing, software ~ distributed under the 
+	License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. ~ See the License for the specific 
+	language governing permissions and ~ limitations under the License. -->
+
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.4.0//EN"
+    "http://google-web-toolkit.googlecode.com/svn/tags/2.5.0/distro-source/core/src/gwt-module.dtd">
+<module>
+	<inherits name="org.jboss.errai.common.ErraiCommon" />
+	<inherits name="org.jboss.errai.bus.ErraiBus" />
+	<inherits name="org.dashbuilder.DatasetAPI" />
+	<source path="kieserver" />
+</module>

--- a/dashbuilder/dashbuilder-shared/pom.xml
+++ b/dashbuilder/dashbuilder-shared/pom.xml
@@ -19,6 +19,7 @@
     <module>dashbuilder-validations</module>
     <module>dashbuilder-navigation-api</module>
     <module>dashbuilder-services-api</module>
+    <module>dashbuilder-kie-server-api</module>
   </modules>
 
 </project>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -100,6 +100,22 @@
       <artifactId>dashbuilder-dataset-client</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-kie-server-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-kie-server-api</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-kie-server-backend</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.dashbuilder</groupId>
@@ -732,7 +748,9 @@
             <compileSourcesArtifact>org.dashbuilder:dashbuilder-navigation-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.dashbuilder:dashbuilder-navigation-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.dashbuilder:dashbuilder-cms-client</compileSourcesArtifact>
-
+            <compileSourcesArtifact>org.dashbuilder:dashbuilder-kie-server-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.dashbuilder:dashbuilder-kie-server-client</compileSourcesArtifact>
+            
             <!-- Uberfire ext -->
             <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-client</compileSourcesArtifact>

--- a/dashbuilder/dashbuilder-webapp/src/main/resources/META-INF/ErraiApp.properties
+++ b/dashbuilder/dashbuilder-webapp/src/main/resources/META-INF/ErraiApp.properties
@@ -65,4 +65,4 @@ errai.marshalling.serializableTypes=org.dashbuilder.dataprovider.StaticProviderT
                                     org.dashbuilder.dataset.impl.DataSetMetadataImpl \
                                     org.dashbuilder.dataset.sort.ColumnSort \
                                     org.dashbuilder.dataset.sort.DataSetSort \
-                                    org.dashbuilder.dataset.sort.SortedList
+                                    org.dashbuilder.dataset.sort.SortedList 

--- a/dashbuilder/dashbuilder-webapp/src/main/resources/org/dashbuilder/DashbuilderShowcase.gwt.xml
+++ b/dashbuilder/dashbuilder-webapp/src/main/resources/org/dashbuilder/DashbuilderShowcase.gwt.xml
@@ -15,11 +15,13 @@
   <inherits name="org.uberfire.experimental.UberfireExperimentalAPI"/>
   <inherits name="org.uberfire.experimental.UberfireExperimentalClient"/>
 
+  <inherits name="org.dashbuilder.DashbuilderKieServerAPI"/>
   <inherits name="org.dashbuilder.DashbuilderClientAll"/>
+  <inherits name="org.dashbuilder.DashbuilderKieServerClient"/>
   <inherits name="org.dashbuilder.DisplayerEditor"/>
   <inherits name="org.dashbuilder.renderer.ChartJsRenderer"/>
   <inherits name="org.dashbuilder.renderer.C3Renderer"/>
-
+  
   <source path='client'/>
   <source path='shared'/>
 

--- a/dashbuilder/dashbuilder-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/dashbuilder/dashbuilder-webapp/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -37,6 +37,7 @@
       <module name="org.jboss.xnio"/>
       <module name="org.slf4j"/>
       <module name="org.slf4j.ext"/>
+      <module name="org.apache.xalan"/>
 
       <!-- Module dependencies for Wildfly / EAP security management providers. -->
       <module name="org.jboss.as.controller-client"/>


### PR DESCRIPTION
MERGE WITH https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1321

This is a port of Kie Server Dataset to dashbuilder webapp and dashbuilder runtime.

As a port most of the code was brought from jbpm-wb Kie Server dataset impl, hence you may find deprecated code. What was done to plug kie server in dashbuilder webapp is remove the code from BC Kie Server APIs and use a plain REST client to query Kie Server.

To see a list of available servers you need to set the following system property with comma separated server template names:

```
org.dashbuilder.kieserver.serverTemplates=serverTemplate1, serverTemplate2 …
```

Then you must set up location and credentials for the server template:

```
org.dashbuilder.kieserver.serverTemplate.{SERVER_TEMPLATE_NAME}.location={LOCATION}
org.dashbuilder.kieserver.serverTemplate.{SERVER_TEMPLATE_NAME}.user={USER}
org.dashbuilder.kieserver.serverTemplate.{SERVER_TEMPLATE_NAME}.password={PASSWORD}
org.dashbuilder.kieserver.serverTemplate.{SERVER_TEMPLATE_NAME}.token={TOKEN} * not used if user provides credentials
```

If you are using dashboards on a new Kie Server instance where queries were not created, the replace_query option will automatically create queries:

```
org.dashbuilder.kieserver.serverTemplate.{SERVER_TEMPLATE_NAME}.replace_query=true
```
With this option queries will be replaced in the target Kie Server to make sure that queries are consistent to run the dashboards.

On Dashbuilder Runtime the org.dashbuilder.kieserver.serverTemplates system property is ignored, there's no use for it there. 
In another words, to test this PR you must have a running Kie Server, then start web app using the mentioned system properties, create a kie server dataset on dashbuilder webapp and use it in some page.

![KS_ON_DASHBUILDER](https://user-images.githubusercontent.com/359820/82460842-123a4c00-9a90-11ea-955a-6bfffe873bfb.gif)

