### PR TITLE
AF-2625: Create Liveness and Readiness Probe on Dashbuilder Runtimes

### DIFF
--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/health/HealthService.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/health/HealthService.java
@@ -30,7 +30,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 @Path("/")
 public class HealthService {
     
-    private static String SUCCESS_RESPONSE = "{\"success\": true}";
+    private static final String SUCCESS_RESPONSE = "{\"success\": true}";
     
     @GET
     @PermitAll

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/health/HealthService.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/health/HealthService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.backend.health;
+
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+/**
+ * Service that reports if Runtime is ready and healthy.
+ *
+ */
+@Path("/")
+public class HealthService {
+    
+    private static String SUCCESS_RESPONSE = "{\"success\": true}";
+    
+    @GET
+    @PermitAll
+    @Path("/ready")
+    @Produces(APPLICATION_JSON)
+    public String ready() {
+        return SUCCESS_RESPONSE;
+    }
+    
+    @GET
+    @PermitAll
+    @Path("/healthy")
+    @Produces(APPLICATION_JSON)
+    public String alive() {
+        return SUCCESS_RESPONSE;
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/webapp/WEB-INF/web.xml
+++ b/dashbuilder/dashbuilder-runtime/src/main/webapp/WEB-INF/web.xml
@@ -75,7 +75,7 @@
     </init-param>
     <init-param>
       <param-name>excludedPaths</param-name>
-      <param-value>/rest/upload</param-value>
+      <param-value>/rest/upload,/rest/healthy,/rest/ready</param-value>
     </init-param>
   </filter>
   <filter-mapping>
@@ -89,8 +89,7 @@
     <form-login-config>
       <form-login-page>/login.html</form-login-page>
       <form-error-page>/login.html?loginMessage=Login failed. Please try
-        again.
-      </form-error-page>
+        again.</form-error-page>
     </form-login-config>
   </login-config>
 
@@ -112,6 +111,10 @@
       </url-pattern>
       <url-pattern>/org.dashbuilder.DashbuilderRuntime/images/*
       </url-pattern>
+      <!-- HealthCheck -->
+      <url-pattern>/rest/ready</url-pattern>
+      <url-pattern>/rest/healthy</url-pattern>
+
     </web-resource-collection>
   </security-constraint>
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**:
[AF-2625](https://issues.redhat.com/browse/AF-2625)


I think that initially this is all for the ready and liveness probes.

*/rest/ready*: Indicates that the server is ready to be accessed;
*/rest/healthy*: Successful response only if the server is ready.