### PR TITLE
AF-2611: Allow default pages in Dashbuilder Runtime

### DIFF
--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
@@ -74,7 +74,7 @@ public class RuntimeOptions {
     /**
      * If true components will be partitioned by the Runtime Model ID.
      */
-    private static final String COMPONENT_PARTITION_PROP = "dashbuilder.dataset.partition";
+    private static final String COMPONENT_PARTITION_PROP = "dashbuilder.components.partition";
 
     private boolean multipleImport;
     private boolean datasetPartition;

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RouterScreen.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RouterScreen.java
@@ -110,8 +110,10 @@ public class RouterScreen {
         }
 
         if (runtimeModelOp.isPresent()) {
+            RuntimeModel runtimeModel = runtimeModelOp.get();
             placeManager.goTo(RuntimePerspective.ID);
-            runtimeScreen.loadDashboards(runtimeModelOp.get());
+            runtimeScreen.loadDashboards(runtimeModel);
+            runtimeScreen.goToIndex(runtimeModel.getLayoutTemplates());
             return;
         }
 

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RouterScreen.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RouterScreen.java
@@ -110,8 +110,8 @@ public class RouterScreen {
         }
 
         if (runtimeModelOp.isPresent()) {
-            runtimeScreen.loadDashboards(runtimeModelOp.get());
             placeManager.goTo(RuntimePerspective.ID);
+            runtimeScreen.loadDashboards(runtimeModelOp.get());
             return;
         }
 

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RuntimeScreen.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RuntimeScreen.java
@@ -16,6 +16,8 @@
 
 package org.dashbuilder.client.screens;
 
+import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -26,7 +28,9 @@ import org.dashbuilder.shared.model.RuntimeModel;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberElemental;
+import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
 import org.uberfire.workbench.model.menu.Menus;
 
 /**
@@ -38,6 +42,8 @@ import org.uberfire.workbench.model.menu.Menus;
 public class RuntimeScreen {
 
     public static final String ID = "RuntimeScreen";
+
+    public static final String INDEX_PAGE_NAME = "index";
 
     private static AppConstants i18n = AppConstants.INSTANCE;
 
@@ -53,6 +59,9 @@ public class RuntimeScreen {
     @Inject
     NavBarHelper menusHelper;
 
+    @Inject
+    PlaceManager placeManager;
+
     @WorkbenchPartTitle
     public String getScreenTitle() {
         return i18n.runtimeScreenTitle();
@@ -67,6 +76,21 @@ public class RuntimeScreen {
         NavTree navTree = runtimeModel.getNavTree();
         Menus menus = menusHelper.buildMenusFromNavTree(navTree).build();
         view.addMenus(menus);
+
+        goToIndex(runtimeModel.getLayoutTemplates());
+
+    }
+
+    void goToIndex(List<LayoutTemplate> templates) {
+        if (templates.size() == 1) {
+            placeManager.goTo(templates.get(0).getName());
+        } else {
+            templates.stream()
+                     .map(LayoutTemplate::getName)
+                     .filter(INDEX_PAGE_NAME::equals)
+                     .findFirst()
+                     .ifPresent(placeManager::goTo);
+        }
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RuntimeScreen.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/screens/RuntimeScreen.java
@@ -76,12 +76,9 @@ public class RuntimeScreen {
         NavTree navTree = runtimeModel.getNavTree();
         Menus menus = menusHelper.buildMenusFromNavTree(navTree).build();
         view.addMenus(menus);
-
-        goToIndex(runtimeModel.getLayoutTemplates());
-
     }
 
-    void goToIndex(List<LayoutTemplate> templates) {
+    public void goToIndex(List<LayoutTemplate> templates) {
         if (templates.size() == 1) {
             placeManager.goTo(templates.get(0).getName());
         } else {

--- a/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/client/screens/RuntimeScreenTest.java
+++ b/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/client/screens/RuntimeScreenTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.client.screens;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.ext.layout.editor.api.editor.LayoutTemplate;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class RuntimeScreenTest {
+
+    @Mock
+    PlaceManager placeManager;
+
+    @InjectMocks
+    RuntimeScreen runtimeScreen;
+
+    @Test
+    public void testGoToIndexWithIndexPage() {
+        String randomPage = "randomPage";
+        List<LayoutTemplate> templates = Arrays.asList(new LayoutTemplate(randomPage),
+                                                       new LayoutTemplate(RuntimeScreen.INDEX_PAGE_NAME));
+        
+        runtimeScreen.goToIndex(templates);
+
+        verify(placeManager).goTo(RuntimeScreen.INDEX_PAGE_NAME);
+        verify(placeManager, times(0)).goTo(randomPage);
+    }
+
+    @Test
+    public void testGoToIndexWithSinglePage() {
+        String randomPage = "randomPage";
+        List<LayoutTemplate> templates = Arrays.asList(new LayoutTemplate(randomPage));
+
+        runtimeScreen.goToIndex(templates);
+
+        verify(placeManager).goTo(randomPage);
+    }
+
+    @Test
+    public void testGoToIndexWithoutIndex() {
+        List<LayoutTemplate> templates = Arrays.asList(new LayoutTemplate("page1"),
+                                                       new LayoutTemplate("page2"));
+        runtimeScreen.goToIndex(templates);
+        verify(placeManager, times(0)).goTo(anyString());
+    }
+
+}


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

[AF-2611: Allow default pages in Dashbuilder Runtime](https://issues.redhat.com/browse/AF-2611)
[AF-2612: Fix components partition system property](https://issues.redhat.com/browse/AF-2612)

In this PR we address the two JIRAs mentioned above. In AF-2611 we have functional changes, it works

1) A page called "index" will be used when opening a runtime model (import);
2) If you have a single page in your import than this page will be the index;
3) If none of this is done than there's no index/default page.

Thanks!

