### PR TITLE
AF-2576: Allow users to export dashboards using REST API

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.transfer.rest;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import org.dashbuilder.transfer.DataTransferExportModel;
+import org.dashbuilder.transfer.DataTransferServices;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Paths;
+
+@ApplicationScoped
+@Path("dashbuilder")
+public class DataTransferResource {
+
+    @Inject
+    DataTransferServices dataTransferServices;
+
+    @Inject
+    @Named("ioStrategy")
+    IOService ioService;
+
+    @GET
+    @Path("export")
+    @Produces("application/zip")
+    public Response export() throws IOException {
+        String exportFile = dataTransferServices.doExport(DataTransferExportModel.exportAll());
+        org.uberfire.java.nio.file.Path path = Paths.get(exportFile);
+        return Response.ok(ioService.readAllBytes(path)).build();
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
@@ -28,12 +28,16 @@ import javax.ws.rs.core.Response;
 
 import org.dashbuilder.transfer.DataTransferExportModel;
 import org.dashbuilder.transfer.DataTransferServices;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Paths;
 
 @ApplicationScoped
 @Path("dashbuilder")
 public class DataTransferResource {
+
+    Logger logger = LoggerFactory.getLogger(DataTransferResource.class);
 
     @Inject
     DataTransferServices dataTransferServices;
@@ -45,10 +49,19 @@ public class DataTransferResource {
     @GET
     @Path("export")
     @Produces("application/zip")
-    public Response export() throws IOException {
-        String exportFile = dataTransferServices.doExport(DataTransferExportModel.exportAll());
-        org.uberfire.java.nio.file.Path path = Paths.get(exportFile);
-        return Response.ok(ioService.readAllBytes(path)).build();
+    public Response export() {
+        try {
+            String exportFile = dataTransferServices.doExport(DataTransferExportModel.exportAll());
+            org.uberfire.java.nio.file.Path path = Paths.get(exportFile);
+            return Response.ok(ioService.readAllBytes(path)).build();
+        } catch (Exception e) {
+            String errorMessage = "Error creating export: " + e.getMessage();
+            logger.error(errorMessage);
+            logger.debug("Not able to create export.", e);
+            return Response.serverError()
+                           .entity(errorMessage)
+                           .build();
+        }
     }
 
 }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
@@ -38,11 +38,11 @@ public class DataTransferResource {
     Logger logger = LoggerFactory.getLogger(DataTransferResource.class);
 
     @Inject
-    DataTransferServices dataTransferServices;
+    private DataTransferServices dataTransferServices;
 
     @Inject
     @Named("ioStrategy")
-    IOService ioService;
+    private IOService ioService;
 
     @GET
     @Path("export")

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/rest/DataTransferResource.java
@@ -16,8 +16,6 @@
 
 package org.dashbuilder.transfer.rest;
 
-import java.io.IOException;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/test/java/org/dashbuilder/transfer/rest/DataTransferResourceTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/test/java/org/dashbuilder/transfer/rest/DataTransferResourceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.transfer.rest;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.Response;
+
+import org.dashbuilder.transfer.DataTransferServices;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.io.IOService;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataTransferResourceTest {
+
+    @Mock
+    private DataTransferServices dataTransferServices;
+
+    @Mock
+    private IOService ioService;
+
+    @InjectMocks
+    DataTransferResource dataTransferResource;
+
+    @Test
+    public void testSuccessExport() throws IOException {
+        when(dataTransferServices.doExport(any())).thenReturn("file://.");
+        Response response = dataTransferResource.export();
+        assertEquals(Response.Status.OK.getStatusCode(),
+                     response.getStatus());
+    }
+
+    @Test
+    public void testBadExport() throws IOException {
+        when(dataTransferServices.doExport(any())).thenThrow(new IOException());
+        Response response = dataTransferResource.export();
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+                     response.getStatus());
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
@@ -16,7 +16,6 @@
 
 package org.dashbuilder.backend;
 
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Optional;
 

--- a/dashbuilder/dashbuilder-webapp/src/main/java/org/dashbuilder/backend/RuntimeJaxApp.java
+++ b/dashbuilder/dashbuilder-webapp/src/main/java/org/dashbuilder/backend/RuntimeJaxApp.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.backend;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public class RuntimeJaxApp extends Application {
+
+}


### PR DESCRIPTION
Exposing export feature in a REST endpoint.

Testing:

* Start Business Central
* Using a browser access http://localhost:8080/business-central/rest/dashbuilder/export
* A ZIP should be downloaded with pages, datasets and navigation
* Do the same with the Data Transfer UI - it should be the same ZIP.

