### PR TITLE
fixed real directory for Errai Wildfly distribution

### DIFF
--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -34,7 +34,7 @@
 
 	<properties>
 		<!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
-		<errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+		<errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
 		<gwt.compiler.skip>false</gwt.compiler.skip>
 		<gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
 	</properties>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
     <gwt.compiler.skip>false</gwt.compiler.skip>
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
   </properties>
@@ -895,7 +895,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}/standalone/deployments</outputDirectory>
+              <outputDirectory>${project.build.directory}/wildfly-${version.org.wildfly}/standalone/deployments</outputDirectory>
               <resources>
                 <resource>
                   <directory>src/test/resources/datasources</directory>

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <gwt.compiler.skip>false</gwt.compiler.skip>
     <!-- Add the absolute path for $JBOSS_HOME below to manage another instance -->
-    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</errai.jboss.home>
+    <errai.jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</errai.jboss.home>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This is a change for having always directory for Errai Wildfly unpacked distribution to be on the same name as original wildfly distribution as Errai just repackaged it so naming directory to that version is not confusing