### PR TITLE
GWT-2.9: Make appformer repository compiling on jdk11

### DIFF
--- a/appformer-kogito-bridge/pom.xml
+++ b/appformer-kogito-bridge/pom.xml
@@ -60,6 +60,10 @@
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
 

--- a/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-dataset-cdi/pom.xml
@@ -165,6 +165,12 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
@@ -40,6 +40,12 @@
 			<groupId>org.jboss.resteasy</groupId>
 			<artifactId>resteasy-client</artifactId>
 			<scope>provided</scope>
+			<exclusions>
+              <exclusion>
+               <groupId>org.jboss.spec.javax.annotation</groupId>
+               <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+              </exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
@@ -41,10 +41,10 @@
 			<artifactId>resteasy-client</artifactId>
 			<scope>provided</scope>
 			<exclusions>
-              <exclusion>
-               <groupId>org.jboss.spec.javax.annotation</groupId>
-               <artifactId>jboss-annotations-api_1.3_spec</artifactId>
-              </exclusion>
+				<exclusion>
+					<groupId>org.jboss.spec.javax.annotation</groupId>
+					<artifactId>jboss-annotations-api_1.3_spec</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-navigation-backend/pom.xml
@@ -58,6 +58,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/pom.xml
@@ -98,6 +98,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/ExternalComponentView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/ExternalComponentView.java
@@ -23,6 +23,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLIFrameElement;
 import elemental2.dom.MessageEvent;
@@ -64,16 +65,7 @@ public class ExternalComponentView extends Composite implements ExternalComponen
     public void setComponentURL(String url) {
         externalComponentIFrame.src = url;
         componentReady = false;
-        externalComponentIFrame.onload = e -> {
-            componentReady = true;
-            if (lastProps != null) {
-                postMessageToComponent(lastProps);
-            }
-            if (lastMessage != null) {
-                postMessageToComponent(lastMessage);
-            }
-            return null;
-        };
+        externalComponentIFrame.onload = this::onInvoke;
     }
 
     @Override
@@ -82,7 +74,6 @@ public class ExternalComponentView extends Composite implements ExternalComponen
         if (componentReady) {
             postMessageToComponent(message);
         }
-
     }
 
     private void postMessageToComponent(Object message) {
@@ -91,4 +82,17 @@ public class ExternalComponentView extends Composite implements ExternalComponen
         }
     }
 
+    /**
+     * Workaround to resolve generics after GWT upgrade. See https://issues.redhat.com/browse/AF-2542
+     */
+    private Object onInvoke(Event e) {
+        componentReady = true;
+        if (lastProps != null) {
+            postMessageToComponent(lastProps);
+        }
+        if (lastMessage != null) {
+            postMessageToComponent(lastMessage);
+        }
+        return null;
+    }
 }

--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -613,6 +613,10 @@
       <artifactId>resteasy-cdi</artifactId>
       <scope>provided</scope>
       <exclusions>
+				<exclusion>
+					<groupId>org.jboss.spec.javax.annotation</groupId>
+					<artifactId>jboss-annotations-api_1.3_spec</artifactId>
+				</exclusion>
         <exclusion>
           <groupId>javax.annotation</groupId>
           <artifactId>jsr250-api</artifactId>
@@ -625,6 +629,10 @@
       <artifactId>resteasy-jaxrs</artifactId>
       <scope>provided</scope>
       <exclusions>
+				<exclusion>
+ 					<groupId>org.jboss.spec.javax.annotation</groupId>
+ 					<artifactId>jboss-annotations-api_1.3_spec</artifactId>
+ 				</exclusion>
         <!-- Collides with org.javassist:javassist -->
         <exclusion>
           <groupId>javassist</groupId>

--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -613,10 +613,10 @@
       <artifactId>resteasy-cdi</artifactId>
       <scope>provided</scope>
       <exclusions>
