### PR TITLE
AF-2637: Implement SVG backend Service for Kie Server

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunction.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunction.java
@@ -14,22 +14,16 @@
  * limitations under the License.
  */
 
-package org.dashbuilder.kieserver;
+package org.dashbuilder.external.impl;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
-import org.jboss.errai.bus.server.annotations.Remote;
+public interface BackendComponentFunction {
 
-@Remote
-public interface KieServerConnectionInfoProvider {
+    default String getName() {
+        return this.getClass().getSimpleName();
+    }
 
-    Optional<KieServerConnectionInfo> get(String name, String serverTemplate);
-
-    List<String> serverTemplates();
-
-    KieServerConnectionInfo verifiedConnectionInfo(RemoteDataSetDef def);
-    
-    Optional<KieServerConnectionInfo> getDefault();
+    Object exec(Map<String, Object> params);
 
 }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunction.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunction.java
@@ -18,12 +18,27 @@ package org.dashbuilder.external.impl;
 
 import java.util.Map;
 
-public interface BackendComponentFunction {
+/**
+ * Server side component functions contract.
+ *
+ * @param <T>
+ * The function return type.
+ */
+public interface BackendComponentFunction<T> {
 
     default String getName() {
         return this.getClass().getSimpleName();
     }
 
-    Object exec(Map<String, Object> params);
+    /**
+     * 
+     * The function execution. Must return an object that can be used in browser windows communication. 
+     * @param params
+     * Params set by user when configuring the component.
+     * @return
+     * The result
+     * 
+     */
+    T exec(Map<String, Object> params);
 
 }

--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunctionServiceImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunctionServiceImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.external.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.dashbuilder.external.service.BackendComponentFunctionService;
+import org.jboss.errai.bus.server.annotations.Service;
+
+@Service
+@ApplicationScoped
+public class BackendComponentFunctionServiceImpl implements BackendComponentFunctionService {
+
+    Map<String, BackendComponentFunction> functions;
+    
+    @Inject
+    Instance<BackendComponentFunction> functionsInstances;
+
+    @PostConstruct
+    void loadFunctions() {
+        functions = new HashMap<>();
+        functionsInstances.forEach(instance -> functions.put(instance.getName(), instance));
+    }
+
+    @Override
+    public List<String> listFunctions() {
+        return new ArrayList<>(functions.keySet());
+    }
+
+    @Override
+    public Object callFunction(String name, Map<String, Object> params) {
+        BackendComponentFunction function = functions.get(name);
+        return function.exec(params);
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunctionServiceImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendComponentFunctionServiceImpl.java
@@ -32,10 +32,10 @@ import org.jboss.errai.bus.server.annotations.Service;
 @ApplicationScoped
 public class BackendComponentFunctionServiceImpl implements BackendComponentFunctionService {
 
-    Map<String, BackendComponentFunction> functions;
+    Map<String, BackendComponentFunction<?>> functions;
     
     @Inject
-    Instance<BackendComponentFunction> functionsInstances;
+    Instance<BackendComponentFunction<?>> functionsInstances;
 
     @PostConstruct
     void loadFunctions() {
@@ -50,7 +50,7 @@ public class BackendComponentFunctionServiceImpl implements BackendComponentFunc
 
     @Override
     public Object callFunction(String name, Map<String, Object> params) {
-        BackendComponentFunction function = functions.get(name);
+        BackendComponentFunction<?> function = functions.get(name);
         return function.exec(params);
     }
 

--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendDateFunction.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendDateFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.external.impl;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+
+import javax.enterprise.context.Dependent;
+
+/**
+ * Component backend function that returns the date.
+ *
+ */
+@Dependent
+public class BackendDateFunction implements BackendComponentFunction {
+
+    private static final String FORMAT_PARAM = "format";
+
+    @Override
+    public Object exec(Map<String, Object> params) {
+        Object pattern = params.get(FORMAT_PARAM);
+        if (pattern != null) {
+            return new SimpleDateFormat(pattern.toString()).format(new Date());
+        }
+        return new Date().toString();
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendDateFunction.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/BackendDateFunction.java
@@ -26,12 +26,12 @@ import javax.enterprise.context.Dependent;
  *
  */
 @Dependent
-public class BackendDateFunction implements BackendComponentFunction {
+public class BackendDateFunction implements BackendComponentFunction<String> {
 
     private static final String FORMAT_PARAM = "format";
 
     @Override
-    public Object exec(Map<String, Object> params) {
+    public String exec(Map<String, Object> params) {
         Object pattern = params.get(FORMAT_PARAM);
         if (pattern != null) {
             return new SimpleDateFormat(pattern.toString()).format(new Date());

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/pom.xml
@@ -1,46 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ~ Copyright 2014 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under 
-	the Apache License, Version 2.0 (the "License"); ~ you may not use this file 
-	except in compliance with the License. ~ You may obtain a copy of the License 
-	at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by 
-	applicable law or agreed to in writing, software ~ distributed under the 
-	License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. ~ See the License for the specific 
-	language governing permissions and ~ limitations under the License. -->
+  the Apache License, Version 2.0 (the "License"); ~ you may not use this file 
+  except in compliance with the License. ~ You may obtain a copy of the License 
+  at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by 
+  applicable law or agreed to in writing, software ~ distributed under the 
+  License is distributed on an "AS IS" BASIS, ~ WITHOUT WARRANTIES OR CONDITIONS 
+  OF ANY KIND, either express or implied. ~ See the License for the specific 
+  language governing permissions and ~ limitations under the License. -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.dashbuilder</groupId>
-		<artifactId>dashbuilder-backend</artifactId>
-		<version>7.46.0-SNAPSHOT</version>
-	</parent>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.dashbuilder</groupId>
+    <artifactId>dashbuilder-backend</artifactId>
+    <version>7.46.0-SNAPSHOT</version>
+  </parent>
 
-	<artifactId>dashbuilder-kie-server-backend</artifactId>
-	<packaging>jar</packaging>
-	<name>Dashbuilder Kie Server Backend</name>
+  <artifactId>dashbuilder-kie-server-backend</artifactId>
+  <packaging>jar</packaging>
+  <name>Dashbuilder Kie Server Backend</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.dashbuilder</groupId>
-			<artifactId>dashbuilder-kie-server-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.enterprise</groupId>
-			<artifactId>cdi-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.errai</groupId>
-			<artifactId>errai-config</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.resteasy</groupId>
-			<artifactId>resteasy-client</artifactId>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-kie-server-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-external-backend</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/function/ProcessSVGFunction.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/function/ProcessSVGFunction.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class ProcessSVGFunction implements BackendComponentFunction {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessSVGFunction.class);
-    
+
     private static final String NOT_FOUND_MSG = "Process SVG not found for container {} and process {}";
 
     private static final String CONTAINERID_PARAM = "containerId";
@@ -69,7 +69,7 @@ public class ProcessSVGFunction implements BackendComponentFunction {
         } catch (Exception e) {
             errorRetrievingSVG(e);
         }
-
+        return null;
     }
 
     private void errorRetrievingSVG(Exception e) {
@@ -81,7 +81,7 @@ public class ProcessSVGFunction implements BackendComponentFunction {
     private void notFoundSVGError(String containerId, String processId) {
         String notFoundMessage = String.format(NOT_FOUND_MSG, containerId, processId);
         LOGGER.warn(notFoundMessage);
-        throw new RuntimeException(notFoundMessage) ;
+        throw new RuntimeException(notFoundMessage);
     }
 
     private String getRequiredParam(String param, Map<String, Object> params) {

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/function/ProcessSVGFunction.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/function/ProcessSVGFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.kieserver.backend.function;
+
+import java.util.Map;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+
+import org.dashbuilder.external.impl.BackendComponentFunction;
+import org.dashbuilder.kieserver.KieServerConnectionInfo;
+import org.dashbuilder.kieserver.KieServerConnectionInfoProvider;
+import org.dashbuilder.kieserver.backend.rest.KieServerQueryClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Dependent
+public class ProcessSVGFunction implements BackendComponentFunction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessSVGFunction.class);
+
+    final static String CONTAINERID_PARAM = "containerId";
+    final static String PROCESSID_PARAM = "processId";
+    final static String SERVER_TEMPLATE_PARAM = "serverTemplate";
+
+    @Inject
+    KieServerQueryClient queryClient;
+
+    @Inject
+    KieServerConnectionInfoProvider connectionInfoProvider;
+
+    @Override
+    public Object exec(Map<String, Object> params) {
+        String containerId = getRequiredParam(CONTAINERID_PARAM, params);
+        String processId = getRequiredParam(PROCESSID_PARAM, params);
+        Object serverTemplate = params.get(SERVER_TEMPLATE_PARAM);
+        KieServerConnectionInfo connectionInfo;
+        if (serverTemplate != null) {
+            connectionInfo = connectionInfoProvider.get(null, serverTemplate.toString())
+                                                   .orElseThrow(() -> new RuntimeException("Configuration for server template not found " + serverTemplate));
+        } else {
+            connectionInfo = connectionInfoProvider.getDefault()
+                                                   .orElseThrow(() -> new RuntimeException("Not able to find credentials to retrieve processes SVG"));
+        }
+        try {
+            return queryClient.processSVG(connectionInfo, containerId, processId);
+        } catch (Exception e) {
+
+            if (e instanceof WebApplicationException) {
+                WebApplicationException webException = (WebApplicationException) e;
+                if (webException.getResponse().getStatus() == 404) {
+                    LOGGER.warn("SVG not found for container " + containerId + ", process " + processId);
+                    throw new RuntimeException("Process SVG not found for container " + containerId + "and process " + processId);
+                }
+            }
+            LOGGER.warn("Error requesting SVG");
+            LOGGER.debug("Error requesting SVG", e);
+            throw new RuntimeException("Error requesting SVG from Kie Server.", e);
+        }
+    }
+
+    private String getRequiredParam(String param, Map<String, Object> params) {
+        Object value = params.get(param);
+        if (value == null || value.toString().trim().isEmpty()) {
+            throw new RuntimeException("Param '" + param + "' is required.");
+        }
+        return value.toString();
+    }
+
+}

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
@@ -17,6 +17,7 @@
 package org.dashbuilder.kieserver.backend.rest;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.client.Client;
@@ -100,14 +101,19 @@ public class KieServerQueryClient {
 
     public String processSVG(KieServerConnectionInfo connectionInfo, String containerId, String processId) {
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target(connectionInfo.getLocation().get())
-                                 .path(PROCESS_SVG_URI)
-                                 .resolveTemplate(CONTAINER_ID_PARAM, containerId)
-                                 .resolveTemplate(PROCESS_ID_PARAM, processId);
-        addAuth(connectionInfo, target);
-        String svg = target.request().get(String.class);
-        client.close();
-        return svg;
+        Optional<String> location = connectionInfo.getLocation();
+        if (location.isPresent()) {
+            WebTarget target = client.target(location.get())
+                                     .path(PROCESS_SVG_URI)
+                                     .resolveTemplate(CONTAINER_ID_PARAM, containerId)
+                                     .resolveTemplate(PROCESS_ID_PARAM, processId);
+            addAuth(connectionInfo, target);
+            String svg = target.request().get(String.class);
+            client.close();
+            return svg;
+        }
+        
+        throw new RuntimeException("Location for Kie Server is required. Check configuration.");
     }
 
     private WebTarget requestForQueryDefinition(KieServerConnectionInfo connectionInfo,

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/rest/KieServerQueryClient.java
@@ -100,9 +100,9 @@ public class KieServerQueryClient {
     }
 
     public String processSVG(KieServerConnectionInfo connectionInfo, String containerId, String processId) {
-        Client client = ClientBuilder.newClient();
         Optional<String> location = connectionInfo.getLocation();
         if (location.isPresent()) {
+            Client client = ClientBuilder.newClient();
             WebTarget target = client.target(location.get())
                                      .path(PROCESS_SVG_URI)
                                      .resolveTemplate(CONTAINER_ID_PARAM, containerId)

--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/test/java/org/dashbuilder/kieserver/backend/KieServerConnectionInfoProviderImplTest.java
@@ -18,6 +18,7 @@ package org.dashbuilder.kieserver.backend;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.dashbuilder.kieserver.KieServerConnectionInfo;
 import org.dashbuilder.kieserver.RemoteDataSetDef;
@@ -29,6 +30,7 @@ import static org.dashbuilder.kieserver.backend.KieServerConnectionInfoProviderI
 import static org.dashbuilder.kieserver.backend.KieServerConnectionInfoProviderImpl.SERVER_TEMPLATE_PROP_PREFFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class KieServerConnectionInfoProviderImplTest {
@@ -166,6 +168,35 @@ public class KieServerConnectionInfoProviderImplTest {
         KieServerConnectionInfo connectionInfo = kieServerConnectionInfoProvider.verifiedConnectionInfo(def);
         assertFalse(connectionInfo.isReplaceQuery());
     }
+    
+    @Test
+    public void testRetrieveServerTemplateId() {
+        String serverTemplate = kieServerConnectionInfoProvider.retrieveTemplateId(SERVER_TEMPLATE_PROP_PREFFIX + ".myServerTemplate.url");
+        assertEquals("myServerTemplate", serverTemplate);
+    }
+    
+    @Test
+    public void testRetrieveServerTemplateIdBadString() {
+        String serverTemplate = kieServerConnectionInfoProvider.retrieveTemplateId("test");
+        assertNull(serverTemplate);
+    }
+    
+    @Test
+    public void testFindFirstServerTemplateConf() {
+        setServerProp(KieServerConfigurationKey.LOCATION, SERVER_LOCATION);
+        setServerProp(KieServerConfigurationKey.USER, SERVER_USER);
+        setServerProp(KieServerConfigurationKey.PASSWORD, SERVER_PASSWORD);
+        
+        Optional<String> conf = kieServerConnectionInfoProvider.findFirstServerTemplateConf();
+        assertTrue(conf.isPresent());
+    }
+    
+    @Test
+    public void testFindFirstServerTemplateConfNotFound() {
+        clearProperties();
+        Optional<String> conf = kieServerConnectionInfoProvider.findFirstServerTemplateConf();
+        assertFalse(conf.isPresent());
+    }
 
     private void setDataSetProp(KieServerConfigurationKey key, String value) {
         System.setProperty(DATASET_PROP + key.getValue(), value);
@@ -178,8 +209,8 @@ public class KieServerConnectionInfoProviderImplTest {
     private void clearProperties() {
         System.setProperty(KieServerConnectionInfoProviderImpl.SERVER_TEMPLATE_LIST_PROPERTY, "");
         for (KieServerConfigurationKey key : KieServerConfigurationKey.values()) {
-            System.setProperty(DATASET_PROP + key.getValue(), "");
-            System.setProperty(SERVER_TEMPLATE_PROP + key.getValue(), "");
+            System.clearProperty(DATASET_PROP + key.getValue());
+            System.clearProperty(SERVER_TEMPLATE_PROP + key.getValue());
         }
     }
 

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/BackendFunctionLoader.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/BackendFunctionLoader.java
@@ -35,7 +35,7 @@ import org.jboss.errai.ioc.client.api.EntryPoint;
 @EntryPoint
 public class BackendFunctionLoader {
 
-    private static final String UNKNOW_BACKEND_ERROR = "Unknow backend error.";
+    private static final String UNKNOWN_BACKEND_ERROR = "Unknown backend error.";
 
     @Inject
     ComponentFunctionLocator componentFunctionLocator;
@@ -59,7 +59,7 @@ public class BackendFunctionLoader {
             @Override
             public void exec(Map<String, Object> params, Consumer<Object> onFinish, Consumer<String> onError) {
                 backendFunctionLoaderService.call(onFinish::accept, (Object message, Throwable throwable) -> {
-                    String errorMessage = UNKNOW_BACKEND_ERROR;
+                    String errorMessage = UNKNOWN_BACKEND_ERROR;
                     if (throwable != null && throwable.getMessage() != null) {
                         errorMessage = throwable.getMessage();
                     } else if (message != null) {

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/BackendFunctionLoader.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/BackendFunctionLoader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dashbuilder.displayer.client.component.function;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.dashbuilder.displayer.external.ExternalComponentFunction;
+import org.dashbuilder.external.service.BackendComponentFunctionService;
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.ioc.client.api.EntryPoint;
+
+/**
+ * Generated wrapped client functions to proxy the call using BackendFunctionLoaderService.
+ *
+ */
+@EntryPoint
+public class BackendFunctionLoader {
+
+    @Inject
+    ComponentFunctionLocator componentFunctionLocator;
+
+    @Inject
+    Caller<BackendComponentFunctionService> backendFunctionLoaderService;
+
+    @PostConstruct
+    public void loadBackendFunctions() {
+        backendFunctionLoaderService.call((List<String> result) -> this.registerFunctions(result)).listFunctions();
+    }
+
+    private void registerFunctions(List<String> result) {
+        result.forEach(name -> {
+            componentFunctionLocator.registerFunction(new ExternalComponentFunction() {
+
+                @Override
+                public String getName() {
+                    return name;
+                }
+
+                @Override
+                public void exec(Map<String, Object> params, Consumer<Object> onFinish, Consumer<String> onError) {
+                    backendFunctionLoaderService.call(result -> {
+                        onFinish.accept(result);
+                    }, (Object message, Throwable throwable) -> {
+                        String errorMessage = "Unknow backend error.";
+                        if (throwable != null && throwable.getMessage() != null) {
+                            errorMessage = throwable.getMessage();
+                        } else if (message != null) {
+                            errorMessage = message.toString();
+                        }
+                        onError.accept(errorMessage);
+                        return false;
+                    }).callFunction(name, params);
+                }
+
+            });
+        });
+
+    }
+
+}

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/ComponentFunctionLocator.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/ComponentFunctionLocator.java
@@ -23,7 +23,9 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
+import org.dashbuilder.displayer.external.ExternalComponentFunction;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 
@@ -50,6 +52,16 @@ public class ComponentFunctionLocator {
 
     public Optional<ExternalComponentFunction> findFunctionByName(String name) {
         return functions.stream().filter(f -> name.equals(f.getName())).findAny();
+    }
+
+    public void registerFunction(ExternalComponentFunction function) {
+        functions.add(function);
+    }
+    
+    public JsArray<String> listFunctions() {
+        JsArray<String> array = new JsArray<>();
+        functions.stream().map(ExternalComponentFunction::getName).forEach(array::push);
+        return array;
     }
 
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/GWTVersion.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/GWTVersion.java
@@ -1,11 +1,12 @@
 package org.dashbuilder.displayer.client.component.function;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.enterprise.context.Dependent;
 
 import com.google.gwt.core.client.GWT;
-import elemental2.core.JsMap;
+import org.dashbuilder.displayer.external.ExternalComponentFunction;
 
 /**
  * Returns GWT Version
@@ -15,8 +16,8 @@ import elemental2.core.JsMap;
 public class GWTVersion implements ExternalComponentFunction {
 
     @Override
-    public void exec(JsMap<String, Object> params, Consumer<Object> onResult) {
-        onResult.accept(GWT.getVersion());
+    public void exec(Map<String, Object> params, Consumer<Object> onFinish, Consumer<String> onError) {
+        onFinish.accept(GWT.getVersion());
     }
 
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/ListFunctions.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/component/function/ListFunctions.java
@@ -15,15 +15,27 @@
  */
 package org.dashbuilder.displayer.client.component.function;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
-import elemental2.core.JsMap;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
 
-public interface ExternalComponentFunction {
+import org.dashbuilder.displayer.external.ExternalComponentFunction;
 
-    default String getName() {
-        return this.getClass().getSimpleName();
+/**
+ * A meta function to list available functions.
+ *
+ */
+@Dependent
+public class ListFunctions implements ExternalComponentFunction {
+
+    @Inject
+    ComponentFunctionLocator locator;
+
+    @Override
+    public void exec(Map<String, Object> params, Consumer<Object> onFinish, Consumer<String> onError) {
+        onFinish.accept(locator.listFunctions());
     }
 
-    void exec(JsMap<String, Object> params, Consumer<Object> onFinish);
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/test/java/org/dashbuilder/displayer/client/component/ExternalComponentDispatcherTest.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/test/java/org/dashbuilder/displayer/client/component/ExternalComponentDispatcherTest.java
@@ -22,8 +22,8 @@ import java.util.function.Consumer;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.dashbuilder.displayer.client.component.function.ComponentFunctionLocator;
-import org.dashbuilder.displayer.client.component.function.ExternalComponentFunction;
 import org.dashbuilder.displayer.client.resources.i18n.CommonConstants;
+import org.dashbuilder.displayer.external.ExternalComponentFunction;
 import org.dashbuilder.displayer.external.ExternalComponentMessage;
 import org.dashbuilder.displayer.external.ExternalComponentMessageHelper;
 import org.dashbuilder.displayer.external.ExternalComponentMessageType;
@@ -160,9 +160,9 @@ public class ExternalComponentDispatcherTest {
         ExternalComponentMessage message = functionCallMessage(callRequestOp);
         ExternalComponentMessage functionErrorMessage = mock(ExternalComponentMessage.class);
         String functionName = "f1";
-        RuntimeException functionError = new RuntimeException();
+        String functionError = "error";
 
-        Mockito.doThrow(functionError).when(function).exec(any(), any());
+        Mockito.doThrow(new RuntimeException(functionError)).when(function).exec(any(), any(), any());
         when(callRequest.getFunctionName()).thenReturn(functionName);
         when(messageHelper.newFunctionError(eq(callRequest), eq(functionError))).thenReturn(functionErrorMessage);
         when(functionLocator.findFunctionByName(eq(functionName))).thenReturn(Optional.of(function));
@@ -173,7 +173,7 @@ public class ExternalComponentDispatcherTest {
 
         verify(messageHelper).functionCallRequest(eq(message));
         verify(functionLocator).findFunctionByName(eq(functionName));
-        verify(function).exec(any(), any());
+        verify(function).exec(any(), any(), any());
         verify(listener).sendMessage(functionErrorMessage);
     }
 
@@ -197,7 +197,7 @@ public class ExternalComponentDispatcherTest {
 
         verify(messageHelper).functionCallRequest(eq(message));
         verify(functionLocator).findFunctionByName(eq(functionName));
-        verify(function).exec(any(), functionExecutionCaptor.capture());
+        verify(function).exec(any(), functionExecutionCaptor.capture(), any());
 
         functionExecutionCaptor.getValue().accept(result);
 

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/test/java/org/dashbuilder/displayer/client/component/function/ComponentFunctionLocatorTest.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/test/java/org/dashbuilder/displayer/client/component/function/ComponentFunctionLocatorTest.java
@@ -18,6 +18,7 @@ package org.dashbuilder.displayer.client.component.function;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.dashbuilder.displayer.external.ExternalComponentFunction;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/external/ExternalComponentFunction.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/external/ExternalComponentFunction.java
@@ -13,23 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.dashbuilder.displayer.external;
 
-package org.dashbuilder.kieserver;
+import java.util.Map;
+import java.util.function.Consumer;
 
-import java.util.List;
-import java.util.Optional;
+public interface ExternalComponentFunction {
 
-import org.jboss.errai.bus.server.annotations.Remote;
+    default String getName() {
+        return this.getClass().getSimpleName();
+    }
 
-@Remote
-public interface KieServerConnectionInfoProvider {
-
-    Optional<KieServerConnectionInfo> get(String name, String serverTemplate);
-
-    List<String> serverTemplates();
-
-    KieServerConnectionInfo verifiedConnectionInfo(RemoteDataSetDef def);
-    
-    Optional<KieServerConnectionInfo> getDefault();
+    void exec(Map<String, Object> params, Consumer<Object> onFinish, Consumer<String> onError);
 
 }

--- a/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/external/ExternalComponentMessageHelper.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-displayer-api/src/main/java/org/dashbuilder/displayer/external/ExternalComponentMessageHelper.java
@@ -136,12 +136,12 @@ public class ExternalComponentMessageHelper {
         return ExternalComponentMessage.create(ExternalComponentMessageType.INIT.name(), componentProperties);
     }
 
-    public ExternalComponentMessage newFunctionError(FunctionCallRequest functionCallRequest, Exception exception) {
+    public ExternalComponentMessage newFunctionError(FunctionCallRequest functionCallRequest, String errorMessage) {
         Map<String, Object> props = Collections.singletonMap(FUNCTION_RESPONSE_PROP,
                                                              FunctionResponse.create(functionCallRequest,
                                                                                      FunctionResultType.ERROR.name(),
                                                                                      FUNCTION_EXECUTION_ERROR_FOUND,
-                                                                                     exception.getMessage()));
+                                                                                     errorMessage));
         return ExternalComponentMessage.create(ExternalComponentMessageType.FUNCTION_RESPONSE.name(), props);
     }
 

--- a/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/external/service/BackendComponentFunctionService.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/external/service/BackendComponentFunctionService.java
@@ -13,23 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.dashbuilder.kieserver;
+package org.dashbuilder.external.service;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 
 import org.jboss.errai.bus.server.annotations.Remote;
 
+/**
+ * List and calls functions available on backend.
+ *
+ */
 @Remote
-public interface KieServerConnectionInfoProvider {
+public interface BackendComponentFunctionService {
 
-    Optional<KieServerConnectionInfo> get(String name, String serverTemplate);
+    List<String> listFunctions();
 
-    List<String> serverTemplates();
-
-    KieServerConnectionInfo verifiedConnectionInfo(RemoteDataSetDef def);
-    
-    Optional<KieServerConnectionInfo> getDefault();
+    Object callFunction(String name, Map<String, Object> params);
 
 }

--- a/dashbuilder/dashbuilder-webapp/pom.xml
+++ b/dashbuilder/dashbuilder-webapp/pom.xml
@@ -806,7 +806,7 @@
 
           </compileSourcesArtifacts>
           <runTarget>dashbuilder.html</runTarget>
-	  <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.jboss.debug.port=8787 -Ddashbuilder.components.enable=true -Ddashbuilder.export.dir=/tmp/dashbuilder/models -Ddashbuilder.runtime.location=http://localhost:8280 -Ddashbuilder.shareOpenModel=true</extraJvmArgs>
+	  <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.jboss.debug.port=8787 -Ddashbuilder.components.enable=true -Ddashbuilder.export.dir=/tmp/dashbuilder/models -Ddashbuilder.runtime.location=http://localhost:8280 -Ddashbuilder.shareOpenModel=true -Ddashbuilder.kieserver.serverTemplate.default.location=http://localhost:8080/kie-server/services/rest/server -Ddashbuilder.kieserver.serverTemplate.default.user=kieserver -Ddashbuilder.kieserver.serverTemplate.default.password=kieserver1! -Ddashbuilder.kieserver.defaultServerTemplate=default -Ddashbuilder.kieserver.serverTemplates=default</extraJvmArgs>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
           <hostedWebapp>src/main/webapp</hostedWebapp>


### PR DESCRIPTION
[AF-2637](https://issues.redhat.com/browse/AF-2637)

Part of an ensemble, merge with:

https://github.com/kiegroup/jbpm-wb/pull/1467

--------------------------------------------------------------------------------
This PR:

* Extends components functions (AF-2636) to backend;
* Add a function to retrieve a process SVG.

The way it was implemented was using a proxy mechanism. The class BackendFunctionLoaderService is responsible to look for backend functions, then the class BackendFunctionLoader calls the service to list the registered functions and register it on client side and also proxy calls to backend funcions.

Along with this we created ProcessSVGFunction, it uses Kie Server API to retrieve a process SVG. Notice it requires two parameters: containerId, process Id. It is also possible to define a serverTemplateId, where user can set a server template to look for the Kie server to retrieve the SVG. If a server template is not used then the function uses the first one available or a default server template, configured using system property `dashbuilder.kieserver.defaultServerTemplate`.

Since the way to access Kie Server in DB is different of how it is done in BC, we implemented a specific function for BC. It has the same name and support the same parameters, so we should be fine when exporting dashboards that uses this function from BC to DB.

https://github.com/kiegroup/jbpm-wb/pull/1467

To test the changes use the component I created called process_svg. Just copy the following folder into your components directory. In BC you create a new page and drag the component, make sure you have Kie Server containers running and a process with SVG (the sample evaluation has SVG) then you create a container, drag the component, set the values corresponding values and it should work, see an example:

![process_svg_comp](https://user-images.githubusercontent.com/359820/97240971-71825200-17ce-11eb-875f-c62f6e7d6149.gif)

 If you just import the evaluation example and deploy, then these values in component config should be okay:

Container: evaluation_1.0.0-SNAPSHOT
Process: evaluation
Server template: sample-server   

![image](https://user-images.githubusercontent.com/359820/97241022-9e366980-17ce-11eb-8be8-234ca2cf7171.png)

Process SVG component:
https://github.com/jesuino/dashbuilder-components/tree/master/process_svg