### PR TITLE
AF-2547: REST API for Dashbuilder Runtime

### DIFF
--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
@@ -16,10 +16,12 @@
 
 package org.dashbuilder.backend.resources.api;
 
-import java.util.List;
+import java.io.IOException;
 
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -27,15 +29,24 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.dashbuilder.backend.resources.FileUploadModel;
+import org.dashbuilder.backend.resources.UploadResourceImpl;
 import org.dashbuilder.backend.services.RuntimeInfoService;
 import org.dashbuilder.shared.model.DashbuilderRuntimeInfo;
+import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 
 @Path("api/")
 @Produces(MediaType.APPLICATION_JSON)
 public class DashbuilderRuntimeResource {
 
+    private static final String DASHBOARD_BASE_URI = "dashboard";
+    private static final String DASHBOARD_ID_URI = DASHBOARD_BASE_URI + "/{id}";
+
     @Inject
     RuntimeInfoService runtimeInfoService;
+
+    @Inject
+    UploadResourceImpl uploadResourceImpl;
 
     @GET
     public DashbuilderRuntimeInfo info() {
@@ -43,17 +54,18 @@ public class DashbuilderRuntimeResource {
     }
 
     @GET
-    @Path("dashboard")
-    public List<String> perspectives() {
-        return runtimeInfoService.singleModelDashboard();
-    }
-
-    @GET
-    @Path("dashboard/{id}")
+    @Path(DASHBOARD_ID_URI)
     public Response dashboard(@PathParam("id") String id) {
         return runtimeInfoService.dashboardInfo(id)
                                  .map(info -> Response.ok().entity(info).build())
                                  .orElse(Response.status(Status.NOT_FOUND).build());
+    }
+
+    @POST
+    @Path(DASHBOARD_BASE_URI)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response uploadResource(@MultipartForm FileUploadModel form) throws IOException {
+        return uploadResourceImpl.uploadFile(form);
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.backend.resources.api;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.dashbuilder.backend.services.RuntimeInfoService;
+import org.dashbuilder.shared.model.DashbuilderRuntimeInfo;
+
+@Path("api/")
+@Produces(MediaType.APPLICATION_JSON)
+public class DashbuilderRuntimeResource {
+
+    @Inject
+    RuntimeInfoService runtimeInfoService;
+
+    @GET
+    public DashbuilderRuntimeInfo info() {
+        return runtimeInfoService.info();
+    }
+
+    @GET
+    @Path("dashboard")
+    public List<String> perspectives() {
+        return runtimeInfoService.singleModelDashboard();
+    }
+
+    @GET
+    @Path("dashboard/{id}")
+    public Response dashboard(@PathParam("id") String id) {
+        return runtimeInfoService.dashboardInfo(id)
+                                 .map(info -> Response.ok().entity(info).build())
+                                 .orElse(Response.status(Status.NOT_FOUND).build());
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/RuntimeInfoService.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/RuntimeInfoService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.backend.services;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.dashbuilder.shared.model.DashboardInfo;
+import org.dashbuilder.shared.model.DashbuilderRuntimeInfo;
+
+/**
+ * Provides information about the running server.
+ *
+ */
+public interface RuntimeInfoService {
+
+    /**
+     * Access Server information.
+     */
+    DashbuilderRuntimeInfo info();
+
+    /**
+     * Information about a specific runtime model. Used in MULTI mode.
+     * 
+     * @param modelId
+     * The model ID.
+     * @return
+     * The dashboard information for the given runtime model id or empty if no dashboard is found.
+     */
+    Optional<DashboardInfo> dashboardInfo(String modelId);
+
+    /**
+     * List of perspectives when using single dashboard model. (STATIC on SINGLE modes)
+     * @return
+     * The list of perspectives or empty if no dashboard is installed or not in a single dashboard mode.
+     */
+    List<String> singleModelDashboard();
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/RuntimeInfoService.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/RuntimeInfoService.java
@@ -16,7 +16,6 @@
 
 package org.dashbuilder.backend.services;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.dashbuilder.shared.model.DashboardInfo;
@@ -42,12 +41,5 @@ public interface RuntimeInfoService {
      * The dashboard information for the given runtime model id or empty if no dashboard is found.
      */
     Optional<DashboardInfo> dashboardInfo(String modelId);
-
-    /**
-     * List of perspectives when using single dashboard model. (STATIC on SINGLE modes)
-     * @return
-     * The list of perspectives or empty if no dashboard is installed or not in a single dashboard mode.
-     */
-    List<String> singleModelDashboard();
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImpl.java
@@ -46,11 +46,8 @@ public class RuntimeInfoServiceImpl implements RuntimeInfoService {
 
     @Override
     public Optional<DashboardInfo> dashboardInfo(String modelId) {
-        Optional<RuntimeModel> runtimeModelOp = registry.get(modelId);
-        if (runtimeModelOp.isPresent()) {
-            return Optional.of(new DashboardInfo(modelId, perspectives(runtimeModelOp.get())));
-        }
-        return Optional.empty();
+        return registry.get(modelId)
+                       .map(model -> new DashboardInfo(modelId, perspectives(model)));
     }
 
     private List<String> perspectives(RuntimeModel runtimeModel) {

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.backend.services.impl;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.dashbuilder.backend.services.RuntimeInfoService;
+import org.dashbuilder.shared.model.DashboardInfo;
+import org.dashbuilder.shared.model.DashbuilderRuntimeInfo;
+import org.dashbuilder.shared.model.DashbuilderRuntimeMode;
+import org.dashbuilder.shared.model.RuntimeModel;
+import org.dashbuilder.shared.service.RuntimeModelRegistry;
+import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
+
+import static java.util.stream.Collectors.toList;
+
+@ApplicationScoped
+public class RuntimeInfoServiceImpl implements RuntimeInfoService {
+
+    @Inject
+    RuntimeModelRegistry registry;
+
+    @Override
+    public DashbuilderRuntimeInfo info() {
+        return new DashbuilderRuntimeInfo(registry.getMode().name(),
+                                          registry.availableModels(),
+                                          registry.acceptingNewImports());
+    }
+
+    @Override
+    public Optional<DashboardInfo> dashboardInfo(String modelId) {
+        Optional<RuntimeModel> runtimeModelOp = registry.get(modelId);
+        if (runtimeModelOp.isPresent()) {
+            return Optional.of(new DashboardInfo(modelId, perspectives(runtimeModelOp.get())));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<String> singleModelDashboard() {
+        if (!isMulti()) {
+            Optional<RuntimeModel> runtimeModelOp = registry.single();
+            if (runtimeModelOp.isPresent()) {
+                return perspectives(runtimeModelOp.get());
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private List<String> perspectives(RuntimeModel runtimeModel) {
+        return runtimeModel.getLayoutTemplates().stream()
+                           .map(LayoutTemplate::getName)
+                           .collect(toList());
+    }
+
+    private boolean isMulti() {
+        return registry.getMode() == DashbuilderRuntimeMode.MULTIPLE_IMPORT;
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImpl.java
@@ -16,7 +16,6 @@
 
 package org.dashbuilder.backend.services.impl;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,7 +25,6 @@ import javax.inject.Inject;
 import org.dashbuilder.backend.services.RuntimeInfoService;
 import org.dashbuilder.shared.model.DashboardInfo;
 import org.dashbuilder.shared.model.DashbuilderRuntimeInfo;
-import org.dashbuilder.shared.model.DashbuilderRuntimeMode;
 import org.dashbuilder.shared.model.RuntimeModel;
 import org.dashbuilder.shared.service.RuntimeModelRegistry;
 import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
@@ -55,25 +53,10 @@ public class RuntimeInfoServiceImpl implements RuntimeInfoService {
         return Optional.empty();
     }
 
-    @Override
-    public List<String> singleModelDashboard() {
-        if (!isMulti()) {
-            Optional<RuntimeModel> runtimeModelOp = registry.single();
-            if (runtimeModelOp.isPresent()) {
-                return perspectives(runtimeModelOp.get());
-            }
-        }
-        return Collections.emptyList();
-    }
-
     private List<String> perspectives(RuntimeModel runtimeModel) {
         return runtimeModel.getLayoutTemplates().stream()
                            .map(LayoutTemplate::getName)
                            .collect(toList());
-    }
-
-    private boolean isMulti() {
-        return registry.getMode() == DashbuilderRuntimeMode.MULTIPLE_IMPORT;
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
@@ -121,11 +121,11 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
 
     private String nextEntryContent(final ZipInputStream zis) {
         try {
-            final int BUFFER_SIZE = 1024;
+            final int BUFFER_SIZE = 8192;
             byte[] buffer = new byte[BUFFER_SIZE];
             int read = 0;
             String output = "";
-            while ((read = zis.read(buffer, 0, BUFFER_SIZE)) >= 0) {
+            while ((read = zis.read(buffer, 0, BUFFER_SIZE)) != -1) {
                 output = output.concat(new String(buffer, 0, read));
             }
             return output.trim();

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelRegistryImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelRegistryImpl.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.PostConstruct;
@@ -133,6 +134,11 @@ public class RuntimeModelRegistryImpl implements RuntimeModelRegistry {
         } catch (Exception e) {
             throw new IllegalArgumentException("Error parsing import model.");
         }
+    }
+
+    @Override
+    public Set<String> availableModels() {
+        return runtimeModels.keySet();
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashboardInfo.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashboardInfo.java
@@ -29,7 +29,6 @@ public class DashboardInfo {
     private Collection<String> pages;
 
     public DashboardInfo(String runtimeModelId, Collection<String> pages) {
-        super();
         this.runtimeModelId = runtimeModelId;
         this.pages = pages;
     }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashboardInfo.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashboardInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.shared.model;
+
+import java.util.Collection;
+
+/**
+ * Specific Dashboard information.
+ *
+ */
+public class DashboardInfo {
+
+    private String runtimeModelId;
+
+    private Collection<String> pages;
+
+    public DashboardInfo(String runtimeModelId, Collection<String> pages) {
+        super();
+        this.runtimeModelId = runtimeModelId;
+        this.pages = pages;
+    }
+
+    public String getRuntimeModelId() {
+        return runtimeModelId;
+    }
+
+    public Collection<String> getPages() {
+        return pages;
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashbuilderRuntimeInfo.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashbuilderRuntimeInfo.java
@@ -18,8 +18,6 @@ package org.dashbuilder.shared.model;
 
 import java.util.Collection;
 
-import org.jboss.errai.common.client.api.annotations.MapsTo;
-
 /**
  * Dashbuilder Runtime information.
  *
@@ -30,9 +28,9 @@ public class DashbuilderRuntimeInfo {
     private Collection<String> availableModels;
     private boolean acceptingNewImports;
 
-    public DashbuilderRuntimeInfo(@MapsTo("mode") String mode,
-                                  @MapsTo("availableModels") Collection<String> availableModels,
-                                  @MapsTo("acceptingNewImports") boolean acceptingNewImports) {
+    public DashbuilderRuntimeInfo(String mode,
+                                  Collection<String> availableModels,
+                                  boolean acceptingNewImports) {
         this.mode = mode;
         this.availableModels = availableModels;
         this.acceptingNewImports = acceptingNewImports;

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashbuilderRuntimeInfo.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/DashbuilderRuntimeInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.shared.model;
+
+import java.util.Collection;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+
+/**
+ * Dashbuilder Runtime information.
+ *
+ */
+public class DashbuilderRuntimeInfo {
+
+    private String mode;
+    private Collection<String> availableModels;
+    private boolean acceptingNewImports;
+
+    public DashbuilderRuntimeInfo(@MapsTo("mode") String mode,
+                                  @MapsTo("availableModels") Collection<String> availableModels,
+                                  @MapsTo("acceptingNewImports") boolean acceptingNewImports) {
+        this.mode = mode;
+        this.availableModels = availableModels;
+        this.acceptingNewImports = acceptingNewImports;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public Collection<String> getAvailableModels() {
+        return availableModels;
+    }
+
+    public boolean isAcceptingNewImports() {
+        return acceptingNewImports;
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/service/RuntimeModelRegistry.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/service/RuntimeModelRegistry.java
@@ -16,7 +16,9 @@
 
 package org.dashbuilder.shared.service;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.dashbuilder.shared.model.DashbuilderRuntimeMode;
 import org.dashbuilder.shared.model.RuntimeModel;
@@ -75,5 +77,10 @@ public interface RuntimeModelRegistry {
      * The path to the file
      */
     Optional<RuntimeModel> registerFile(String filePath);
-
+    
+    /**
+     * List all models that are currently available.
+     */
+    Set<String> availableModels();
+    
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/service/RuntimeModelRegistry.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/service/RuntimeModelRegistry.java
@@ -16,7 +16,6 @@
 
 package org.dashbuilder.shared.service;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 

--- a/dashbuilder/dashbuilder-runtime/src/main/webapp/WEB-INF/web.xml
+++ b/dashbuilder/dashbuilder-runtime/src/main/webapp/WEB-INF/web.xml
@@ -86,6 +86,7 @@
 	<security-constraint>
 		<web-resource-collection>
 			<web-resource-name>default</web-resource-name>
+			<url-pattern>/rest/*</url-pattern>
 			<url-pattern>/dashbuilder.html</url-pattern>
 			<url-pattern>/org.dashbuilder.DashbuilderRuntime/*</url-pattern>
 			<url-pattern>*.erraiBus</url-pattern>

--- a/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImplTest.java
+++ b/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/services/impl/RuntimeInfoServiceImplTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.backend.services.impl;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+
+import org.dashbuilder.shared.model.DashboardInfo;
+import org.dashbuilder.shared.model.DashbuilderRuntimeInfo;
+import org.dashbuilder.shared.model.DashbuilderRuntimeMode;
+import org.dashbuilder.shared.model.RuntimeModel;
+import org.dashbuilder.shared.service.RuntimeModelRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
+
+import static org.dashbuilder.shared.model.DashbuilderRuntimeMode.MULTIPLE_IMPORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RuntimeInfoServiceImplTest {
+
+    final static String RUNTIME_MODEL_ID = "ID";
+    final static String NOT_FOUND_ID = "NOT FOUND";
+    final static String LT_NAME = "LAYOUT TEMPLATE";
+
+    @Mock
+    RuntimeModel runtimeModel;
+
+    @Mock
+    RuntimeModelRegistry registry;
+
+    @InjectMocks
+    RuntimeInfoServiceImpl runtimeInfoService;
+
+    @Before
+    public void init() {
+        LayoutTemplate lt = new LayoutTemplate(LT_NAME);
+        when(runtimeModel.getLayoutTemplates()).thenReturn(Arrays.asList(lt));
+        when(registry.getMode()).thenReturn(MULTIPLE_IMPORT);
+        when(registry.get(RUNTIME_MODEL_ID)).thenReturn(Optional.of(runtimeModel));
+        when(registry.get(NOT_FOUND_ID)).thenReturn(Optional.empty());
+        when(registry.availableModels()).thenReturn(new HashSet<>(Arrays.asList(RUNTIME_MODEL_ID)));
+    }
+
+    @Test
+    public void testInfo() {
+        DashbuilderRuntimeInfo info = runtimeInfoService.info();
+
+        assertEquals(1, info.getAvailableModels().size());
+        assertTrue(info.getAvailableModels().contains(RUNTIME_MODEL_ID));
+        assertEquals(MULTIPLE_IMPORT.name(), info.getMode());
+        assertFalse(info.isAcceptingNewImports());
+    }
+
+    @Test
+    public void testDashboardInfoWithFoundModel() {
+        Optional<DashboardInfo> dashboardInfoOp = runtimeInfoService.dashboardInfo(RUNTIME_MODEL_ID);
+        DashboardInfo dashboardInfo = dashboardInfoOp.get();
+        assertEquals(1, dashboardInfo.getPages().size());
+        assertTrue(dashboardInfo.getPages().contains(LT_NAME));
+        assertEquals(RUNTIME_MODEL_ID, dashboardInfo.getRuntimeModelId());
+    }
+
+    @Test
+    public void testDashboardInfoWithNotFoundModel() {
+        Optional<DashboardInfo> dashboardInfoOp = runtimeInfoService.dashboardInfo(NOT_FOUND_ID);
+        assertFalse(dashboardInfoOp.isPresent());
+    }
+
+}


### PR DESCRIPTION
REST API for Dashbuilder Runtime.

The goal of this API is be a support for developers using dashboards outside of Dashbuilder Runtime:

* Inside React components (AF-2546);
* To compose embedded dashboards (see AF-2529);

The Available endpoints are:

`GET /api`: Provides server information: Runtime Mode and list of available models;
`POST /api/dashboard/`: Received a POST ZIP with dashboards and register it for use (upload);
`GET /api/dashboard/{id}`: Retrieves information about the dashboard {id}