-				<exclusion>
-					<groupId>org.jboss.spec.javax.annotation</groupId>
-					<artifactId>jboss-annotations-api_1.3_spec</artifactId>
-				</exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>javax.annotation</groupId>
           <artifactId>jsr250-api</artifactId>
@@ -629,10 +629,10 @@
       <artifactId>resteasy-jaxrs</artifactId>
       <scope>provided</scope>
       <exclusions>
-				<exclusion>
- 					<groupId>org.jboss.spec.javax.annotation</groupId>
- 					<artifactId>jboss-annotations-api_1.3_spec</artifactId>
- 				</exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
         <!-- Collides with org.javassist:javassist -->
         <exclusion>
           <groupId>javassist</groupId>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-navigation-api/pom.xml
@@ -44,6 +44,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -32,12 +32,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.1_spec</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
     <version.org.webjars.bower.d3geoprojection>2.5.1</version.org.webjars.bower.d3geoprojection>
     <version.org.webjars.bower.jqueryui>1.12.1</version.org.webjars.bower.jqueryui>
 
-    <version.org.jboss.byteman>3.0.10</version.org.jboss.byteman>
     <version.org.jboss.jboss-msc>1.2.7.SP1</version.org.jboss.jboss-msc>
 
     <version.org.apache.activemq.artemis>2.3.0</version.org.apache.activemq.artemis>

--- a/uberfire-backend/uberfire-backend-cdi/pom.xml
+++ b/uberfire-backend/uberfire-backend-cdi/pom.xml
@@ -43,11 +43,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.spec.javax.interceptor</groupId>
       <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
       <scope>provided</scope>
@@ -154,6 +149,12 @@
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/uberfire-backend/uberfire-backend-server/pom.xml
+++ b/uberfire-backend/uberfire-backend-server/pom.xml
@@ -138,6 +138,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Encryption\Decryption service-->

--- a/uberfire-commons/pom.xml
+++ b/uberfire-commons/pom.xml
@@ -103,6 +103,10 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
     <!-- /ActiveMQ (artemis) -->
   </dependencies>
 

--- a/uberfire-experimental/uberfire-experimental-backend/pom.xml
+++ b/uberfire-experimental/uberfire-experimental-backend/pom.xml
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-experimental/uberfire-experimental-client/pom.xml
+++ b/uberfire-experimental/uberfire-experimental-client/pom.xml
@@ -48,6 +48,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/pom.xml
@@ -38,6 +38,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/pom.xml
@@ -54,6 +54,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.soup</groupId>

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/pom.xml
@@ -44,6 +44,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- as javax.inject is excluded in parent pom's errai-bus dep. It had to be declared here -->

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/pom.xml
@@ -93,6 +93,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/pom.xml
@@ -67,6 +67,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-backend/pom.xml
@@ -65,6 +65,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/pom.xml
@@ -114,6 +114,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/pom.xml
@@ -88,6 +88,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
@@ -80,6 +80,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
@@ -95,6 +95,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-tomcat/pom.xml
@@ -71,6 +71,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-wildfly/pom.xml
@@ -75,6 +75,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/pom.xml
@@ -131,6 +131,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/pom.xml
@@ -44,6 +44,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/pom.xml
@@ -52,6 +52,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.gwt</groupId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/pom.xml
@@ -121,6 +121,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-service/uberfire-widgets-service-backend/pom.xml
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-bpmn/uberfire-wires-bpmn-backend/pom.xml
@@ -98,6 +98,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/pom.xml
@@ -130,6 +130,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/pom.xml
@@ -65,6 +65,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-message-console/uberfire-message-console-client/pom.xml
+++ b/uberfire-message-console/uberfire-message-console-client/pom.xml
@@ -55,6 +55,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
@@ -149,6 +149,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/BaseGitCommand.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/BaseGitCommand.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.apache.sshd.common.channel.ChannelOutputStream;
 import org.apache.sshd.common.session.Session;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.SessionAware;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHService.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHService.java
@@ -33,7 +33,7 @@ import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.CachingPublicKeyAuthenticator;
 import org.apache.sshd.server.keyprovider.AbstractGeneratorHostKeyProvider;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.scp.UnknownCommand;
