### PR TITLE
KOGITO-2120: Kogito Tooling i18n

### DIFF
--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nApi.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nApi.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.appformer.kogito.bridge.client.i18n;
+
+import elemental2.promise.Promise;
+
+public interface I18nApi {
+    /**
+     * Sets the {@link LocaleChangeCallback} that will be called when the locale changes on Kogito Channel
+     *
+     * @param callback The callback function to execute when locale changes
+     */
+    void onLocaleChange(LocaleChangeCallback callback);
+
+    /**
+     * Gets i18n locale from Kogito Channel
+     */
+    Promise<String> getLocale();
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nApiInteropWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nApiInteropWrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.i18n;
+
+import elemental2.promise.Promise;
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = "window", name = "envelope")
+public class I18nApiInteropWrapper {
+
+    @JsMethod
+    public native void onLocaleChange(LocaleChangeCallback callback);
+
+    @JsMethod
+    public native Promise<String> getLocale();
+
+    @JsProperty(name = "i18n")
+    public native static I18nApiInteropWrapper get();
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nApiInteropWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nApiInteropWrapper.java
@@ -30,6 +30,6 @@ public class I18nApiInteropWrapper {
     @JsMethod
     public native Promise<String> getLocale();
 
-    @JsProperty(name = "i18n")
+    @JsProperty(name = "i18nService")
     public native static I18nApiInteropWrapper get();
 }

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.i18n;
+
+import elemental2.promise.Promise;
+
+/**
+ * A {@link I18nApi} implementation used when envelope API is available
+ */
+public class I18nService implements I18nApi {
+    @Override
+    public void onLocaleChange(LocaleChangeCallback callback) {
+        I18nApiInteropWrapper.get().onLocaleChange(callback);
+    }
+
+    @Override
+    public Promise<String> getLocale() {
+        return I18nApiInteropWrapper.get().getLocale();
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nServiceProducer.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/I18nServiceProducer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.i18n;
+
+import elemental2.dom.DomGlobal;
+import org.appformer.kogito.bridge.client.interop.WindowRef;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+/**
+ * Produces {@link I18nService} beans according to whether the envelope API is available or not
+ */
+public class I18nServiceProducer {
+
+    @Produces
+    @ApplicationScoped
+    public I18nApi produce() {
+
+        if (WindowRef.isEnvelopeAvailable()) {
+            return new I18nService();
+        }
+
+        DomGlobal.console.debug("[I18nApiServiceProducer] Envelope API is not available. Producing NoOpI18nService");
+        return new NoOpI18nService();
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/LocaleChangeCallback.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/LocaleChangeCallback.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.i18n;
+
+import jsinterop.annotations.JsFunction;
+
+@JsFunction
+@FunctionalInterface
+public interface LocaleChangeCallback {
+
+    /**
+     * Executes the command
+     */
+    void execute(String locale);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/NoOpI18nService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/i18n/NoOpI18nService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.appformer.kogito.bridge.client.i18n;
+
+import elemental2.promise.Promise;
+
+/**
+ * This {@link I18nApi} implementation is used when the envelope API is not available
+ */
+public class NoOpI18nService implements I18nApi {
+
+    @Override
+    public void onLocaleChange(LocaleChangeCallback callback) {
+
+    }
+
+    @Override
+    public Promise<String> getLocale() {
+        return Promise.resolve("en");
+    }
+}


### PR DESCRIPTION
## Task
https://issues.redhat.com/browse/KOGITO-2120

## On this PR
Add the bridge to the i18n service on kogito-tooling.

Provides two methods:
 - onLocaleChange
Subscribes to locale changes with a callback.

 - getLocale
Get the current locale.