### PR TITLE
AF-2638: Index page is not updated when changing models

### DIFF
--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/perspective/generator/RuntimePerspectiveGenerator.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/client/perspective/generator/RuntimePerspectiveGenerator.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.mvp.Activity;
@@ -55,14 +54,14 @@ public class RuntimePerspectiveGenerator {
         if (isANewPerspective(layoutTemplate)) {
             PerspectiveEditorScreenActivity screen = createNewScreen(layoutTemplate);
             return createNewPerspective(layoutTemplate,
-                                 screen);
+                                        screen);
         } else {
             PerspectiveEditorScreenActivity screen = updateScreen(layoutTemplate);
             return updatePerspective(layoutTemplate,
-                              screen);
+                                     screen);
         }
     }
-    
+
     private PerspectiveEditorScreenActivity createNewScreen(LayoutTemplate perspective) {
         PerspectiveEditorScreenActivity activity = new PerspectiveEditorScreenActivity(perspective,
                                                                                        layoutGenerator);
@@ -104,7 +103,7 @@ public class RuntimePerspectiveGenerator {
         activityBeansCache.addNewPerspectiveActivity(beanManager.lookupBeans(perspectiveName).iterator().next());
         return activity;
     }
-    
+
     private PerspectiveEditorScreenActivity updateScreen(LayoutTemplate layoutTemplate) {
         final String perspectiveScreenId = PerspectiveEditorScreenActivity.buildScreenId(layoutTemplate.getName());
         final SyncBeanDef<Activity> activity = activityBeansCache.getActivity(perspectiveScreenId);
@@ -112,20 +111,18 @@ public class RuntimePerspectiveGenerator {
         screenActivity.setLayoutTemplate(layoutTemplate);
         return screenActivity;
     }
-    
+
     private PerspectiveEditorActivity updatePerspective(LayoutTemplate layoutTemplate,
                                                         PerspectiveEditorScreenActivity screen) {
-                             final SyncBeanDef<Activity> activity = activityBeansCache.getActivity(layoutTemplate.getName());
-                             final PerspectiveEditorActivity perspectiveEditorActivity = (PerspectiveEditorActivity) activity.getInstance();
-                             perspectiveEditorActivity.update(layoutTemplate,
-                                                              screen);
-                             return perspectiveEditorActivity;
-                         }
-    
-    
+        final SyncBeanDef<Activity> activity = activityBeansCache.getActivity(layoutTemplate.getName());
+        final PerspectiveEditorActivity perspectiveEditorActivity = (PerspectiveEditorActivity) activity.getInstance();
+        perspectiveEditorActivity.update(layoutTemplate,
+                                         screen);
+        return perspectiveEditorActivity;
+    }
+
     private boolean isANewPerspective(LayoutTemplate layoutTemplate) {
-        final IOCBeanDef<Activity> activity = activityBeansCache.getActivity(layoutTemplate.getName());
-        return activity == null;
+        return activityBeansCache.getActivity(layoutTemplate.getName()) == null;
     }
 
 }


### PR DESCRIPTION
[AF-2638](https://issues.redhat.com/browse/AF-2638)

SyncBeanManager does not override registered beans, hence we need to replace the page content instead register it again and again