### PR TITLE
KOGITO-764: Create a Guided Tour for first time users on DMN editor

### DIFF
--- a/appformer-kogito-bridge/pom.xml
+++ b/appformer-kogito-bridge/pom.xml
@@ -60,5 +60,13 @@
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
+
+    <!-- Test dependencies -->
+
+    <dependency>
+      <groupId>com.google.gwt.gwtmockito</groupId>
+      <artifactId>gwtmockito</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridge.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridge.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.appformer.kogito.bridge.client.guided.tour.GuidedTourCustomSelectorPositionProvider.PositionProviderFunction;
+import org.appformer.kogito.bridge.client.guided.tour.observers.GlobalHTMLObserver;
+import org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+
+@ApplicationScoped
+public class GuidedTourBridge {
+
+    private final GuidedTourService guidedTourService;
+
+    private final GlobalHTMLObserver globalHTMLObserver;
+
+    List<GuidedTourObserver> observers = new ArrayList<>();
+
+    @Inject
+    public GuidedTourBridge(final GuidedTourService guidedTourService,
+                            final GlobalHTMLObserver globalHTMLObserver) {
+        this.guidedTourService = guidedTourService;
+        this.globalHTMLObserver = globalHTMLObserver;
+    }
+
+    @PostConstruct
+    public void init() {
+        registerObserver(globalHTMLObserver);
+    }
+
+    public void refresh(final UserInteraction userInteraction) {
+        getGuidedTourService().refresh(userInteraction);
+    }
+
+    public void registerTutorial(final Tutorial tutorial) {
+        getGuidedTourService().registerTutorial(tutorial);
+    }
+
+    public void registerObserver(final GuidedTourObserver observer) {
+        observer.setMonitorBridge(this);
+        observers.add(observer);
+    }
+
+    public void registerPositionProvider(final String type,
+                                         final PositionProviderFunction positionProviderFunction) {
+        getPositionProviderInstance().registerPositionProvider(type, positionProviderFunction);
+    }
+
+    private GuidedTourService getGuidedTourService() {
+        if (guidedTourService.isEnabled()) {
+            return guidedTourService;
+        }
+        disposeObservers();
+        return GuidedTourService.DEFAULT;
+    }
+
+    private void disposeObservers() {
+        observers.forEach(GuidedTourObserver::dispose);
+    }
+
+    GuidedTourCustomSelectorPositionProvider getPositionProviderInstance() {
+        return GuidedTourCustomSelectorPositionProvider.getInstance();
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridge.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridge.java
@@ -29,6 +29,9 @@ import org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
 
+/**
+ * Provides a bridge between the GWT code and the the native JavaScript implementations.
+ */
 @ApplicationScoped
 public class GuidedTourBridge {
 
@@ -50,19 +53,31 @@ public class GuidedTourBridge {
         registerObserver(globalHTMLObserver);
     }
 
+    /**
+     * Refreshes the Guided Tour component by calling the {@link GuidedTourService}.
+     */
     public void refresh(final UserInteraction userInteraction) {
         getGuidedTourService().refresh(userInteraction);
     }
 
+    /**
+     * Registers a tutorial into the Guided Tour component by calling the {@link GuidedTourService}.
+     */
     public void registerTutorial(final Tutorial tutorial) {
         getGuidedTourService().registerTutorial(tutorial);
     }
 
+    /**
+     * Register a new observer into the {@link GuidedTourBridge}.
+     */
     public void registerObserver(final GuidedTourObserver observer) {
         observer.setMonitorBridge(this);
         observers.add(observer);
     }
 
+    /**
+     * Register a position provider into the {@link GuidedTourCustomSelectorPositionProvider}.
+     */
     public void registerPositionProvider(final String type,
                                          final PositionProviderFunction positionProviderFunction) {
         getPositionProviderInstance().registerPositionProvider(type, positionProviderFunction);

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
@@ -22,10 +22,11 @@ import java.util.Optional;
 
 import elemental2.dom.DomGlobal;
 import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.Rect;
 
-@JsType
+@JsType(namespace = JsPackage.GLOBAL, name = "JsInterop__Envelope__GuidedTour__GuidedTourCustomSelectorPositionProvider")
 public class GuidedTourCustomSelectorPositionProvider {
 
     private static GuidedTourCustomSelectorPositionProvider instance;

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import elemental2.dom.DomGlobal;
+import jsinterop.annotations.JsFunction;
+import jsinterop.annotations.JsType;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Rect;
+
+@JsType
+public class GuidedTourCustomSelectorPositionProvider {
+
+    private static GuidedTourCustomSelectorPositionProvider instance;
+
+    private Map<String, PositionProviderFunction> providers = new HashMap<>();
+
+    private GuidedTourCustomSelectorPositionProvider() {
+
+    }
+
+    public static GuidedTourCustomSelectorPositionProvider getInstance() {
+        if (instance == null) {
+            instance = new GuidedTourCustomSelectorPositionProvider();
+        }
+        return instance;
+    }
+
+    public Rect getPosition(final String querySelector) {
+
+        final String[] querySelectorParts = getQuerySelectorParts(querySelector);
+        final boolean isValidQuerySelector = querySelectorParts.length == 2;
+
+        if (isValidQuerySelector) {
+
+            final String type = querySelectorParts[0];
+            final String selector = querySelectorParts[1];
+            final Optional<PositionProviderFunction> positionProvider = Optional.ofNullable(providers.get(type));
+
+            if (positionProvider.isPresent()) {
+                return positionProvider.get().call(selector);
+            } else {
+                DomGlobal.console.warn("[Guided Tour - Position Provider] The position provider could not be found: " + type);
+            }
+        } else {
+            DomGlobal.console.warn("[Guided Tour - Position Provider] Invalid custom query selector: " + querySelector);
+        }
+        return Rect.NONE();
+    }
+
+    public void registerPositionProvider(final String type,
+                                         final PositionProviderFunction positionProviderFunction) {
+        providers.put(type, positionProviderFunction);
+    }
+
+    private String[] getQuerySelectorParts(final String selector) {
+        if (selector == null) {
+            return new String[0];
+        }
+        final String separator = ":::";
+        return selector.split(separator);
+    }
+
+    @JsFunction
+    public interface PositionProviderFunction {
+
+        Rect call(final String selector);
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
@@ -26,6 +26,9 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.Rect;
 
+/**
+ * Provides a {@link JsType} native API for JavaScript consumers that may request positions with a custom query selector.
+ */
 @JsType(namespace = JsPackage.GLOBAL, name = "JsInterop__Envelope__GuidedTour__GuidedTourCustomSelectorPositionProvider")
 public class GuidedTourCustomSelectorPositionProvider {
 
@@ -37,6 +40,9 @@ public class GuidedTourCustomSelectorPositionProvider {
 
     }
 
+    /**
+     * Gets an instance of the {@link GuidedTourCustomSelectorPositionProvider}
+     */
     public static GuidedTourCustomSelectorPositionProvider getInstance() {
         if (instance == null) {
             instance = new GuidedTourCustomSelectorPositionProvider();
@@ -44,6 +50,12 @@ public class GuidedTourCustomSelectorPositionProvider {
         return instance;
     }
 
+    /**
+     * Gets a {@link Rect} position for a given custom 'querySelector', which must follow this convention:
+     * 'TYPE:::ELEMENT'. E.g. Graph:::Node-1, Iframe:::body, Any:::Element1.
+     * @param querySelector a custom query selector
+     * @return the position of the selected element
+     */
     public Rect getPosition(final String querySelector) {
 
         final String[] querySelectorParts = getQuerySelectorParts(querySelector);
@@ -66,6 +78,11 @@ public class GuidedTourCustomSelectorPositionProvider {
         return Rect.NONE();
     }
 
+    /**
+     * Registers a {@link PositionProviderFunction} with its type.
+     * @param type the prefix for the position provider function
+     * @param positionProviderFunction a function that returns a {@link Rect} for a given 'selector'
+     */
     public void registerPositionProvider(final String type,
                                          final PositionProviderFunction positionProviderFunction) {
         providers.put(type, positionProviderFunction);

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProvider.java
@@ -75,6 +75,10 @@ public class GuidedTourCustomSelectorPositionProvider {
         } else {
             DomGlobal.console.warn("[Guided Tour - Position Provider] Invalid custom query selector: " + querySelector);
         }
+        return none();
+    }
+
+    Rect none() {
         return Rect.NONE();
     }
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserver.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour;
+
+import java.util.Optional;
+
+import org.jboss.errai.ioc.client.api.Disposer;
+
+public abstract class GuidedTourObserver<T extends GuidedTourObserver> {
+
+    private final Disposer<T> selfDisposer;
+
+    private GuidedTourBridge bridge;
+
+    public GuidedTourObserver(final Disposer<T> selfDisposer) {
+        this.selfDisposer = selfDisposer;
+    }
+
+    protected Optional<GuidedTourBridge> getMonitorBridge() {
+        return Optional.ofNullable(this.bridge);
+    }
+
+    protected void setMonitorBridge(final GuidedTourBridge bridge) {
+        this.bridge = bridge;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void dispose() {
+        selfDisposer.dispose((T) this);
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserver.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserver.java
@@ -18,8 +18,14 @@ package org.appformer.kogito.bridge.client.guided.tour;
 
 import java.util.Optional;
 
+import org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService;
 import org.jboss.errai.ioc.client.api.Disposer;
 
+/**
+ * {@link GuidedTourObserver} implementation must events and notifies the {@link GuidedTourBridge}.
+ * Notice: {@link GuidedTourObserver} instances must be disposed once the {@link GuidedTourService} is disable, this
+ * provides the proper {@link Disposer}.
+ */
 public abstract class GuidedTourObserver<T extends GuidedTourObserver> {
 
     private final Disposer<T> selfDisposer;

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/observers/GlobalHTMLObserver.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/observers/GlobalHTMLObserver.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.observers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import elemental2.dom.Attr;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
+import elemental2.dom.EventListener;
+import elemental2.dom.HTMLDocument;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.NamedNodeMap;
+import org.appformer.kogito.bridge.client.guided.tour.GuidedTourObserver;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+import org.jboss.errai.ioc.client.api.Disposer;
+
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+
+public class GlobalHTMLObserver extends GuidedTourObserver<GlobalHTMLObserver> {
+
+    final EventListener CLICK_LISTENER = this::onHTMLElementEvent;
+
+    @Inject
+    public GlobalHTMLObserver(final Disposer<GlobalHTMLObserver> selfDisposer) {
+        super(selfDisposer);
+    }
+
+    @PostConstruct
+    public void init() {
+        addGlobalEventListener(CLICK, CLICK_LISTENER);
+    }
+
+    @Override
+    protected void dispose() {
+        removeGlobalEventListener(CLICK, CLICK_LISTENER);
+        super.dispose();
+    }
+
+    void onHTMLElementEvent(final Event event) {
+        getMonitorBridge().ifPresent(bridge -> bridge.refresh(getUserInteraction(event)));
+    }
+
+    private UserInteraction getUserInteraction(final Event event) {
+        final String action = CLICK.toUpperCase();
+        final String selector = getSelector(getTarget(event));
+        return makeUserInteraction(action, selector);
+    }
+
+    private String getSelector(final HTMLElement element) {
+
+        final String tag = element.tagName.toLowerCase();
+        final String id = element.id != null && !element.id.isEmpty() ? "#" + element.id : "";
+        final String dataAttributes = getDataAttributes(element);
+        final String className = element.classList.length > 0 ? "." + String.join(".", element.classList.asList()) : "";
+
+        return tag + dataAttributes + id + className;
+    }
+
+    public String getDataAttributes(final HTMLElement element) {
+        final NamedNodeMap<Attr> attributes = element.attributes;
+        final List<String> dataAttributes = new ArrayList<>();
+
+        for (int i = 0, objectsSize = attributes.length; i < objectsSize; i++) {
+            final String nodeName = attributes.item(i).nodeName;
+            final String nodeValue = attributes.item(i).nodeValue;
+            if (nodeName.startsWith("data-")) {
+                dataAttributes.add("[" + nodeName + "=\"" + nodeValue + "\"]");
+            }
+        }
+        return String.join("", dataAttributes);
+    }
+
+    private HTMLElement getTarget(final Event e) {
+        return (HTMLElement) e.target;
+    }
+
+    private void addGlobalEventListener(final String type,
+                                        final EventListener eventListener) {
+        document().addEventListener(type, eventListener);
+    }
+
+    private void removeGlobalEventListener(final String type,
+                                           final EventListener eventListener) {
+        document().removeEventListener(type, eventListener);
+    }
+
+    UserInteraction makeUserInteraction(final String action,
+                                        final String target) {
+        final UserInteraction userInteraction = new UserInteraction();
+        userInteraction.setAction(action);
+        userInteraction.setTarget(target);
+        return userInteraction;
+    }
+
+    HTMLDocument document() {
+        return DomGlobal.document;
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourService.java
@@ -19,14 +19,33 @@ package org.appformer.kogito.bridge.client.guided.tour.service;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
 
+/**
+ * Service to access Guided Tour features.
+ */
 public interface GuidedTourService {
 
+    /**
+     * Refreshes the Guided Tour with a new user interaction. Thus, depending of the user interaction, the Guided Tour
+     * may react or do not react upon a given user interaction.
+     * @param userInteraction an user interaction
+     */
     void refresh(final UserInteraction userInteraction);
 
+    /**
+     * Registers a tutorial into the Guided Tour
+     * @param tutorial a tutorial
+     */
     void registerTutorial(final Tutorial tutorial);
 
+    /**
+     * Checks if the Guided Tour is enabled.
+     * @return 'true' when the Guided Tour is enabled, otherwise it returns 'false'
+     */
     boolean isEnabled();
 
+    /**
+     * It's the default implementation of the {@link GuidedTourService}.
+     */
     GuidedTourService DEFAULT = new GuidedTourService() {
 
         @Override

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service;
+
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+
+public interface GuidedTourService {
+
+    void refresh(final UserInteraction userInteraction);
+
+    void registerTutorial(final Tutorial tutorial);
+
+    boolean isEnabled();
+
+    GuidedTourService DEFAULT = new GuidedTourService() {
+
+        @Override
+        public void refresh(final UserInteraction userInteraction) {
+            // empty
+        }
+
+        @Override
+        public void registerTutorial(final Tutorial tutorial) {
+            // empty
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+    };
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceEnvelope.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceEnvelope.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service;
+
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+
+public class GuidedTourServiceEnvelope implements GuidedTourService {
+
+    @Override
+    public void refresh(final UserInteraction userInteraction) {
+        getNativeEnvelope().refresh(userInteraction);
+    }
+
+    @Override
+    public void registerTutorial(final Tutorial tutorial) {
+        getNativeEnvelope().registerTutorial(tutorial);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return getNativeEnvelope().isEnabled();
+    }
+
+    GuidedTourServiceNativeEnvelope getNativeEnvelope() {
+        return GuidedTourServiceNativeEnvelope.get();
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceEnvelope.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceEnvelope.java
@@ -19,6 +19,9 @@ package org.appformer.kogito.bridge.client.guided.tour.service;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
 import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
 
+/**
+ * Expose Guided Tour features provided by the native envelope on {@link GuidedTourServiceNativeEnvelope}.
+ */
 public class GuidedTourServiceEnvelope implements GuidedTourService {
 
     @Override

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceNativeEnvelope.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceNativeEnvelope.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service;
+
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+
+@JsType(isNative = true, namespace = "window", name = "envelope")
+public class GuidedTourServiceNativeEnvelope {
+
+    public native void refresh(final UserInteraction userInteraction);
+
+    public native void registerTutorial(final Tutorial tutorial);
+
+    public native boolean isEnabled();
+
+    @JsProperty(name = "guidedTourService")
+    public static native GuidedTourServiceNativeEnvelope get();
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceProducer.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceProducer.java
@@ -24,6 +24,9 @@ import org.appformer.kogito.bridge.client.interop.WindowRef;
 
 import static org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService.DEFAULT;
 
+/**
+ * Produces {@link GuidedTourService} beans according to whether the envelope API is available or not
+ */
 public class GuidedTourServiceProducer {
 
     @Produces

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceProducer.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceProducer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import elemental2.dom.DomGlobal;
+import org.appformer.kogito.bridge.client.interop.WindowRef;
+
+import static org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService.DEFAULT;
+
+public class GuidedTourServiceProducer {
+
+    @Produces
+    @ApplicationScoped
+    public GuidedTourService produce() {
+        if (isEnvelopeAvailable()) {
+            return new GuidedTourServiceEnvelope();
+        }
+        DomGlobal.console.info("[GuidedTourServiceProducer] Envelope API is not available.");
+        return DEFAULT;
+    }
+
+    boolean isEnvelopeAvailable() {
+        return WindowRef.isEnvelopeAvailable();
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/AutoMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/AutoMode.java
@@ -20,6 +20,10 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ * A {@link Step} with mode as a {@link AutoMode} instance shows something, stays opened for some time, and it's auto-skipped.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class AutoMode implements Mode {
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/AutoMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/AutoMode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class AutoMode implements Mode {
+
+    @JsProperty
+    public native void setDelay(final int delay);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/BlockMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/BlockMode.java
@@ -21,6 +21,10 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ * A {@link Step} with mode as a {@link BlockMode} instance shows something, and waits for some user interaction.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class BlockMode implements Mode {
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/BlockMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/BlockMode.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import elemental2.core.JsArray;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class BlockMode implements Mode {
+
+    @JsProperty
+    public native void setUserInteraction(final UserInteraction userInteraction);
+
+    @JsProperty
+    public native void setAllowedSelectors(final JsArray<String> allowedSelectors);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/DemoMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/DemoMode.java
@@ -19,6 +19,10 @@ package org.appformer.kogito.bridge.client.guided.tour.service.api;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ * A {@link Step} with mode as a {@link DemoMode} instance shows something, and waits for the "Next step" click.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class DemoMode implements Mode {
     // empty

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/DemoMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/DemoMode.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class DemoMode implements Mode {
+    // empty
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Mode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Mode.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true)
+public interface Mode {
+    // empty
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Mode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Mode.java
@@ -16,9 +16,11 @@
 
 package org.appformer.kogito.bridge.client.guided.tour.service.api;
 
-import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ */
 @JsType(isNative = true)
 public interface Mode {
     // empty

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Rect.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Rect.java
@@ -21,6 +21,9 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class Rect {
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Rect.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Rect.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class Rect {
+
+    @JsProperty
+    public native void setBottom(final int bottom);
+
+    @JsProperty
+    public native void setHeight(final int height);
+
+    @JsProperty
+    public native void setLeft(final int left);
+
+    @JsProperty
+    public native void setRight(final int right);
+
+    @JsProperty
+    public native void setTop(final int top);
+
+    @JsProperty
+    public native void setWidth(final int width);
+
+    @JsProperty
+    public native void setX(final int x);
+
+    @JsProperty
+    public native void setY(final int y);
+
+    @JsOverlay
+    public static Rect NONE() {
+        return new Rect();
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Step.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Step.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class Step {
+
+    @JsProperty
+    public native void setMode(final Mode mode);
+
+    @JsProperty
+    public native void setContent(final String content);
+
+    @JsProperty
+    public native void setSelector(final String selector);
+
+    @JsProperty
+    public native void setHighlightEnabled(final boolean highlightEnabled);
+
+    @JsProperty
+    public native void setNavigatorEnabled(final boolean navigatorEnabled);
+
+    @JsProperty
+    public native void setPosition(final String position);
+
+    @JsProperty
+    public native void setNegativeReinforcementMessage(final String negativeReinforcementMessage);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Step.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Step.java
@@ -20,6 +20,10 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ * Defines a single step in a tutorial.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class Step {
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Step.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Step.java
@@ -42,6 +42,10 @@ public class Step {
     @JsProperty
     public native void setNavigatorEnabled(final boolean navigatorEnabled);
 
+    /**
+     * Sets the position of the step in the screen.
+     * Allowed values: "right" | "bottom" | "center" | "left". Any different type ise handled as "center".
+     */
     @JsProperty
     public native void setPosition(final String position);
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/SubTutorialMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/SubTutorialMode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class SubTutorialMode {
+
+    @JsProperty
+    public native void setLabel(final String label);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/SubTutorialMode.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/SubTutorialMode.java
@@ -20,6 +20,10 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ * A {@link Step} with mode as a {@link SubTutorialMode} encloses an amount of other sub-steps.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class SubTutorialMode {
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Tutorial.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Tutorial.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import elemental2.core.JsArray;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class Tutorial {
+
+    @JsProperty
+    public native void setLabel(final String label);
+
+    @JsProperty
+    public native void setSteps(final JsArray<Step> steps);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Tutorial.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/Tutorial.java
@@ -21,6 +21,10 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ * It holds an amount of steps with a label.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class Tutorial {
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/UserInteraction.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/UserInteraction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service.api;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class UserInteraction {
+
+    @JsProperty
+    public native void setAction(final String action);
+
+    @JsProperty
+    public native void setTarget(final String target);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/UserInteraction.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/guided/tour/service/api/UserInteraction.java
@@ -20,6 +20,10 @@ import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
+/**
+ * Native class defined into the Guided Tour component.
+ * It holds a general description of some user interaction.
+ */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class UserInteraction {
 

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridgeTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridgeTest.java
@@ -120,7 +120,7 @@ public class GuidedTourBridgeTest {
 
         bridge.registerPositionProvider(type, positionProviderFunction);
 
-        verify(bridge).registerPositionProvider(type, positionProviderFunction);
+        verify(positionProvider).registerPositionProvider(type, positionProviderFunction);
     }
 
     class GlobalHTMLObserverFake extends GlobalHTMLObserver {

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridgeTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourBridgeTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour;
+
+import org.appformer.kogito.bridge.client.guided.tour.GuidedTourCustomSelectorPositionProvider.PositionProviderFunction;
+import org.appformer.kogito.bridge.client.guided.tour.observers.GlobalHTMLObserver;
+import org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+import org.jboss.errai.ioc.client.api.Disposer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidedTourBridgeTest {
+
+    @Mock
+    private GuidedTourService service;
+
+    @Mock
+    private GlobalHTMLObserverFake observer;
+
+    private GuidedTourBridge bridge;
+
+    @Before
+    public void setup() {
+        bridge = spy(new GuidedTourBridge(service, observer));
+        bridge.init();
+    }
+
+    @Test
+    public void testInit() {
+        // 'init' is called on setup
+        assertEquals(singletonList(observer), bridge.observers);
+    }
+
+    @Test
+    public void testRefresh() {
+        final UserInteraction userInteraction = mock(UserInteraction.class);
+        when(service.isEnabled()).thenReturn(true);
+
+        bridge.refresh(userInteraction);
+
+        verify(service).refresh(userInteraction);
+    }
+
+    @Test
+    public void testRegisterTutorial() {
+        final Tutorial tutorial = mock(Tutorial.class);
+        when(service.isEnabled()).thenReturn(true);
+
+        bridge.registerTutorial(tutorial);
+
+        verify(service).registerTutorial(tutorial);
+    }
+
+    @Test
+    public void testRefreshWhenBridgeIsNotEnabled() {
+        final UserInteraction userInteraction = mock(UserInteraction.class);
+        when(service.isEnabled()).thenReturn(false);
+
+        bridge.refresh(userInteraction);
+
+        verify(observer).dispose();
+    }
+
+    @Test
+    public void testRegisterTutorialWhenBridgeIsNotEnabled() {
+        final Tutorial tutorial = mock(Tutorial.class);
+        when(service.isEnabled()).thenReturn(false);
+
+        bridge.registerTutorial(tutorial);
+
+        verify(observer).dispose();
+    }
+
+    @Test
+    public void testRegisterObserver() {
+        final GuidedTourObserver observer = mock(GuidedTourObserver.class);
+
+        bridge.registerObserver(observer);
+
+        verify(observer).setMonitorBridge(bridge);
+        assertEquals(asList(this.observer, observer), bridge.observers);
+    }
+
+    @Test
+    public void testRegisterPositionProvider() {
+        final GuidedTourCustomSelectorPositionProvider positionProvider = mock(GuidedTourCustomSelectorPositionProvider.class);
+        final PositionProviderFunction positionProviderFunction = mock(PositionProviderFunction.class);
+        final String type = "type";
+
+        doReturn(positionProvider).when(bridge).getPositionProviderInstance();
+
+        bridge.registerPositionProvider(type, positionProviderFunction);
+
+        verify(bridge).registerPositionProvider(type, positionProviderFunction);
+    }
+
+    class GlobalHTMLObserverFake extends GlobalHTMLObserver {
+
+        GlobalHTMLObserverFake(final Disposer<GlobalHTMLObserver> selfDisposer) {
+            super(selfDisposer);
+        }
+
+        @Override
+        protected void dispose() {
+            super.dispose();
+        }
+    }
+}

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProviderTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProviderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour;
+
+import java.util.Objects;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Console;
+import elemental2.dom.DomGlobal;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Rect;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedTourCustomSelectorPositionProviderTest {
+
+    @Mock
+    private Console console;
+
+    private GuidedTourCustomSelectorPositionProvider positionProvider;
+
+    @Before
+    public void setup() {
+        positionProvider = spy(GuidedTourCustomSelectorPositionProvider.getInstance());
+        DomGlobal.console = console;
+    }
+
+    @Test
+    public void testGetPosition() {
+        final Rect rect1 = makeRect(1);
+        final Rect rect2 = makeRect(2);
+
+        positionProvider.registerPositionProvider("TEST_PROVIDER_1", name -> Objects.equals(name, "OBJECT-1") ? rect1 : rect2);
+
+        assertEquals(rect1, positionProvider.getPosition("TEST_PROVIDER_1:::OBJECT-1"));
+        assertEquals(rect2, positionProvider.getPosition("TEST_PROVIDER_1:::OBJECT-2"));
+    }
+
+    @Test
+    public void testGetPositionWhenSelectorIsInvalid() {
+        final Rect rect1 = makeRect(1);
+        final Rect rect2 = makeRect(2);
+
+        positionProvider.registerPositionProvider("TEST_PROVIDER_2", name -> Objects.equals(name, "OBJECT-1") ? rect1 : rect2);
+
+        final Rect position = positionProvider.getPosition("TEST_PROVIDER_2___OBJECT-1");
+
+        verify(console).warn("[Guided Tour - Position Provider] Invalid custom query selector: TEST_PROVIDER_2___OBJECT-1");
+        assertNotNull(position);
+    }
+
+    @Test
+    public void testGetPositionWhenNoSelectorIsRegistered() {
+        final Rect position = positionProvider.getPosition("TEST_PROVIDER_3:::OBJECT-1");
+
+        verify(console).warn("[Guided Tour - Position Provider] The position provider could not be found: TEST_PROVIDER_3");
+        assertNotNull(position);
+    }
+
+    @Test
+    public void testGetPositionWhenSelectorIsNull() {
+        final Rect position = positionProvider.getPosition(null);
+
+        verify(console).warn("[Guided Tour - Position Provider] Invalid custom query selector: null");
+        assertNotNull(position);
+    }
+
+    private Rect makeRect(final int seed) {
+        final Rect rect = new Rect();
+        rect.setBottom(seed);
+        rect.setHeight(seed);
+        rect.setLeft(seed);
+        rect.setRight(seed);
+        rect.setTop(seed);
+        rect.setWidth(seed);
+        rect.setX(seed);
+        rect.setY(seed);
+        return rect;
+    }
+}

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProviderTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourCustomSelectorPositionProviderTest.java
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -38,12 +38,18 @@ public class GuidedTourCustomSelectorPositionProviderTest {
     @Mock
     private Console console;
 
+    private Rect none;
+
     private GuidedTourCustomSelectorPositionProvider positionProvider;
 
     @Before
     public void setup() {
         positionProvider = spy(GuidedTourCustomSelectorPositionProvider.getInstance());
+        none = makeRect(0);
+
         DomGlobal.console = console;
+
+        doReturn(none).when(positionProvider).none();
     }
 
     @Test
@@ -67,7 +73,7 @@ public class GuidedTourCustomSelectorPositionProviderTest {
         final Rect position = positionProvider.getPosition("TEST_PROVIDER_2___OBJECT-1");
 
         verify(console).warn("[Guided Tour - Position Provider] Invalid custom query selector: TEST_PROVIDER_2___OBJECT-1");
-        assertNotNull(position);
+        assertEquals(none, position);
     }
 
     @Test
@@ -75,7 +81,7 @@ public class GuidedTourCustomSelectorPositionProviderTest {
         final Rect position = positionProvider.getPosition("TEST_PROVIDER_3:::OBJECT-1");
 
         verify(console).warn("[Guided Tour - Position Provider] The position provider could not be found: TEST_PROVIDER_3");
-        assertNotNull(position);
+        assertEquals(none, position);
     }
 
     @Test
@@ -83,7 +89,7 @@ public class GuidedTourCustomSelectorPositionProviderTest {
         final Rect position = positionProvider.getPosition(null);
 
         verify(console).warn("[Guided Tour - Position Provider] Invalid custom query selector: null");
-        assertNotNull(position);
+        assertEquals(none, position);
     }
 
     private Rect makeRect(final int seed) {

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserverTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/GuidedTourObserverTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour;
+
+import org.jboss.errai.ioc.client.api.Disposer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuidedTourObserverTest {
+
+    @Mock
+    private Disposer<GuidedTourObserverFake> selfDisposer;
+
+    @Mock
+    private GuidedTourBridge bridge;
+
+    private GuidedTourObserverFake observer;
+
+    @Before
+    public void setup() {
+        observer = new GuidedTourObserverFake(selfDisposer);
+    }
+
+    @Test
+    public void testDispose() {
+        observer.dispose();
+        verify(selfDisposer).dispose(observer);
+    }
+
+    @Test
+    public void testSetMonitorBridge() {
+        observer.setMonitorBridge(bridge);
+        assertTrue(observer.getMonitorBridge().isPresent());
+        assertEquals(bridge, observer.getMonitorBridge().get());
+    }
+
+    class GuidedTourObserverFake extends GuidedTourObserver<GuidedTourObserverFake> {
+
+        GuidedTourObserverFake(final Disposer<GuidedTourObserverFake> selfDisposer) {
+            super(selfDisposer);
+        }
+    }
+}

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/observers/GlobalHTMLObserverTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/observers/GlobalHTMLObserverTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.observers;
+
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Attr;
+import elemental2.dom.DOMTokenList;
+import elemental2.dom.Event;
+import elemental2.dom.HTMLDocument;
+import elemental2.dom.HTMLElement;
+import elemental2.dom.NamedNodeMap;
+import org.appformer.kogito.bridge.client.guided.tour.GuidedTourBridge;
+import org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+import org.jboss.errai.ioc.client.api.Disposer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import static com.google.gwt.dom.client.BrowserEvents.CLICK;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GlobalHTMLObserverTest {
+
+    @Mock
+    private Disposer<GlobalHTMLObserver> selfDisposer;
+
+    @Mock
+    private HTMLDocument document;
+
+    @Mock
+    private GuidedTourService service;
+
+    @Mock
+    private GlobalHTMLObserver observer;
+
+    @Captor
+    private ArgumentCaptor<UserInteraction> userInteractionArgumentCaptor;
+
+    private GuidedTourBridge bridge;
+
+    private GlobalHTMLObserver htmlObserver;
+
+    @Before
+    public void setup() {
+        bridge = spy(new GuidedTourBridge(service, observer));
+        htmlObserver = spy(new GlobalHTMLObserver(selfDisposer));
+
+        doReturn(document).when(htmlObserver).document();
+
+        htmlObserver.init();
+        bridge.registerObserver(htmlObserver);
+    }
+
+    @Test
+    public void testInit() {
+        // 'init' is called on setup
+        document.addEventListener(CLICK, htmlObserver.CLICK_LISTENER);
+    }
+
+    @Test
+    public void testDispose() {
+        htmlObserver.dispose();
+        document.removeEventListener(CLICK, htmlObserver.CLICK_LISTENER);
+    }
+
+    @Test
+    public void testOnHTMLElementEvent() {
+
+        final Event event = mock(Event.class);
+        final HTMLElement htmlElement = mock(HTMLElement.class);
+        final DOMTokenList classList = mock(DOMTokenList.class);
+        final UserInteraction expected = mock(UserInteraction.class);
+        final List<String> classStringList = asList("pf-label", "pf-label--red", "pf-label--xl");
+        final NamedNodeMap<Attr> attrNamedNodeMap = spy(new NamedNodeMap<>());
+        final Attr node1 = new Attr();
+        final Attr node2 = new Attr();
+
+        htmlElement.id = "user-name-label";
+        htmlElement.tagName = "div";
+        htmlElement.classList = classList;
+        htmlElement.attributes = attrNamedNodeMap;
+
+        event.target = htmlElement;
+        classList.length = classStringList.size();
+
+        attrNamedNodeMap.length = 2;
+        node1.nodeName = "data-field";
+        node1.nodeValue = "username";
+        node2.nodeName = "data-key";
+        node2.nodeValue = "123";
+
+        when(classList.asList()).thenReturn(classStringList);
+        doReturn(node1).when(attrNamedNodeMap).item(0);
+        doReturn(node2).when(attrNamedNodeMap).item(1);
+        doReturn(expected).when(htmlObserver).makeUserInteraction("CLICK", "div[data-field=\"username\"][data-key=\"123\"]#user-name-label.pf-label.pf-label--red.pf-label--xl");
+
+        htmlObserver.onHTMLElementEvent(event);
+
+        verify(bridge).refresh(userInteractionArgumentCaptor.capture());
+        final UserInteraction actual = userInteractionArgumentCaptor.getValue();
+        assertEquals(expected, actual);
+    }
+}

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceEnvelopeTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceEnvelopeTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.Tutorial;
+import org.appformer.kogito.bridge.client.guided.tour.service.api.UserInteraction;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedTourServiceEnvelopeTest {
+
+    private GuidedTourServiceEnvelope envelope;
+
+    @Mock
+    private GuidedTourServiceNativeEnvelope nativeEnvelope;
+
+    @Before
+    public void setup() {
+        envelope = spy(new GuidedTourServiceEnvelope());
+        doReturn(nativeEnvelope).when(envelope).getNativeEnvelope();
+    }
+
+    @Test
+    public void testRefresh() {
+        final UserInteraction userInteraction = mock(UserInteraction.class);
+        envelope.refresh(userInteraction);
+        verify(nativeEnvelope).refresh(userInteraction);
+    }
+
+    @Test
+    public void testRegisterTutorial() {
+        final Tutorial tutorial = mock(Tutorial.class);
+        envelope.registerTutorial(tutorial);
+        verify(nativeEnvelope).registerTutorial(tutorial);
+    }
+
+    @Test
+    public void testIsEnabledWhenItReturnsTrue() {
+        when(nativeEnvelope.isEnabled()).thenReturn(true);
+        assertTrue(envelope.isEnabled());
+    }
+
+    @Test
+    public void testIsEnabledWhenItReturnsFalse() {
+        when(nativeEnvelope.isEnabled()).thenReturn(false);
+        assertFalse(envelope.isEnabled());
+    }
+}

--- a/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceProducerTest.java
+++ b/appformer-kogito-bridge/src/test/java/org/appformer/kogito/bridge/client/guided/tour/service/GuidedTourServiceProducerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.guided.tour.service;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import elemental2.dom.Console;
+import elemental2.dom.DomGlobal;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.appformer.kogito.bridge.client.guided.tour.service.GuidedTourService.DEFAULT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GuidedTourServiceProducerTest {
+
+    private GuidedTourServiceProducer producer;
+
+    @Mock
+    private Console console;
+
+    @Before
+    public void setup() {
+        producer = spy(new GuidedTourServiceProducer());
+        DomGlobal.console = console;
+    }
+
+    @Test
+    public void testProduceWhenEnvelopeIsAvailable() {
+        doReturn(true).when(producer).isEnvelopeAvailable();
+
+        final GuidedTourService guidedTourService = producer.produce();
+
+        verifyNoMoreInteractions(console);
+        assertNotNull(guidedTourService);
+        assertNotEquals(DEFAULT, guidedTourService);
+    }
+
+    @Test
+    public void testProduceWhenEnvelopeIsNotAvailable() {
+        doReturn(false).when(producer).isEnvelopeAvailable();
+
+        final GuidedTourService guidedTourService = producer.produce();
+
+        verify(console).info("[GuidedTourServiceProducer] Envelope API is not available.");
+        assertNotNull(guidedTourService);
+        assertEquals(DEFAULT, guidedTourService);
+    }
+}


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-764

![2020-06-17 10 08 27](https://user-images.githubusercontent.com/1079279/84905077-8dd6eb00-b086-11ea-9bad-2da7de7405bd.gif)

<img width="2011" alt="Screen Shot 2020-06-17 at 10 09 17" src="https://user-images.githubusercontent.com/1079279/84905103-962f2600-b086-11ea-8930-3265372c824f.png">

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/988
- https://github.com/kiegroup/kie-wb-common/pull/3336
- https://github.com/kiegroup/kogito-tooling/pull/182

---

Assumptions:
- This PR does not include i18n for any tour. It will be separately implemented by https://issues.redhat.com/browse/KOGITO-2471;
- This PR does not include the final version of the tour, and the steps are a mix of the preliminary input provided by Liz and the Learn DMN in 15 minutes (as accordingly with @ederign).
