### PR TITLE
AF-2522: org.uberfire.java.nio.fs.k8s tests are failing on IBM JDK1.8

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemInitTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/K8SFileSystemInitTest.java
@@ -19,19 +19,25 @@ package org.uberfire.java.nio.fs.k8s;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.Lists;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.fabric8.kubernetes.client.server.mock.KubernetesCrudDispatcher;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.Context;
+import io.fabric8.mockwebserver.ServerRequest;
+import io.fabric8.mockwebserver.ServerResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.uberfire.java.nio.base.attributes.HiddenAttributes;
 import org.uberfire.java.nio.file.DirectoryStream;
@@ -51,12 +57,11 @@ import static org.uberfire.java.nio.fs.k8s.K8SFileSystemUtils.getPathByFsObjCM;
 
 public class K8SFileSystemInitTest {
 
-    @ClassRule
-    public static KubernetesServer SERVER = new KubernetesServer(false, true);
+    public static KubernetesMockServer SERVER =
+            new KubernetesMockServer(new Context(), new MockWebServer(), new HashMap<ServerRequest, Queue<ServerResponse>>(), new KubernetesCrudDispatcher(), false);
     // The default namespace for MockKubernetes Server is 'test'
     protected static String TEST_NAMESPACE = "test";
-    protected static ThreadLocal<KubernetesClient> CLIENT_FACTORY =
-            ThreadLocal.withInitial(() -> SERVER.getClient());
+    protected static ThreadLocal<KubernetesClient> CLIENT_FACTORY;
 
     protected static final FileSystemProvider fsProvider = new K8SFileSystemProvider() {
 
@@ -71,6 +76,8 @@ public class K8SFileSystemInitTest {
 
     @BeforeClass
     public static void setup() {
+        SERVER.init();
+        CLIENT_FACTORY = ThreadLocal.withInitial(() -> SERVER.createClient());
         //Checking the operating system before test execution
         Assume.assumeFalse("k8s does not support in Windows platform", System.getProperty("os.name").toLowerCase().contains("windows"));
         fstore = fsProvider.getFileSystem(URI.create("default:///")).getFileStores().iterator().next();
@@ -80,6 +87,7 @@ public class K8SFileSystemInitTest {
     public static void tearDown() {
         CLIENT_FACTORY.get().configMaps().inNamespace(TEST_NAMESPACE).delete();
         CLIENT_FACTORY.get().close();
+        SERVER.destroy();
     }
     
     @Test


### PR DESCRIPTION
To workaround a known [issue](fabric8io/kubernetes-client#1243) of f8 k8s client, which is that if in CRUD mode the OpenShift mock server uses HTTPS as always.
It causes certificate issues in JDK 11 on RHEL 8, and IBM JDK1.8.

Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Related JIRAs:
https://issues.redhat.com/projects/AF/issues/AF-2522

Related PRs:
https://github.com/kiegroup/droolsjbpm-integration/pull/2090