### PR TITLE
RHDM-1354: NPE creating a project using Decision Central REST API and githook configured

### DIFF
--- a/uberfire-rest/uberfire-rest-backend/src/build/revapi-config.json
+++ b/uberfire-rest/uberfire-rest-backend/src/build/revapi-config.json
@@ -24,7 +24,7 @@
           "old": "parameter javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::createProject(java.lang.String, ===org.guvnor.rest.client.CreateProjectRequest===)",
           "new": "parameter javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::createProject(java.lang.String, ===java.util.Locale===, org.guvnor.rest.client.CreateProjectRequest)",
           "annotationType": "javax.ws.rs.HeaderParam",
-          "annotation": "@javax.ws.rs.HeaderParam(\"accept-language\")",
+          "annotation": "@javax.ws.rs.HeaderParam(\"Accept-Language\")",
           "package": "org.guvnor.rest.backend",
           "classSimpleName": "ProjectResource",
           "methodName": "createProject",

--- a/uberfire-rest/uberfire-rest-backend/src/build/revapi-config.json
+++ b/uberfire-rest/uberfire-rest-backend/src/build/revapi-config.json
@@ -18,7 +18,31 @@
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.44.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
+      "ignore": [
+        {
+          "code": "java.annotation.added",
+          "old": "parameter javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::createProject(java.lang.String, ===org.guvnor.rest.client.CreateProjectRequest===)",
+          "new": "parameter javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::createProject(java.lang.String, ===java.util.Locale===, org.guvnor.rest.client.CreateProjectRequest)",
+          "annotationType": "javax.ws.rs.HeaderParam",
+          "annotation": "@javax.ws.rs.HeaderParam(\"accept-language\")",
+          "package": "org.guvnor.rest.backend",
+          "classSimpleName": "ProjectResource",
+          "methodName": "createProject",
+          "parameterIndex": "1",
+          "elementKind": "parameter",
+          "justification": "Added header param for accepted languages in REST call"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::createProject(java.lang.String, org.guvnor.rest.client.CreateProjectRequest)",
+          "new": "method javax.ws.rs.core.Response org.guvnor.rest.backend.ProjectResource::createProject(java.lang.String, java.util.Locale, org.guvnor.rest.client.CreateProjectRequest)",
+          "package": "org.guvnor.rest.backend",
+          "classSimpleName": "ProjectResource",
+          "methodName": "createProject",
+          "elementKind": "method",
+          "justification": "Added header param for accepted languages in REST call"
+        }
+      ]
     }
   }
 }

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
@@ -104,7 +104,8 @@ public class JobRequestScheduler {
                                            params));
     }
 
