### PR TITLE
AF-2587: Indexes are removed when project is deleted

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/provider/InfinispanContext.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/provider/InfinispanContext.java
@@ -396,6 +396,11 @@ public class InfinispanContext implements Disposable {
         }
     }
 
+    public void deleteCache(String index){
+        String cacheName = AttributesUtil.toProtobufFormat(index).toLowerCase();
+        this.cacheManager.administration().removeCache(cacheName);
+    }
+
     public void observeInitialization(Runnable runnable) {
         this.initializationObserver = Optional.of(runnable);
     }

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/provider/InfinispanIndexProvider.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-infinispan/src/main/java/org/uberfire/ext/metadata/backend/infinispan/provider/InfinispanIndexProvider.java
@@ -86,7 +86,7 @@ public class InfinispanIndexProvider implements IndexProvider {
 
     @Override
     public void delete(String index) {
-
+        this.infinispanContext.deleteCache(index);
     }
 
     @Override

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/provider/LuceneIndexProvider.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/provider/LuceneIndexProvider.java
@@ -101,6 +101,7 @@ public class LuceneIndexProvider implements IndexProvider {
         indexManager.delete(new KClusterImpl(index));
     }
 
+
     @Override
     public void delete(String index,
                        String id) {


### PR DESCRIPTION
@RishiRajAnand @ederign 

The change is simple, I'm resolving a single path for the project to be deleted. The deletion already exist, I just did a small change to resolve the Path before the physical directory is deleted.