### PR TITLE
AF-2555: Link BC <-> DB

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/DataTransferServicesImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/DataTransferServicesImpl.java
@@ -89,6 +89,7 @@ public class DataTransferServicesImpl implements DataTransferServices {
 
     private String dashbuilderLocation;
     private String exportDir;
+    private boolean shareOpenModel;
 
     public DataTransferServicesImpl() {
         // empty constructor
@@ -127,6 +128,9 @@ public class DataTransferServicesImpl implements DataTransferServices {
     public void init() {
         dashbuilderLocation = System.getProperty(DB_STANDALONE_LOCATION_PROP);
         exportDir = System.getProperty(EXPORT_LOCATION_PROP);
+
+        String shareOpenModelStr = System.getProperty(SHARE_OPEN_MODEL_PROP, Boolean.FALSE.toString());
+        shareOpenModel = Boolean.parseBoolean(shareOpenModelStr);
     }
 
     @Override
@@ -265,7 +269,8 @@ public class DataTransferServicesImpl implements DataTransferServices {
         }
         try {
             String path = this.doExport(exportModel);
-            String fileName = sessionInfo.getIdentity().getIdentifier() + "-dashboard-latest";
+            String prefix = shareOpenModel ? "business-central" : sessionInfo.getIdentity().getIdentifier();
+            String fileName = prefix + "-dashboard-latest";
             String destination = new StringBuilder().append(exportDir)
                                                     .append(File.separator)
                                                     .append(fileName)

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/DataTransferServicesImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/DataTransferServicesImpl.java
@@ -86,12 +86,14 @@ public class DataTransferServicesImpl implements DataTransferServices {
     private NavTreeStorage navTreeStorage;
     private byte[] buffer = new byte[1024];
     private ExternalComponentLoader externalComponentLoader;
-    
+
     private String dashbuilderLocation;
     private String exportDir;
 
-    public DataTransferServicesImpl() {}
-    
+    public DataTransferServicesImpl() {
+        // empty constructor
+    }
+
     @Inject
     public DataTransferServicesImpl(
                                     final @Named("ioStrategy") IOService ioService,
@@ -126,7 +128,7 @@ public class DataTransferServicesImpl implements DataTransferServices {
         dashbuilderLocation = System.getProperty(DB_STANDALONE_LOCATION_PROP);
         exportDir = System.getProperty(EXPORT_LOCATION_PROP);
     }
-    
+
     @Override
     public String doExport(DataTransferExportModel exportModel) throws java.io.IOException {
         String zipLocation = new StringBuilder().append(System.getProperty("java.io.tmpdir"))
@@ -163,18 +165,18 @@ public class DataTransferServicesImpl implements DataTransferServices {
 
         if (externalComponentLoader.isEnabled()) {
             String componentsPath = externalComponentLoader.getExternalComponentsDir();
-    
+
             if (componentsPath != null && exists(componentsPath)) {
                 Path componentsBasePath = Paths.get(new StringBuilder().append(SpacesAPI.Scheme.FILE)
-                                                    .append("://")
-                                                    .append(componentsPath)
-                                                    .toString());
-                externalComponentLoader.load().forEach(c -> {                
-                 Path componentPath = componentsBasePath.resolve(c.getId());
-                 zipComponentFiles(componentsBasePath,
-                                   componentPath,
-                                   zos,
-                                   p -> true);
+                                                                       .append("://")
+                                                                       .append(componentsPath)
+                                                                       .toString());
+                externalComponentLoader.load().forEach(c -> {
+                    Path componentPath = componentsBasePath.resolve(c.getId());
+                    zipComponentFiles(componentsBasePath,
+                                      componentPath,
+                                      zos,
+                                      p -> true);
                 });
             }
         }
@@ -253,10 +255,9 @@ public class DataTransferServicesImpl implements DataTransferServices {
                                                                                .map(this::parseDataSetDefinition)
                                                                                .filter(DataSetDef::isPublic)
                                                                                .collect(Collectors.toList());
-        boolean connectedToDashbuilder = isExternalServerConfigured();
-        return new ExportInfo(datasetsDefs, pages, connectedToDashbuilder);
+        return new ExportInfo(datasetsDefs, pages, isExternalServerConfigured());
     }
-    
+
     @Override
     public String generateExportUrl(DataTransferExportModel exportModel) throws Exception {
         if (!isExternalServerConfigured()) {
@@ -277,9 +278,9 @@ public class DataTransferServicesImpl implements DataTransferServices {
             LOGGER.error("Error generating model link.", e);
             throw new RuntimeException("Error generating model link.", e);
         }
-        
+
     }
-    
+
     private boolean isExternalServerConfigured() {
         return exportDir != null && dashbuilderLocation != null;
     }
@@ -608,7 +609,7 @@ public class DataTransferServicesImpl implements DataTransferServices {
             return false;
         };
     }
-    
+
     private boolean exists(String file) {
         return java.nio.file.Files.exists(java.nio.file.Paths.get(file));
     }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/DataTransferServicesImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/DataTransferServicesImpl.java
@@ -275,7 +275,7 @@ public class DataTransferServicesImpl implements DataTransferServices {
             return new URIBuilder(dashbuilderLocation).addParameter("import", fileName).toString();
         } catch (Exception e) {
             LOGGER.error("Error generating model link.", e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error generating model link.", e);
         }
         
     }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/ExportModelValidationServiceImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/main/java/org/dashbuilder/transfer/ExportModelValidationServiceImpl.java
@@ -90,8 +90,7 @@ public class ExportModelValidationServiceImpl implements ExportModelValidationSe
                                         .map(DisplayerSettings::getDataSetLookup)
                                         .filter(Objects::nonNull)
                                         .map(DataSetLookup::getDataSetUUID)
-                                        .filter(Objects::nonNull)
-                                        ;
+                                        .filter(Objects::nonNull);
     }
 
 }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/test/java/org/dashbuilder/transfer/DataTransferServicesTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/test/java/org/dashbuilder/transfer/DataTransferServicesTest.java
@@ -559,12 +559,12 @@ public class DataTransferServicesTest {
         createFile(perspectivesFS, PAGE, "");
         createFile(perspectivesFS, PAGE_PLUGIN, "");
 
-        ExportInfo assetsToExport = dataTransferServices.exportInfo();
+        ExportInfo exportInfo = dataTransferServices.exportInfo();
 
-        assertEquals(1, assetsToExport.getDatasetsDefinitions().size());
-        assertEquals(DS_NAME, assetsToExport.getDatasetsDefinitions().get(0).getName());
-        assertEquals(1, assetsToExport.getPages().size());
-        assertEquals(PAGE_ID, assetsToExport.getPages().get(0));
+        assertEquals(1, exportInfo.getDatasetsDefinitions().size());
+        assertEquals(DS_NAME, exportInfo.getDatasetsDefinitions().get(0).getName());
+        assertEquals(1, exportInfo.getPages().size());
+        assertEquals(PAGE_ID, exportInfo.getPages().get(0));
         
         cleanFileSystems();
     }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-services/src/test/java/org/dashbuilder/transfer/DataTransferServicesTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-services/src/test/java/org/dashbuilder/transfer/DataTransferServicesTest.java
@@ -559,7 +559,7 @@ public class DataTransferServicesTest {
         createFile(perspectivesFS, PAGE, "");
         createFile(perspectivesFS, PAGE_PLUGIN, "");
 
-        DataTransferAssets assetsToExport = dataTransferServices.assetsToExport();
+        ExportInfo assetsToExport = dataTransferServices.exportInfo();
 
         assertEquals(1, assetsToExport.getDatasetsDefinitions().size());
         assertEquals(DS_NAME, assetsToExport.getDatasetsDefinitions().get(0).getName());
@@ -571,7 +571,7 @@ public class DataTransferServicesTest {
     
     @Test
     public void testAssetsToImportNoFiles() {
-        DataTransferAssets assetsToExport = dataTransferServices.assetsToExport();
+        ExportInfo assetsToExport = dataTransferServices.exportInfo();
         assertTrue(assetsToExport.getDatasetsDefinitions().isEmpty());
         assertTrue(assetsToExport.getPages().isEmpty());
     }
@@ -607,7 +607,7 @@ public class DataTransferServicesTest {
 
         createFile(datasetsFS, DS, DS_CONTENT);
 
-        DataTransferAssets assetsToExport = dataTransferServices.assetsToExport();
+        ExportInfo assetsToExport = dataTransferServices.exportInfo();
 
         assertTrue(assetsToExport.getDatasetsDefinitions().isEmpty());
         

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/resources/i18n/ContentManagerConstants.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/resources/i18n/ContentManagerConstants.java
@@ -147,4 +147,6 @@ public interface ContentManagerConstants extends Messages {
     String navigationHelpText();
 
     String validationError();
+
+    String openHelpText();
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/DataTransferView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/DataTransferView.java
@@ -183,4 +183,9 @@ public class DataTransferView implements DataTransferScreen.View, IsElement {
             btnImport.disabled = false;
         }
     }
+
+    @Override
+    public void openUrl(String url) {
+        DomGlobal.window.open(url, "_blank");
+    }
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.html
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.html
@@ -43,6 +43,8 @@
         <div class="blank-slate-pf-main-action">
             <button class="btn btn-primary btn-lg" id="downloadExport"
                 data-i18n-key="download"></button>
+            <button class="btn btn-primary btn-lg" id="openExport"
+                data-i18n-key="open"></button>
         </div>
     </div>
 </div>

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.html
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.html
@@ -34,13 +34,14 @@
                         id="pagesInfoAnchor"><span
                         id="pagesInformation"></span></a>
                 </div>
-                <div class="list-group-item" id="navigationSummaryContainer">
+                <div class="list-group-item"
+                    id="navigationSummaryContainer">
                     <span class="fa fa-navicon"></span> <span
                         data-i18n-key="navigation"></span>
                 </div>
             </div>
         </div>
-        <div class="blank-slate-pf-main-action">
+        <div class="blank-slate-pf-main-action" id="actionsContainer">
             <button class="btn btn-primary btn-lg" id="downloadExport"
                 data-i18n-key="download"></button>
             <button class="btn btn-primary btn-lg" id="openExport"

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.java
@@ -79,6 +79,10 @@ public class ExportSummaryWizardPageView implements ExportSummaryWizardPage.View
 
     @Inject
     @DataField
+    HTMLButtonElement openExport;
+
+    @Inject
+    @DataField
     @Named("h1")
     HTMLHeadingElement exportHeading;
 
@@ -124,6 +128,11 @@ public class ExportSummaryWizardPageView implements ExportSummaryWizardPage.View
     @EventHandler("downloadExport")
     public void downloadAction(ClickEvent click) {
         presenter.confirmDownload();
+    }
+
+    @EventHandler("openExport")
+    public void openAction(ClickEvent click) {
+        presenter.openExport();
     }
 
     @EventHandler("datasetsInfoAnchor")
@@ -205,6 +214,11 @@ public class ExportSummaryWizardPageView implements ExportSummaryWizardPage.View
         wbNotification.fire(new NotificationEvent(i18n.validationError(),
                                                   NotificationEvent.NotificationType.ERROR));
     }
+    
+    @Override
+    public void showOpenExport(boolean externalServerAvailable) {
+        openExport.style.visibility = externalServerAvailable ? "visible" : "hidden";
+    }
 
     private void errorState() {
         state("pficon pficon-error-circle-o",
@@ -229,6 +243,7 @@ public class ExportSummaryWizardPageView implements ExportSummaryWizardPage.View
         exportHeading.textContent = headingText;
         alertContainer.hidden = hideAlert;
         downloadExport.disabled = hideDownload;
+        openExport.disabled = hideDownload;
     }
 
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageView.java
@@ -24,6 +24,7 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.google.gwt.dom.client.Style.VerticalAlign;
 import com.google.gwt.event.dom.client.ClickEvent;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLAnchorElement;
@@ -80,6 +81,10 @@ public class ExportSummaryWizardPageView implements ExportSummaryWizardPage.View
     @Inject
     @DataField
     HTMLButtonElement openExport;
+    
+    @Inject
+    @DataField
+    HTMLDivElement actionsContainer;
 
     @Inject
     @DataField
@@ -109,11 +114,18 @@ public class ExportSummaryWizardPageView implements ExportSummaryWizardPage.View
     private Event<NotificationEvent> wbNotification;
 
     private ExportSummaryWizardPage presenter;
+    
+    private HelpIcon openHelp;
 
     @Override
     public void init(ExportSummaryWizardPage presenter) {
         this.presenter = presenter;
         alertContainer.hidden = true;
+        
+        openHelp = new HelpIcon();
+        openHelp.setHelpContent(i18n.openHelpText());
+        openHelp.getElement().getStyle().setVerticalAlign(VerticalAlign.SUPER);
+        elementalUtil.appendWidgetToElement(actionsContainer, openHelp);
 
         HelpIcon navigationhelp = new HelpIcon();
         navigationhelp.setHelpContent(i18n.navigationHelpText());
@@ -218,6 +230,7 @@ public class ExportSummaryWizardPageView implements ExportSummaryWizardPage.View
     @Override
     public void showOpenExport(boolean externalServerAvailable) {
         openExport.style.visibility = externalServerAvailable ? "visible" : "hidden";
+        openHelp.setVisible(externalServerAvailable);
     }
 
     private void errorState() {

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportWizard.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportWizard.java
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.Widget;
 import org.dashbuilder.client.cms.resources.i18n.ContentManagerConstants;
-import org.dashbuilder.transfer.DataTransferAssets;
+import org.dashbuilder.transfer.ExportInfo;
 import org.dashbuilder.transfer.DataTransferExportModel;
 import org.uberfire.client.callbacks.Callback;
 import org.uberfire.ext.widgets.core.client.wizards.AbstractWizard;
@@ -67,10 +67,10 @@ public class ExportWizard extends AbstractWizard {
         exportSummaryWizardPage.setGoToPagesCommand(() -> goTo(pagesWizardPage));
     }
 
-    public void start(DataTransferAssets assets) {
-        dataSetsWizardPage.setDataSets(assets.getDatasetsDefinitions());
-        pagesWizardPage.setPages(assets.getPages());
-        exportSummaryWizardPage.setAssets(assets);
+    public void start(ExportInfo exportInfo) {
+        dataSetsWizardPage.setDataSets(exportInfo.getDatasetsDefinitions());
+        pagesWizardPage.setPages(exportInfo.getPages());
+        exportSummaryWizardPage.setExportInfo(exportInfo);
         this.start();
     }
 
@@ -114,8 +114,12 @@ public class ExportWizard extends AbstractWizard {
                                            true);
     }
 
-    public void setCallback(ParameterizedCommand<DataTransferExportModel> dataTransferExportModelCallback) {
-        exportSummaryWizardPage.setCallback(dataTransferExportModelCallback);
+    public void setDownloadCallback(ParameterizedCommand<DataTransferExportModel> dataTransferExportModelCallback) {
+        exportSummaryWizardPage.setDownloadCallback(dataTransferExportModelCallback);
+    }
+    
+    public void setOpenCallback(ParameterizedCommand<DataTransferExportModel> dataTransferExportModelCallback) {
+        exportSummaryWizardPage.setOpenCallback(dataTransferExportModelCallback);
     }
     
     @Override

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/resources/org/dashbuilder/client/cms/resources/i18n/ContentManagerConstants.properties
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/resources/org/dashbuilder/client/cms/resources/i18n/ContentManagerConstants.properties
@@ -70,6 +70,7 @@ datasetLabel=dataset
 pagesLabel=pages
 datasetsLabel=datasets
 ExportSummaryWizardPageView.download=Download
+ExportSummaryWizardPageView.open=Open
 ExportSummaryWizardPageView.navigation=Navigation
 ExportSummaryWizardPageView.errorHighlightedMessage=Missing Dependencies!
 ExportSummaryWizardPageView.summary=Summary

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/resources/org/dashbuilder/client/cms/resources/i18n/ContentManagerConstants.properties
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/main/resources/org/dashbuilder/client/cms/resources/i18n/ContentManagerConstants.properties
@@ -86,3 +86,4 @@ missingDependencies=Some dependencies were not fulfilled:
 nothingToExport=No page or dataset was selected to export
 navigationHelpText=Navigation is always exported.
 validationError=Export validation error. Check logs.
+openHelpText=Open in the connected Dashbuilder Standalone Server

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/test/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageTest.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/test/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageTest.java
@@ -52,9 +52,9 @@ public class ExportSummaryWizardPageTest {
         HashMap<String, List<String>> validation = new HashMap<>();
         validation.put(PAGE, Collections.singletonList(UUID));
 
-        ExportInfo assets = new ExportInfo(Collections.singletonList(def1), Collections.emptyList(), false);
+        ExportInfo exportInfo = new ExportInfo(Collections.singletonList(def1), Collections.emptyList(), false);
 
-        exportWizardSummaryPage.setExportInfo(assets);
+        exportWizardSummaryPage.setExportInfo(exportInfo);
         exportWizardSummaryPage.remapMissingDependencies(validation);
         
         assertEquals(NAME, validation.get(PAGE).get(0));
@@ -71,5 +71,5 @@ public class ExportSummaryWizardPageTest {
         
         assertEquals(UUID, validation.get(PAGE).get(0));
     }
-
+    
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/test/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageTest.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-cms-client/src/test/java/org/dashbuilder/client/cms/screen/transfer/export/wizard/ExportSummaryWizardPageTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.dashbuilder.dataset.def.DataSetDef;
-import org.dashbuilder.transfer.DataTransferAssets;
+import org.dashbuilder.transfer.ExportInfo;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,9 +52,9 @@ public class ExportSummaryWizardPageTest {
         HashMap<String, List<String>> validation = new HashMap<>();
         validation.put(PAGE, Collections.singletonList(UUID));
 
-        DataTransferAssets assets = new DataTransferAssets(Collections.singletonList(def1), Collections.emptyList());
+        ExportInfo assets = new ExportInfo(Collections.singletonList(def1), Collections.emptyList(), false);
 
-        exportWizardSummaryPage.setAssets(assets);
+        exportWizardSummaryPage.setExportInfo(assets);
         exportWizardSummaryPage.remapMissingDependencies(validation);
         
         assertEquals(NAME, validation.get(PAGE).get(0));

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/ExternalComponentsContentListener.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/ExternalComponentsContentListener.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.backend;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+import org.dashbuilder.external.service.ExternalComponentLoader;
+import org.dashbuilder.shared.event.RemovedRuntimeModelEvent;
+
+/**
+ * When a runtime model is removed then we should remove components content as well.
+ *
+ */
+@ApplicationScoped
+public class ExternalComponentsContentListener {
+
+    @Inject
+    ExternalComponentLoader loader;
+
+    @Inject
+    RuntimeOptions options;
+
+    public void onRuntimeModelRemoved(@Observes RemovedRuntimeModelEvent event) {
+        String externalComponentsDir = loader.getExternalComponentsDir();
+        String runtimeModelId = event.getRuntimeModelId();
+        if (options.isComponentPartition()) {
+            File runtimeModelComponentsFile = Paths.get(externalComponentsDir, runtimeModelId).toFile();
+            FileUtils.deleteQuietly(runtimeModelComponentsFile);
+        }
+
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/ExternalComponentsContentListener.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/ExternalComponentsContentListener.java
@@ -41,11 +41,13 @@ public class ExternalComponentsContentListener {
     RuntimeOptions options;
 
     public void onRuntimeModelRemoved(@Observes RemovedRuntimeModelEvent event) {
-        String externalComponentsDir = loader.getExternalComponentsDir();
-        String runtimeModelId = event.getRuntimeModelId();
         if (options.isComponentPartition()) {
-            File runtimeModelComponentsFile = Paths.get(externalComponentsDir, runtimeModelId).toFile();
-            FileUtils.deleteQuietly(runtimeModelComponentsFile);
+            String componentsDir = loader.getExternalComponentsDir();
+            String runtimeModelId = event.getRuntimeModelId();
+            if (componentsDir != null && runtimeModelId != null) {
+                File runtimeModelComponentsFile = Paths.get(componentsDir, runtimeModelId).toFile();
+                FileUtils.deleteQuietly(runtimeModelComponentsFile);
+            }
         }
 
     }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
@@ -75,28 +75,32 @@ public class RuntimeOptions {
      * If true components will be partitioned by the Runtime Model ID.
      */
     private static final String COMPONENT_PARTITION_PROP = "dashbuilder.components.partition";
+    
+    /**
+     * Boolean property that allows Runtime to check model last update in FS to update its content.
+     */
+    private static final String MODEL_UPDATE_PROP = "dashbuilder.model.update";
 
     private boolean multipleImport;
     private boolean datasetPartition;
     private boolean componentPartition;
     private boolean allowExternal;
+    private boolean modelUpdate;
     private String importFileLocation;
     private String importsBaseDir;
     private int uploadSize;
 
     @PostConstruct
     public void init() {
-        String multipleImportStr = System.getProperty(DASHBUILDER_RUNTIME_MULTIPLE_IMPORT_PROP, Boolean.FALSE.toString());
-        String allowExternalStr = System.getProperty(ALLOW_EXTERNAL_FILE_REGISTER_PROP, Boolean.FALSE.toString());
-        String datasetPartitionStr = System.getProperty(DATASET_PARTITION_PROP, Boolean.TRUE.toString());
-        String componentPartitionStr = System.getProperty(COMPONENT_PARTITION_PROP, Boolean.TRUE.toString());
 
         importFileLocation = System.getProperty(IMPORT_FILE_LOCATION_PROP);
         importsBaseDir = System.getProperty(IMPORTS_BASE_DIR_PROP, DEFAULT_MODEL_DIR);
-        multipleImport = Boolean.parseBoolean(multipleImportStr);
-        allowExternal = Boolean.parseBoolean(allowExternalStr);
-        datasetPartition = Boolean.parseBoolean(datasetPartitionStr);
-        componentPartition = Boolean.parseBoolean(componentPartitionStr);
+        
+        multipleImport = booleanProp(DASHBUILDER_RUNTIME_MULTIPLE_IMPORT_PROP, Boolean.FALSE);
+        allowExternal = booleanProp(ALLOW_EXTERNAL_FILE_REGISTER_PROP, Boolean.FALSE);
+        datasetPartition = booleanProp(DATASET_PARTITION_PROP, Boolean.TRUE);
+        componentPartition = booleanProp(COMPONENT_PARTITION_PROP, Boolean.TRUE);
+        modelUpdate = booleanProp(MODEL_UPDATE_PROP, Boolean.TRUE);
         
         uploadSize = DEFAULT_UPLOAD_SIZE_KB;
 
@@ -109,6 +113,7 @@ public class RuntimeOptions {
                 logger.debug("Not able to parse upload size {}", uploadSizeStr, e);
             }
         }
+        logger.info("Max upload size is " + uploadSize);
     }
 
     /**
@@ -170,9 +175,18 @@ public class RuntimeOptions {
     public boolean isComponentPartition() {
         return componentPartition;
     }
+    
+    public boolean isModelUpdate() {
+        return modelUpdate;
+    }
 
     public String buildFilePath(String fileId) {
         return String.join("/", getImportsBaseDir(), fileId).concat(DASHBOARD_EXTENSION);
+    }
+    
+    private boolean booleanProp(String prop, Boolean defaultValue) {
+        String propStr = System.getProperty(prop, defaultValue.toString());
+        return Boolean.parseBoolean(propStr);
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
@@ -113,7 +113,7 @@ public class RuntimeOptions {
                 logger.debug("Not able to parse upload size {}", uploadSizeStr, e);
             }
         }
-        logger.info("Max upload size is " + uploadSize);
+        logger.info("Max upload size is {}", uploadSize);
     }
 
     /**

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/remote/services/RuntimeModelServiceImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/remote/services/RuntimeModelServiceImpl.java
@@ -16,7 +16,6 @@
 
 package org.dashbuilder.backend.remote.services;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/remote/services/RuntimeModelServiceImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/remote/services/RuntimeModelServiceImpl.java
@@ -117,7 +117,6 @@ public class RuntimeModelServiceImpl implements RuntimeModelService {
 
     private long lastModified(String modelFilePath) {
         try {
-            System.currentTimeMillis();
             return Files.readAttributes(Paths.get(modelFilePath), BasicFileAttributes.class)
                         .lastModifiedTime()
                         .toMillis();

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/remote/services/RuntimeModelServiceImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/remote/services/RuntimeModelServiceImpl.java
@@ -16,6 +16,11 @@
 
 package org.dashbuilder.backend.remote.services;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -84,7 +89,7 @@ public class RuntimeModelServiceImpl implements RuntimeModelService {
     private Optional<RuntimeModel> loadImportById(String id) {
         Optional<RuntimeModel> runtimeModelOp = registry.get(id);
         if (runtimeModelOp.isPresent()) {
-            return runtimeModelOp;
+            return loadLatestModel(id, runtimeModelOp.get());
         }
 
         Optional<String> modelPath = runtimeOptions.modelPath(id);
@@ -96,6 +101,32 @@ public class RuntimeModelServiceImpl implements RuntimeModelService {
             return externalImportService.registerExternalImport(id);
         }
         return Optional.empty();
+    }
+
+    private Optional<RuntimeModel> loadLatestModel(String id, RuntimeModel runtimeModel) {
+        Optional<String> modelPath = runtimeOptions.modelPath(id);
+        if (runtimeOptions.isModelUpdate() && modelPath.isPresent()) {
+            String modelFilePath = modelPath.get();
+            if (lastModified(modelFilePath) > runtimeModel.getLastModified()) {
+                logger.info("Replacing model {}", id);
+                registry.remove(id);
+                return registry.registerFile(modelFilePath);
+            }
+        }
+        return Optional.of(runtimeModel);
+    }
+
+    private long lastModified(String modelFilePath) {
+        try {
+            System.currentTimeMillis();
+            return Files.readAttributes(Paths.get(modelFilePath), BasicFileAttributes.class)
+                        .lastModifiedTime()
+                        .toMillis();
+        } catch (IOException e) {
+            logger.error("Error reading file last modified time");
+            logger.debug("Error reading file last modified time", e);
+            return -1;
+        }
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
@@ -141,7 +141,7 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
         }
         NavTree navTree = runtimeNavigationBuilder.build(navTreeOp, layoutTemplates);
 
-        return new RuntimeModel(navTree, layoutTemplates);
+        return new RuntimeModel(navTree, layoutTemplates, System.currentTimeMillis());
     }
 
     String transformId(String modelId, String id) {

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/RuntimeModel.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/model/RuntimeModel.java
@@ -33,11 +33,15 @@ public class RuntimeModel {
     NavTree navTree;
 
     List<LayoutTemplate> layoutTemplates;
+    
+    Long lastModified;
 
     public RuntimeModel(@MapsTo("navTree") final NavTree navTree,
-                        @MapsTo("layoutTemplates") final List<LayoutTemplate> layoutTemplates) {
+                        @MapsTo("layoutTemplates") final List<LayoutTemplate> layoutTemplates,
+                        @MapsTo("lastModified") Long lastModified) {
         this.navTree = navTree;
         this.layoutTemplates = layoutTemplates;
+        this.lastModified = lastModified;
     }
 
     public NavTree getNavTree() {
@@ -46,6 +50,10 @@ public class RuntimeModel {
 
     public List<LayoutTemplate> getLayoutTemplates() {
         return layoutTemplates;
+    }
+    
+    public Long getLastModified() {
+        return lastModified;
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/client/ClientRuntimeModelLoaderTest.java
+++ b/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/client/ClientRuntimeModelLoaderTest.java
@@ -84,7 +84,7 @@ public class ClientRuntimeModelLoaderTest {
         LayoutTemplate perspective = mock(LayoutTemplate.class);
         List<LayoutTemplate> perspectives = Arrays.asList(perspective);
         NavTree navTree = mock(NavTree.class);
-        RuntimeModel runtimeModel = new RuntimeModel(navTree, perspectives);
+        RuntimeModel runtimeModel = new RuntimeModel(navTree, perspectives, System.currentTimeMillis());
         when(runtimeModelService.getRuntimeModel(eq(modelId))).thenReturn(Optional.of(runtimeModel));
 
         Consumer<RuntimeModel> runtimeModelConsumer = mock(Consumer.class);

--- a/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/DataTransferServices.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/DataTransferServices.java
@@ -27,16 +27,17 @@ public interface DataTransferServices {
     public static final String EXPORT_FILE_NAME = "export.zip";
     public static final String IMPORT_FILE_NAME = "import.zip";
     public static final String COMPONENTS_EXPORT_PATH = "dashbuilder/components/";
-    
-    public static final String EXPORT_LOCATION_PROP = "dashbuilder.import.base.dir";
+
+    public static final String EXPORT_LOCATION_PROP = "dashbuilder.export.dir";
+    public static final String SHARE_OPEN_MODEL_PROP = "dashbuilder.shareOpenModel";
     public static final String DB_STANDALONE_LOCATION_PROP = "dashbuilder.runtime.location";
 
     public String doExport(DataTransferExportModel exportsModel) throws java.io.IOException;
-    
+
     public List<String> doImport() throws Exception;
 
     public String generateExportUrl(DataTransferExportModel exportsModel) throws Exception;
 
     public ExportInfo exportInfo();
-    
+
 }

--- a/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/DataTransferServices.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/DataTransferServices.java
@@ -27,12 +27,16 @@ public interface DataTransferServices {
     public static final String EXPORT_FILE_NAME = "export.zip";
     public static final String IMPORT_FILE_NAME = "import.zip";
     public static final String COMPONENTS_EXPORT_PATH = "dashbuilder/components/";
-
+    
+    public static final String EXPORT_LOCATION_PROP = "dashbuilder.import.base.dir";
+    public static final String DB_STANDALONE_LOCATION_PROP = "dashbuilder.runtime.location";
 
     public String doExport(DataTransferExportModel exportsModel) throws java.io.IOException;
-
+    
     public List<String> doImport() throws Exception;
 
-    public DataTransferAssets assetsToExport();
+    public String generateExportUrl(DataTransferExportModel exportsModel) throws Exception;
 
+    public ExportInfo exportInfo();
+    
 }

--- a/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/ExportInfo.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/ExportInfo.java
@@ -31,8 +31,8 @@ public class ExportInfo {
     public ExportInfo() {}
 
     public ExportInfo(List<DataSetDef> datasetsDefinitions,
-                       List<String> pages,
-                       boolean externalServerAvailable) {
+                      List<String> pages,
+                      boolean externalServerAvailable) {
         this.datasetsDefinitions = datasetsDefinitions;
         this.pages = pages;
         this.externalServerAvailable = externalServerAvailable;

--- a/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/ExportInfo.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/transfer/ExportInfo.java
@@ -20,17 +20,22 @@ import java.util.List;
 
 import org.dashbuilder.dataset.def.DataSetDef;
 
-public class DataTransferAssets {
+public class ExportInfo {
+
+    private boolean externalServerAvailable;
 
     private List<DataSetDef> datasetsDefinitions;
 
     private List<String> pages;
 
-    public DataTransferAssets() {}
+    public ExportInfo() {}
 
-    public DataTransferAssets(List<DataSetDef> datasetsDefinitions, List<String> pages) {
+    public ExportInfo(List<DataSetDef> datasetsDefinitions,
+                       List<String> pages,
+                       boolean externalServerAvailable) {
         this.datasetsDefinitions = datasetsDefinitions;
         this.pages = pages;
+        this.externalServerAvailable = externalServerAvailable;
     }
 
     public List<DataSetDef> getDatasetsDefinitions() {
@@ -41,9 +46,15 @@ public class DataTransferAssets {
         return pages;
     }
 
+    public boolean isExternalServerAvailable() {
+        return externalServerAvailable;
+    }
+
     @Override
     public String toString() {
-        return "DataTransferAssetsExport [datasetsDefinitions=" + datasetsDefinitions + ", pages=" + pages + "]";
+        return "ExportModel [externalServerAvailable=" + externalServerAvailable + ", " +
+               "datasetsDefinitions=" + datasetsDefinitions + "," +
+               " pages=" + pages + "]";
     }
 
 }

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -806,7 +806,7 @@
 
           </compileSourcesArtifacts>
           <runTarget>dashbuilder.html</runTarget>
-	  <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.jboss.debug.port=8787 -Ddashbuilder.components.enable=true -Ddashbuilder.import.base.dir=/tmp/dashbuilder/models -Ddashbuilder.runtime.location=http://localhost:8280</extraJvmArgs>
+	  <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.jboss.debug.port=8787 -Ddashbuilder.components.enable=true -Ddashbuilder.export.dir=/tmp/dashbuilder/models -Ddashbuilder.runtime.location=http://localhost:8280 -Ddashbuilder.shareOpenModel=true</extraJvmArgs>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
           <hostedWebapp>src/main/webapp</hostedWebapp>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -806,7 +806,7 @@
 
           </compileSourcesArtifacts>
           <runTarget>dashbuilder.html</runTarget>
-          <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.jboss.debug.port=8787 -Ddashbuilder.components.enable=true</extraJvmArgs>
+	  <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.jboss.debug.port=8787 -Ddashbuilder.components.enable=true -Ddashbuilder.import.base.dir=/tmp/dashbuilder/models -Ddashbuilder.runtime.location=http://localhost:8280</extraJvmArgs>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
           <hostedWebapp>src/main/webapp</hostedWebapp>


### PR DESCRIPTION
Link BC to DB

**JIRA**: 

[AF-2555](https://issues.redhat.com/browse/AF-2555)

This is a new feature for 7.44. It links BC/Dashbuilder Webapp with Dashbuilder Runtime. It introduces in Dashbuilder Runtime the Refresh mode, which is turned on by default, and allow users from BC to call dashbuilder runtime by setting the following system properties:

* **dashbuilder.import.base.dir**. The location in Runtime configured to store dashbuilder models. In runtime the same system property is used, but it has a default value, but in BC you must set it, even if it points to the default value. Sample value: `/tmp/dashbuilder/models`;
*  **dashbuilder.runtime.location**: Dashbuilder Runtime root URL. Sample value: `http://localhost:8280`

To test it:

* Start Dashbuilder Runtime with multi mode and components enabled:

```
./bin/standalone.sh -Djboss.socket.binding.port-offset=200 -Ddashbuilder.runtime.multi=true -Ddashbuilder.components.enable=true
```
* Start BC and set the path for modes and your dashbuilder runtime location (base URL):
```
-Ddashbuilder.import.base.dir=/tmp/dashbuilder/models -Ddashbuilder.runtime.location=http://localhost:8280
```
* Then go to BC, create some content and go to Gradual Export. Close to the Download button you will see an "Open" button. Click on it and a new tab/window will open runtime with the import:


![link_with_replace](https://user-images.githubusercontent.com/359820/92292240-863f1980-eef2-11ea-91ad-c6134c0b17da.gif)
