### PR TITLE
FAI-173: Embed kogito-tooling editors in trusty-ai. Part 2 (trusty-ai changes)

### DIFF
--- a/appformer-client-api/src/main/java/org/appformer/client/context/Channel.java
+++ b/appformer-client-api/src/main/java/org/appformer/client/context/Channel.java
@@ -24,7 +24,8 @@ public enum Channel {
     ONLINE("ONLINE"),
     VSCODE("VSCODE"),
     GITHUB("GITHUB"),
-    DESKTOP("DESKTOP");
+    DESKTOP("DESKTOP"),
+    EMBEDDED("EMBEDDED");
 
     private final String name;
 
@@ -38,8 +39,8 @@ public enum Channel {
 
     public static Channel withName(String name) {
         return Stream.of(Channel.values())
-                     .filter(channel -> channel.getName().equalsIgnoreCase(name))
-                     .findFirst().orElseThrow(() -> new IllegalArgumentException("Name not recognized: " + name));
+                .filter(channel -> channel.getName().equalsIgnoreCase(name))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("Name not recognized: " + name));
     }
 
 }

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/ChannelTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/context/ChannelTest.java
@@ -30,6 +30,7 @@ public class ChannelTest {
         assertEquals(Channel.ONLINE, Channel.withName("ONLine"));
         assertEquals(Channel.VSCODE, Channel.withName("VSCode"));
         assertEquals(Channel.DESKTOP, Channel.withName("Desktop"));
+        assertEquals(Channel.EMBEDDED, Channel.withName("emBedDED"));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
See https://issues.redhat.com/browse/FAI-173

Cousin of https://github.com/kiegroup/kogito-tooling/pull/165 for `appformer`.