### PR TITLE
BXMSPROD-494 allow GA build on windows machine

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,11 +6,15 @@ jobs:
   build-chain:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         java-version: [8, 11]
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     name: Maven Build
     steps:
+      - name: Support longpaths
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -795,6 +795,7 @@
           <strict>true</strict>
           <compileSourcesArtifacts>
           <codeServerWorkDir>${basedir}/dashbuilder-runtime/gwt/codeserver</codeServerWorkDir>
+          <extraJvmArgs>-Djava.io.tmpdir={basedir}/dashbuilder-webapp/gwt/codeserver</extraJvmArgs>
 
             <!-- Validation -->
             <compileSourcesArtifact>org.hibernate:hibernate-validator</compileSourcesArtifact>
@@ -970,6 +971,7 @@
               <draftCompile>false</draftCompile>
               <force>true</force>
               <codeServerWorkDir>${basedir}/dashbuilder-runtime/gwt/codeserver</codeServerWorkDir>
+              <extraJvmArgs>-Djava.io.tmpdir={basedir}/dashbuilder-webapp/gwt/codeserver</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>
@@ -987,6 +989,7 @@
             <configuration>
               <skip>true</skip>
               <codeServerWorkDir>${basedir}/dashbuilder-runtime/gwt/codeserver</codeServerWorkDir>
+              <extraJvmArgs>-Djava.io.tmpdir={basedir}/dashbuilder-webapp/gwt/codeserver</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>

--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -794,6 +794,7 @@
           <logLevel>INFO</logLevel>
           <strict>true</strict>
           <compileSourcesArtifacts>
+          <codeServerWorkDir>${basedir}/dashbuilder-runtime/gwt/codeserver</codeServerWorkDir>
 
             <!-- Validation -->
             <compileSourcesArtifact>org.hibernate:hibernate-validator</compileSourcesArtifact>
@@ -968,6 +969,7 @@
               <module>org.dashbuilder.DashbuilderRuntime</module>
               <draftCompile>false</draftCompile>
               <force>true</force>
+              <codeServerWorkDir>${basedir}/dashbuilder-runtime/gwt/codeserver</codeServerWorkDir>
             </configuration>
           </plugin>
         </plugins>
@@ -984,6 +986,7 @@
             <artifactId>gwt-maven-plugin</artifactId>
             <configuration>
               <skip>true</skip>
+              <codeServerWorkDir>${basedir}/dashbuilder-runtime/gwt/codeserver</codeServerWorkDir>
             </configuration>
           </plugin>
         </plugins>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -726,6 +726,7 @@
           <logLevel>INFO</logLevel>
           <strict>true</strict>
           <codeServerWorkDir>${basedir}/dashbuilder-webapp/gwt/codeserver</codeServerWorkDir>
+          <extraJvmArgs>-Djava.io.tmpdir=/tmp/494/cache</extraJvmArgs>
           <compileSourcesArtifacts>
 
             <!-- Dashbuilder -->
@@ -930,6 +931,7 @@
               <draftCompile>false</draftCompile>
               <force>true</force>
               <codeServerWorkDir>${basedir}/dashbuilder-webapp/gwt/codeserver</codeServerWorkDir>
+              <extraJvmArgs>-Djava.io.tmpdir={basedir}/dashbuilder-webapp/gwt/codeserver</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>
@@ -946,6 +948,7 @@
             <configuration>
               <skip>true</skip>
               <codeServerWorkDir>${basedir}/dashbuilder-webapp/gwt/codeserver</codeServerWorkDir>
+              <extraJvmArgs>-Djava.io.tmpdir={basedir}/dashbuilder-webapp/gwt/codeserver</extraJvmArgs>
             </configuration>
           </plugin>
         </plugins>

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -725,6 +725,7 @@
           <draftCompile>true</draftCompile>
           <logLevel>INFO</logLevel>
           <strict>true</strict>
+          <codeServerWorkDir>${basedir}/dashbuilder-webapp/gwt/codeserver</codeServerWorkDir>
           <compileSourcesArtifacts>
 
             <!-- Dashbuilder -->
@@ -928,6 +929,7 @@
               <module>org.dashbuilder.DashbuilderShowcase</module>
               <draftCompile>false</draftCompile>
               <force>true</force>
+              <codeServerWorkDir>${basedir}/dashbuilder-webapp/gwt/codeserver</codeServerWorkDir>
             </configuration>
           </plugin>
         </plugins>
@@ -943,6 +945,7 @@
             <artifactId>gwt-maven-plugin</artifactId>
             <configuration>
               <skip>true</skip>
+              <codeServerWorkDir>${basedir}/dashbuilder-webapp/gwt/codeserver</codeServerWorkDir>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-494

related to

https://github.com/kiegroup/lienzo-core/pull/133
https://github.com/kiegroup/lienzo-tests/pull/108
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1471
https://github.com/kiegroup/kie-soup/pull/158
https://github.com/kiegroup/appformer/pull/1054
https://github.com/kiegroup/droolsjbpm-knowledge/pull/465
https://github.com/kiegroup/drools/pull/3116
https://github.com/kiegroup/optaplanner/pull/940
https://github.com/kiegroup/jbpm/pull/1758
https://github.com/kiegroup/kie-jpmml-integration/pull/43
https://github.com/kiegroup/droolsjbpm-integration/pull/2243
https://github.com/kiegroup/openshift-drools-hacep/pull/100
https://github.com/kiegroup/droolsjbpm-tools/pull/118
https://github.com/kiegroup/kie-uberfire-extensions/pull/106
https://github.com/kiegroup/kie-wb-playground/pull/97
https://github.com/kiegroup/kie-wb-common/pull/3423
https://github.com/kiegroup/drools-wb/pull/1423
https://github.com/kiegroup/optaplanner-wb/pull/381
https://github.com/kiegroup/jbpm-designer/pull/891
https://github.com/kiegroup/jbpm-wb/pull/1461
https://github.com/kiegroup/jbpm-work-items/pull/153
https://github.com/kiegroup/kie-docs/pull/2849
https://github.com/kiegroup/optaweb-employee-rostering/pull/498
https://github.com/kiegroup/optaweb-vehicle-routing/pull/367
https://github.com/kiegroup/kie-wb-distributions/pull/1062