### PR TITLE
AF-2658: Option to clean all registered models

### DIFF
--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -818,7 +818,7 @@
           <runTarget>dashbuilder.html</runTarget>
           <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000
             -Derrai.jboss.home=${errai.jboss.home}
-            -Ddashbuilder.runtime.multi=true</extraJvmArgs>
+		  -Ddashbuilder.runtime.multi=true -Ddashbuilder.components.enable=true -Ddashbuilder.removeModelFile=true</extraJvmArgs>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
           <hostedWebapp>src/main/webapp</hostedWebapp>

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/RuntimeOptions.java
@@ -16,6 +16,7 @@
 
 package org.dashbuilder.backend;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
@@ -39,7 +40,7 @@ public class RuntimeOptions {
 
     private static final String DEFAULT_MODEL_DIR = "/tmp/dashbuilder/models";
 
-    private static final int DEFAULT_UPLOAD_SIZE_KB =  10 * 1024 * 1024;
+    private static final int DEFAULT_UPLOAD_SIZE_KB = 10 * 1024 * 1024;
 
     /**
      * Base Directory where dashboards ZIPs are stored
@@ -70,22 +71,28 @@ public class RuntimeOptions {
      * If true datasets IDs will partitioned by the Runtime Model ID.
      */
     private static final String DATASET_PARTITION_PROP = "dashbuilder.dataset.partition";
-    
+
     /**
      * If true components will be partitioned by the Runtime Model ID.
      */
     private static final String COMPONENT_PARTITION_PROP = "dashbuilder.components.partition";
-    
+
     /**
      * Boolean property that allows Runtime to check model last update in FS to update its content.
      */
     private static final String MODEL_UPDATE_PROP = "dashbuilder.model.update";
+
+    /**
+     * Boolean property when true will also remove actual model file from file system.
+     */
+    private static final String MODEL_FILE_REMOVAL_PROP = "dashbuilder.removeModelFile";
 
     private boolean multipleImport;
     private boolean datasetPartition;
     private boolean componentPartition;
     private boolean allowExternal;
     private boolean modelUpdate;
+    private boolean removeModelFile;
     private String importFileLocation;
     private String importsBaseDir;
     private int uploadSize;
@@ -95,13 +102,14 @@ public class RuntimeOptions {
 
         importFileLocation = System.getProperty(IMPORT_FILE_LOCATION_PROP);
         importsBaseDir = System.getProperty(IMPORTS_BASE_DIR_PROP, DEFAULT_MODEL_DIR);
-        
+
         multipleImport = booleanProp(DASHBUILDER_RUNTIME_MULTIPLE_IMPORT_PROP, Boolean.FALSE);
         allowExternal = booleanProp(ALLOW_EXTERNAL_FILE_REGISTER_PROP, Boolean.FALSE);
         datasetPartition = booleanProp(DATASET_PARTITION_PROP, Boolean.TRUE);
         componentPartition = booleanProp(COMPONENT_PARTITION_PROP, Boolean.TRUE);
         modelUpdate = booleanProp(MODEL_UPDATE_PROP, Boolean.TRUE);
-        
+        removeModelFile = booleanProp(MODEL_FILE_REMOVAL_PROP, Boolean.FALSE);
+
         uploadSize = DEFAULT_UPLOAD_SIZE_KB;
 
         String uploadSizeStr = System.getProperty(UPLOAD_SIZE_PROP);
@@ -171,19 +179,24 @@ public class RuntimeOptions {
     public boolean isDatasetPartition() {
         return datasetPartition;
     }
-    
+
     public boolean isComponentPartition() {
         return componentPartition;
     }
-    
+
     public boolean isModelUpdate() {
         return modelUpdate;
     }
 
-    public String buildFilePath(String fileId) {
-        return String.join("/", getImportsBaseDir(), fileId).concat(DASHBOARD_EXTENSION);
+    public boolean isRemoveModelFile() {
+        return removeModelFile;
     }
-    
+
+    public String buildFilePath(String fileId) {
+        Path modelFile = Paths.get(fileId + DASHBOARD_EXTENSION);
+        return Paths.get(getImportsBaseDir()).resolve(modelFile).toString();
+    }
+
     private boolean booleanProp(String prop, Boolean defaultValue) {
         String propStr = System.getProperty(prop, defaultValue.toString());
         return Boolean.parseBoolean(propStr);

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
@@ -77,7 +77,7 @@ public class DashbuilderRuntimeResource {
 
     @DELETE
     @Path(DASHBOARD_BASE_URI)
-    public void removeAll() throws IOException {
+    public void removeAll() {
         registry.clear();
     }
 

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/resources/api/DashbuilderRuntimeResource.java
@@ -17,9 +17,11 @@
 package org.dashbuilder.backend.resources.api;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -32,7 +34,9 @@ import javax.ws.rs.core.Response.Status;
 import org.dashbuilder.backend.resources.FileUploadModel;
 import org.dashbuilder.backend.resources.UploadResourceImpl;
 import org.dashbuilder.backend.services.RuntimeInfoService;
+import org.dashbuilder.shared.model.DashboardInfo;
 import org.dashbuilder.shared.model.DashbuilderRuntimeInfo;
+import org.dashbuilder.shared.service.RuntimeModelRegistry;
 import org.jboss.resteasy.annotations.providers.multipart.MultipartForm;
 
 @Path("api/")
@@ -47,6 +51,9 @@ public class DashbuilderRuntimeResource {
 
     @Inject
     UploadResourceImpl uploadResourceImpl;
+
+    @Inject
+    RuntimeModelRegistry registry;
 
     @GET
     public DashbuilderRuntimeInfo info() {
@@ -66,6 +73,24 @@ public class DashbuilderRuntimeResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public Response uploadResource(@MultipartForm FileUploadModel form) throws IOException {
         return uploadResourceImpl.uploadFile(form);
+    }
+
+    @DELETE
+    @Path(DASHBOARD_BASE_URI)
+    public void removeAll() throws IOException {
+        registry.clear();
+    }
+
+    @DELETE
+    @Path(DASHBOARD_ID_URI)
+    public Response remove(@PathParam("id") String id) {
+        Optional<DashboardInfo> dashboardInfo = runtimeInfoService.dashboardInfo(id);
+        if (dashboardInfo.isPresent()) {
+            registry.remove(id);
+            return Response.ok().build();
+        } else {
+            return Response.status(Status.NOT_FOUND).build();
+        }
     }
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/service/RuntimeModelRegistry.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/shared/service/RuntimeModelRegistry.java
@@ -76,7 +76,7 @@ public interface RuntimeModelRegistry {
      * The path to the file.
      */
     Optional<RuntimeModel> registerFile(String filePath);
-    
+
     /**
      * Removes a runtime model.
      * @param runtimeModelid
@@ -88,5 +88,10 @@ public interface RuntimeModelRegistry {
      * List all models that are currently available.
      */
     Collection<String> availableModels();
+
+    /**
+     * Remove all registered models.
+     */
+    void clear();
 
 }

--- a/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/shared/service/RuntimeModelRegistryTest.java
+++ b/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/shared/service/RuntimeModelRegistryTest.java
@@ -27,37 +27,36 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class RuntimeModelRegistryTest {
-    
+
     @Test
     public void testAcceptingNewImportsMultiple() {
         RuntimeModelRegistry registry = new RuntimeModelRegistryMock(DashbuilderRuntimeMode.MULTIPLE_IMPORT, false);
         assertTrue(registry.acceptingNewImports());
     }
-    
+
     @Test
     public void testNotAcceptingNewImportsStatic() {
         RuntimeModelRegistry registry = new RuntimeModelRegistryMock(DashbuilderRuntimeMode.STATIC, false);
         assertFalse(registry.acceptingNewImports());
     }
-    
+
     @Test
     public void testNotAcceptingNewImportsSingleAndNotEmpty() {
         RuntimeModelRegistry registry = new RuntimeModelRegistryMock(DashbuilderRuntimeMode.SINGLE_IMPORT, false);
         assertFalse(registry.acceptingNewImports());
     }
-    
+
     @Test
     public void testNotAcceptingNewImportsSingleAndEmpty() {
         RuntimeModelRegistry registry = new RuntimeModelRegistryMock(DashbuilderRuntimeMode.SINGLE_IMPORT, true);
         assertTrue(registry.acceptingNewImports());
     }
-    
+
     // Having classloading issues with Mockito, hence having to create this
     public class RuntimeModelRegistryMock implements RuntimeModelRegistry {
 
         private DashbuilderRuntimeMode mode;
-        
-        
+
         public RuntimeModelRegistryMock(DashbuilderRuntimeMode mode, boolean b) {
             super();
             this.mode = mode;
@@ -87,8 +86,7 @@ public class RuntimeModelRegistryTest {
         }
 
         @Override
-        public void setMode(DashbuilderRuntimeMode mode) {
-        }
+        public void setMode(DashbuilderRuntimeMode mode) {}
 
         @Override
         public Optional<RuntimeModel> registerFile(String filePath) {
@@ -97,12 +95,18 @@ public class RuntimeModelRegistryTest {
 
         @Override
         public void remove(String runtimeModelid) {
-            
+
         }
 
         @Override
         public Collection<String> availableModels() {
             return null;
-        }}
+        }
+
+        @Override
+        public void clear() {
+
+        }
+    }
 
 }


### PR DESCRIPTION
**JIRA**: 

[AF-2658](https://issues.redhat.com/browse/AF-2658)


Adds an option to unregister models. By default it won't delete the file, if users want the file to be removed then they must set the property `dashbuilder.removeModelFile` as true.