### PR TITLE
KOGITO-2601: Move State Control API to kie-bc-editors

### DIFF
--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/stateControl/interop/StateControl.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/stateControl/interop/StateControl.java
@@ -24,7 +24,7 @@ import org.appformer.kogito.bridge.client.stateControl.registry.interop.KogitoJS
 /**
  * Represents the TypeScript StateControl engine present on the Envelope
  */
-@JsType(isNative = true, namespace = "window", name = "gwtStateControl")
+@JsType(isNative = true, namespace = "window", name = "gwt")
 public class StateControl {
 
     /**
@@ -51,6 +51,6 @@ public class StateControl {
     @JsMethod
     public native void setRedoCommand(StateControlCommand command);
 
-    @JsProperty
-    public static native StateControl get();
+    @JsProperty(name = "stateControl")
+    public native static StateControl get();
 }

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/stateControl/interop/StateControl.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/stateControl/interop/StateControl.java
@@ -24,12 +24,11 @@ import org.appformer.kogito.bridge.client.stateControl.registry.interop.KogitoJS
 /**
  * Represents the TypeScript StateControl engine present on the Envelope
  */
-@JsType(isNative = true, namespace = "window", name = "envelope")
+@JsType(isNative = true, namespace = "window", name = "gwtStateControl")
 public class StateControl {
 
     /**
      * Retrieves the {@link KogitoJSCommandRegistry}
-     *
      * @param <C> Anything that can be considered a command
      * @return The {@link KogitoJSCommandRegistry}
      */
@@ -39,7 +38,6 @@ public class StateControl {
     /**
      * Sets the {@link StateControlCommand} that will be called when the StateControl engine is notified to undo last
      * command on the {@link KogitoJSCommandRegistry}
-     *
      * @param command The command to execute on undo
      */
     @JsMethod
@@ -48,12 +46,11 @@ public class StateControl {
     /**
      * Sets the {@link StateControlCommand} that will be called when the StateControl engine is notified to redo last
      * undone command on the {@link KogitoJSCommandRegistry}
-     *
      * @param command The command to execute on redo
      */
     @JsMethod
     public native void setRedoCommand(StateControlCommand command);
 
-    @JsProperty(name = "stateControl")
+    @JsProperty
     public static native StateControl get();
 }


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-2601

Related PRs:
https://github.com/kiegroup/kogito-tooling/pull/200
https://github.com/kiegroup/appformer/pull/997