+import org.apache.sshd.server.shell.UnknownCommand;
 import org.eclipse.jgit.transport.resolver.ReceivePackFactory;
 import org.eclipse.jgit.transport.resolver.UploadPackFactory;
 import org.jboss.errai.security.shared.api.identity.User;

--- a/uberfire-nio2-backport/uberfire-nio2-model/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-model/pom.xml
@@ -34,6 +34,16 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-preferences/uberfire-preferences-backend/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-backend/pom.xml
@@ -42,6 +42,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/uberfire-preferences/uberfire-preferences-client-backend/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-client-backend/pom.xml
@@ -68,6 +68,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-preferences/uberfire-preferences-client/pom.xml
+++ b/uberfire-preferences/uberfire-preferences-client/pom.xml
@@ -63,6 +63,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-project/uberfire-project-backend/pom.xml
+++ b/uberfire-project/uberfire-project-backend/pom.xml
@@ -214,11 +214,12 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-rest/uberfire-rest-backend/pom.xml
+++ b/uberfire-rest/uberfire-rest-backend/pom.xml
@@ -72,10 +72,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-    </dependency>
     <!-- REST dependencies -->
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>

--- a/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/UserManagementHelperTest.java
+++ b/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/UserManagementHelperTest.java
@@ -18,7 +18,6 @@ package org.guvnor.rest.backend;
 
 import java.util.Arrays;
 
-import javax.jws.soap.SOAPBinding;
 import javax.ws.rs.core.Response;
 
 import org.guvnor.common.services.project.service.WorkspaceProjectService;

--- a/uberfire-security/uberfire-security-api/pom.xml
+++ b/uberfire-security/uberfire-security-api/pom.xml
@@ -43,11 +43,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>

--- a/uberfire-security/uberfire-security-client-backend/pom.xml
+++ b/uberfire-security/uberfire-security-client-backend/pom.xml
@@ -77,6 +77,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-security/uberfire-security-client/pom.xml
+++ b/uberfire-security/uberfire-security-client/pom.xml
@@ -72,6 +72,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-security/uberfire-security-codegen/pom.xml
+++ b/uberfire-security/uberfire-security-codegen/pom.xml
@@ -63,6 +63,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-server/pom.xml
+++ b/uberfire-server/pom.xml
@@ -49,6 +49,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.errai</groupId>

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -164,6 +164,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-ssh/uberfire-ssh-backend/pom.xml
+++ b/uberfire-ssh/uberfire-ssh-backend/pom.xml
@@ -22,6 +22,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-structure/uberfire-structure-api/pom.xml
+++ b/uberfire-structure/uberfire-structure-api/pom.xml
@@ -53,6 +53,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -179,6 +179,12 @@
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-structure/uberfire-structure-client/pom.xml
+++ b/uberfire-structure/uberfire-structure-client/pom.xml
@@ -49,6 +49,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-test-utils/pom.xml
+++ b/uberfire-test-utils/pom.xml
@@ -57,6 +57,12 @@
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -94,11 +100,6 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-lucene</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.spec.javax.annotation</groupId>
-      <artifactId>jboss-annotations-api_1.2_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-testing-utils/pom.xml
+++ b/uberfire-testing-utils/pom.xml
@@ -56,6 +56,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -70,6 +70,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.soup</groupId>

--- a/uberfire-workbench/uberfire-workbench-client/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client/pom.xml
@@ -70,6 +70,12 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.elemental2</groupId>


### PR DESCRIPTION
This PR is a draft. Description will be updated!

Dependent on #1030 

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1450
* https://github.com/kiegroup/kie-wb-common/pull/3406

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>

I was able to run showcase webapp as `mvn clean gwt:run` see screenshot below
![Screenshot from 2020-08-31 19-07-00](https://user-images.githubusercontent.com/8044780/91747544-abfcb380-ebbe-11ea-9236-ee6ba5c1cafe.png)
