### PR TITLE
[7.39.x] JBPM-9216: upgrade of postgresql JDBC driver to 42.2.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <!-- database testing -->
     <version.org.mariadb.jdbc>1.3.6</version.org.mariadb.jdbc>
     <version.org.mysql-driver>5.1.6</version.org.mysql-driver>
-    <version.org.postgres-driver>9.1-901.jdbc4</version.org.postgres-driver>
+    <version.org.postgres-driver>42.2.14</version.org.postgres-driver>
 
     <!-- required to fix RHDM-293 -->
     <version.org.apache.logging.log4j.log4j-to-slf4j>2.9.0</version.org.apache.logging.log4j.log4j-to-slf4j>
@@ -1323,7 +1323,7 @@
       </dependency>
 
       <dependency>
-        <groupId>postgresql</groupId>
+        <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${version.org.postgres-driver}</version>
         <scope>test</scope>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9216
parent PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1428