### PR TITLE
AF-2602 Adding write-file-atomic dependencies to fix Appformer-js build failures in the windows environment

### DIFF
--- a/appformer-js/package.json
+++ b/appformer-js/package.json
@@ -57,6 +57,7 @@
     "webpack": "4.15.1",
     "webpack-cli": "3.0.8",
     "babel-jest": "23.0.0",
-    "lock-treatment-tool": "^0.4.1"
+    "lock-treatment-tool": "^0.4.1",
+    "write-file-atomic": "2.4.1"
   }
 }

--- a/appformer-js/yarn.lock
+++ b/appformer-js/yarn.lock
@@ -7987,6 +7987,15 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
+write-file-atomic@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
+  integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write-file-atomic@^2.0.0, write-file-atomic@^2.1.0, write-file-atomic@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"


### PR DESCRIPTION
Adding write-file-atomic dependencies to fix Appformer-js build failures in the Windows environment

**Thank you for submitting this pull request**

**JIRA**:  

[AF-2602](https://issues.redhat.com/browse/AF-2602)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