-    public void createProjectRequest(final CreateProjectJobRequest jobRequest) {
+    public void createProjectRequest(final CreateProjectJobRequest jobRequest,
+                                     final Map<String, Object> headers) {
         final Map<String, Object> params = getContext(jobRequest);
         params.put("Space",
                    jobRequest.getSpaceName());
@@ -112,6 +113,8 @@ public class JobRequestScheduler {
                    jobRequest.getProjectName());
         params.put("Operation",
                    "createProject");
+        params.put("acceptLanguage",
+                   headers.get("acceptLanguage"));
 
         scheduleJob(jobRequest,
                     new CreateProjectCmd(jobRequestHelper,

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
@@ -63,6 +63,7 @@ import static org.guvnor.rest.backend.cmd.AbstractJobCommand.JOB_REQUEST_KEY;
 public class JobRequestScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(JobRequestScheduler.class);
+    private static final String ACCEPT_LANGUAGE = "acceptLanguage";
 
     private ExecutorService executorService;
 
@@ -113,8 +114,8 @@ public class JobRequestScheduler {
                    jobRequest.getProjectName());
         params.put("Operation",
                    "createProject");
-        params.put("acceptLanguage",
-                   headers.get("acceptLanguage"));
+        params.put(ACCEPT_LANGUAGE,
+                   headers.get(ACCEPT_LANGUAGE));
 
         scheduleJob(jobRequest,
                     new CreateProjectCmd(jobRequestHelper,

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
@@ -17,7 +17,10 @@ package org.guvnor.rest.backend;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -28,6 +31,7 @@ import javax.inject.Named;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -194,6 +198,7 @@ public class ProjectResource {
     @RolesAllowed({REST_ROLE, REST_PROJECT_ROLE})
     public Response createProject(
             @PathParam("spaceName") String spaceName,
+            @HeaderParam("accept-language") Locale locales,
             CreateProjectRequest createProjectRequest) {
         logger.debug("-----createProject--- , spaceName: {} , project name: {}",
                      spaceName,
@@ -202,7 +207,9 @@ public class ProjectResource {
         assertObjectExists(organizationalUnitService.getOrganizationalUnit(spaceName),
                            "space",
                            spaceName);
-
+        
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put("acceptLanguage", locales);
         final String id = newId();
         final CreateProjectJobRequest jobRequest = new CreateProjectJobRequest();
         jobRequest.setStatus(JobStatus.ACCEPTED);
@@ -214,7 +221,8 @@ public class ProjectResource {
         jobRequest.setDescription(createProjectRequest.getDescription());
         addAcceptedJobResult(id);
 
-        jobRequestObserver.createProjectRequest(jobRequest);
+        jobRequestObserver.createProjectRequest(jobRequest,
+                                                headers);
 
         return createAcceptedStatusResponse(jobRequest);
     }

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
@@ -39,6 +39,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -90,6 +91,7 @@ import static org.guvnor.rest.backend.PermissionConstants.REST_ROLE;
 public class ProjectResource {
 
     private static final Logger logger = LoggerFactory.getLogger(ProjectResource.class);
+    private static final String ACCEPT_LANGUAGE = "acceptLanguage";
     private Variant defaultVariant = getDefaultVariant();
 
     protected Variant getDefaultVariant() {
@@ -198,7 +200,7 @@ public class ProjectResource {
     @RolesAllowed({REST_ROLE, REST_PROJECT_ROLE})
     public Response createProject(
             @PathParam("spaceName") String spaceName,
-            @HeaderParam("accept-language") Locale locales,
+            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) Locale locales,
             CreateProjectRequest createProjectRequest) {
         logger.debug("-----createProject--- , spaceName: {} , project name: {}",
                      spaceName,
@@ -209,7 +211,7 @@ public class ProjectResource {
                            spaceName);
         
         final Map<String, Object> headers = new HashMap<>();
-        headers.put("acceptLanguage", locales);
+        headers.put(ACCEPT_LANGUAGE, locales);
         final String id = newId();
         final CreateProjectJobRequest jobRequest = new CreateProjectJobRequest();
         jobRequest.setStatus(JobStatus.ACCEPTED);

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/cmd/CreateProjectCmd.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/cmd/CreateProjectCmd.java
@@ -15,6 +15,7 @@
 
 package org.guvnor.rest.backend.cmd;
 
+import java.util.Locale;
 import java.util.Map;
 
 import org.guvnor.rest.backend.JobRequestHelper;
@@ -23,6 +24,7 @@ import org.guvnor.rest.client.CreateProjectJobRequest;
 import org.guvnor.rest.client.JobRequest;
 import org.guvnor.rest.client.JobResult;
 import org.guvnor.rest.client.JobStatus;
+import org.guvnor.structure.backend.LocaleContext;
 
 public class CreateProjectCmd extends AbstractJobCommand {
 
@@ -38,6 +40,7 @@ public class CreateProjectCmd extends AbstractJobCommand {
     public JobResult internalExecute(final JobRequest request) throws Exception {
         JobRequestHelper helper = getHelper();
         CreateProjectJobRequest jobRequest = (CreateProjectJobRequest) request;
+        LocaleContext.set((Locale) context.get("acceptLanguage"));
 
         JobResult result = null;
         try {

--- a/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/ProjectResourceJobTest.java
+++ b/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/ProjectResourceJobTest.java
@@ -15,6 +15,8 @@
 */
 package org.guvnor.rest.backend;
 
+import java.util.Locale;
+
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
 
@@ -106,6 +108,7 @@ public class ProjectResourceJobTest {
     public void createProject() throws Exception {
 
         projectResource.createProject("spaceName",
+                                      Locale.ENGLISH,
                                       new CreateProjectRequest());
 
         verify(jobManager).putJob(jobResultArgumentCaptor.capture());

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/LocaleContext.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/LocaleContext.java
@@ -22,6 +22,8 @@ public class LocaleContext {
     
     private static final ThreadLocal<Locale> threadLocal = new ThreadLocal<>();
     
+    private LocaleContext() {}
+    
     public static Locale get() {
         return Optional.ofNullable(threadLocal.get())
                 .orElse(Locale.getDefault());

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/LocaleContext.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/LocaleContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.guvnor.structure.backend;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public class LocaleContext {
+    
+    private static final ThreadLocal<Locale> threadLocal = new ThreadLocal<>();
+    
+    public static Locale get() {
+        return Optional.ofNullable(threadLocal.get())
+                .orElse(Locale.getDefault());
+    }
+    
+    public static void set(final Locale locale) {
+        threadLocal.set(locale);
+    }
+}

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/git/hooks/impl/MessageReader.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/git/hooks/impl/MessageReader.java
@@ -17,6 +17,7 @@
 package org.guvnor.structure.backend.repositories.git.hooks.impl;
 
 import org.apache.commons.io.FilenameUtils;
+import org.guvnor.structure.backend.LocaleContext;
 import org.jboss.errai.bus.server.api.RpcContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +84,9 @@ public class MessageReader {
                 ClassLoader bundleClassLoader = new URLClassLoader(urls);
 
                 // Getting the bundle from the current generated classloader
-                ResourceBundle bundle = ResourceBundle.getBundle(bundleName, localeSupplier.get(), bundleClassLoader);
+                ResourceBundle bundle = ResourceBundle.getBundle(bundleName,
+                                                                 getLocale(),
+                                                                 bundleClassLoader);
 
                 result = bundle.getString(String.valueOf(exitCode));
             } catch (MissingResourceException e) {
@@ -94,6 +97,15 @@ public class MessageReader {
         }
 
         return Optional.ofNullable(result);
+    }
+    
+    private Locale getLocale() {
+        try {
+            return localeSupplier.get();
+        } catch (Exception e) {
+            LOG.warn("Locale info not available in RpcContext.");
+            return LocaleContext.get();
+        }
     }
 
 }


### PR DESCRIPTION

 * Added HeaderParam to include accept-language in Rest calls for createProject

**Issue:** The issue is caused by a failure to get custom post-commit notification messages while using the REST API to create the project. Currently, messages are fetched with RpcContext which is not active in REST calls.
**Solution:** Added a HttpHeader option in REST API to set a Locale. If Locale isn't available in Header param, default Locale will be used to get the custom messages.

**JIRA**: [RHDM-1354](https://issues.redhat.com/browse/RHDM-1354)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
