### PR TITLE
[TEST] maven connection errors

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,3 +27,4 @@ jobs:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3


### PR DESCRIPTION
trying to solve problems like this one
https://github.com/kiegroup/appformer/pull/1067/checks?sha=a74dccf13c50f2c0a09078924b7c40f8f7c23d1d

```
Error:  Failed to execute goal on project uberfire-metadata-backend-infinispan: Could not resolve dependencies for project org.uberfire:uberfire-metadata-backend-infinispan:jar:7.46.0-SNAPSHOT: Failed to collect dependencies at org.arquillian.cube:arquillian-cube-docker-junit-rule:jar:1.15.3 -> org.arquillian.cube:arquillian-cube-docker:jar:1.0.0.Alpha15 -> org.arquillian.cube:arquillian-cube-spi:jar:1.0.0.Alpha15 -> org.arquillian.extension:arquillian-recorder-reporter-api:jar:1.1.2.Final -> org.eclipse.persistence:org.eclipse.persistence.moxy:jar:2.7.6: Failed to read artifact descriptor for org.eclipse.persistence:org.eclipse.persistence.moxy:jar:2.7.6: Could not transfer artifact org.eclipse.persistence:org.eclipse.persistence.moxy:pom:2.7.6 from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/eclipse/persistence/org.eclipse.persistence.moxy/2.7.6/org.eclipse.persistence.moxy-2.7.6.pom: Connection reset -> [Help 1]
```

Testing what's proposed from https://github.community/t/getting-maven-could-not-transfer-artifact-with-500-error-when-using-github-actions/17570/7.

Related PR:
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1512
* https://github.com/kiegroup/appformer/pull/1069

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
