### PR TITLE
DROOLS-5384: Clicking rightmost column's header in DMN decision table raises an error

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilities.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilities.java
@@ -81,6 +81,9 @@ public class ColumnIndexUtilities {
         if (candidateHeaderColumnIndex == allColumns.size() - 1) {
             return candidateHeaderColumnIndex;
         }
+        if (candidateHeaderColumnIndex >= allColumns.size()) {
+            return candidateHeaderColumnIndex - 1;
+        }
         while (candidateHeaderColumnIndex < allColumns.size() - 1) {
             final GridColumn candidateColumn = allColumns.get(candidateHeaderColumnIndex + 1);
             final List<GridColumn.HeaderMetaData> candidateHeaderMetaData = candidateColumn.getHeaderMetaData();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilitiesTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/util/ColumnIndexUtilitiesTest.java
@@ -104,6 +104,16 @@ public class ColumnIndexUtilitiesTest {
     }
 
     @Test
+    public void testGetHeaderBlockEndColumnIndexWithIndexOutOfBounds() {
+        //MetaDataGroups: [""][""][""][""]
+        assertEquals(3,
+                     ColumnIndexUtilities.getHeaderBlockEndColumnIndex(columns,
+                                                                       columns.get(0).getHeaderMetaData().get(0),
+                                                                       0,
+                                                                       4));
+    }
+
+    @Test
     public void testGetUiHeaderRowIndex() {
         final BaseGridData model = new BaseGridData();
         columns.forEach(col -> model.appendColumn(col));


### PR DESCRIPTION
[See](https://issues.redhat.com/browse/DROOLS-5384).