### PR TITLE
fixed enforcer rule ban-duplicated-classes for wildfly-elytron, which…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,14 @@
                           <ignoreClass>org.apache.xmlbeans.xml.stream.Location</ignoreClass>
                         </ignoreClasses>
                       </dependency>
+                      <dependency>
+                        <groupId>org.wildfly.security</groupId>
+                        <artifactId>wildfly-elytron</artifactId>
+                        <type>jar</type>
+                        <ignoreClasses>
+                          <ignoreClass>*</ignoreClass>
+                        </ignoreClasses>
+                      </dependency>
                     </dependencies>
                     <findAllDuplicates>true</findAllDuplicates>
                   </banDuplicateClasses>


### PR DESCRIPTION
… is shaded jar

Parent PR - https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1326
the same change on the kie-parent level for Enforcer