### PR TITLE
RHPAM-2981 :Unable to access business-central after user containing dot(.) character changes role settings

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/JAASAuthenticationService.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/JAASAuthenticationService.java
@@ -108,7 +108,7 @@ public class JAASAuthenticationService extends GroupAdapterAuthorizationSource i
                                                                      loginContext.getSubject(),
                                                                      new String[]{rolePrincipleName});
         Collection<Role> roles = getRoles(principals);
-        Collection<org.jboss.errai.security.shared.api.Group> groups = getGroups(principals);
+        Collection<org.jboss.errai.security.shared.api.Group> groups = getGroups(principals, username);
         UserImpl user = new UserImpl(username,
                                      roles,
                                      groups);

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
@@ -183,7 +183,7 @@ public class GroupAdapterAuthorizationSource {
      * For a given collection of principal names, return the Role instances for the ones
      * that are considered roles, so the ones that exist on the RoleRegistry.
      */
-    protected List<Group> getGroups(List<String> principals) {
+    protected List<Group> getGroups(List<String> principals, String user) {
 
         if (null != principals && !principals.isEmpty()) {
 
@@ -195,7 +195,7 @@ public class GroupAdapterAuthorizationSource {
 
                 for (String role : principals) {
 
-                    if (null == RoleRegistry.get().getRegisteredRole(role)) {
+                    if ( role != user && null == RoleRegistry.get().getRegisteredRole(role)) {
 
                         result.add(new GroupImpl(role));
                     }

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/ServletSecurityAuthenticationService.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/ServletSecurityAuthenticationService.java
@@ -137,7 +137,7 @@ public class ServletSecurityAuthenticationService extends GroupAdapterAuthorizat
                 if (null != roles && !roles.isEmpty()) {
                     userRoles.addAll(roles);
                 }
-                Collection<org.jboss.errai.security.shared.api.Group> userGroups = getGroups(principals);
+                Collection<org.jboss.errai.security.shared.api.Group> userGroups = getGroups(principals, name);
                 // Create the user instance.
                 user = new UserImpl(name,
                                     userRoles,


### PR DESCRIPTION
Removed username entry as part of user groups.
Due to this entry,  BC was creating an entry for user in security-policy.properties file. In absence of such entries, user with dot (.) character shouldn't throw any error.

backport PR: https://github.com/kiegroup/appformer/pull/1008