### PR TITLE
AF-2702: Support for component mandatory fields

### DIFF
--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/resources/i18n/CommonConstants.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/resources/i18n/CommonConstants.java
@@ -281,4 +281,8 @@ public interface CommonConstants extends Messages {
     String noPropertiesComponent();
 
     String componentConfigDefaultMessage();
+
+    String mandatoryHelpHeader();
+
+    String mandatoryHelpText();
 }

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/ExternalComponentPropertiesEditor.java
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/java/org/dashbuilder/displayer/client/widgets/ExternalComponentPropertiesEditor.java
@@ -17,6 +17,7 @@
 package org.dashbuilder.displayer.client.widgets;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,12 +40,15 @@ import org.uberfire.client.mvp.UberView;
 import org.uberfire.ext.properties.editor.model.PropertyEditorCategory;
 import org.uberfire.ext.properties.editor.model.PropertyEditorFieldInfo;
 import org.uberfire.ext.properties.editor.model.PropertyEditorType;
+import org.uberfire.ext.properties.editor.model.validators.MandatoryValidator;
 import org.uberfire.ext.widgets.common.client.common.BusyIndicatorView;
 
 @Dependent
 public class ExternalComponentPropertiesEditor implements IsWidget {
     
-    CommonConstants i18n = CommonConstants.INSTANCE;
+    private static final CommonConstants i18n = CommonConstants.INSTANCE;
+    
+    private static final MandatoryValidator MANDATORY_VALIDATOR = new MandatoryValidator();
 
     private static final String DEFAULT_CATEGORY = "Component Properties";
 
@@ -143,6 +147,10 @@ public class ExternalComponentPropertiesEditor implements IsWidget {
         field.withKey(fieldKey);
         if (field.getType() == PropertyEditorType.COMBO) {
             field.withComboValues(p.getComboValues());
+        }
+        if (p.isMandatory()) {
+            field.withValidators(Collections.singleton(MANDATORY_VALIDATOR));
+            field.withHelpInfo(i18n.mandatoryHelpHeader(), i18n.mandatoryHelpText());
         }
         if (currentValue != null) {
             field.setCurrentStringValue(currentValue);

--- a/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/resources/org/dashbuilder/displayer/client/resources/i18n/CommonConstants.properties
+++ b/dashbuilder/dashbuilder-client/dashbuilder-displayer-client/src/main/resources/org/dashbuilder/displayer/client/resources/i18n/CommonConstants.properties
@@ -190,3 +190,5 @@ componentEditor=Component Editor
 componentNotFound=Component Not Found
 noPropertiesComponent=This component has no properties.
 componentConfigDefaultMessage=Read the component configuration to find which columns it supports. 
+mandatoryHelpHeader=Mandatory
+mandatoryHelpText=This field is mandatory.

--- a/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/external/model/ComponentParameter.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-services-api/src/main/java/org/dashbuilder/external/model/ComponentParameter.java
@@ -30,6 +30,7 @@ public class ComponentParameter {
     private String defaultValue;
     private String label;
     private List<String> comboValues;
+    private boolean mandatory;
 
     public ComponentParameter() {
         // default constructor used internally
@@ -95,6 +96,16 @@ public class ComponentParameter {
 
     public void setComboValues(List<String> comboValues) {
         this.comboValues = comboValues;
+    }
+
+    
+    public boolean isMandatory() {
+        return mandatory;
+    }
+
+    
+    public void setMandatory(boolean mandatory) {
+        this.mandatory = mandatory;
     }
 
 }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/main/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidator.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/main/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidator.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.uberfire.ext.properties.editor.model.validators;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
 
 @Portable
-public class MandatoryValidator implements PropertyFieldValidator{
+public class MandatoryValidator implements PropertyFieldValidator {
 
     @Override
     public boolean validate(Object value) {

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/main/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidator.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/main/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidator.java
@@ -1,0 +1,18 @@
+package org.uberfire.ext.properties.editor.model.validators;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class MandatoryValidator implements PropertyFieldValidator{
+
+    @Override
+    public boolean validate(Object value) {
+        return value != null && !value.toString().trim().isEmpty();
+    }
+
+    @Override
+    public String getValidatorErrorMessage() {
+        return "Field is mandatory.";
+    }
+
+}

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/main/java/org/uberfire/ext/properties/editor/model/validators/PropertyFieldValidator.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/main/java/org/uberfire/ext/properties/editor/model/validators/PropertyFieldValidator.java
@@ -24,7 +24,9 @@ public interface PropertyFieldValidator {
     /**
      * Validate a field new value
      * @param value
+     * The value to be validated
      * @return
+     * true if valid, false otherwise
      */
     public boolean validate(Object value);
 

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/test/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidatorTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/test/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.uberfire.ext.properties.editor.model.validators;
 
 import org.junit.Before;

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/test/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidatorTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-properties-editor/uberfire-widgets-properties-editor-api/src/test/java/org/uberfire/ext/properties/editor/model/validators/MandatoryValidatorTest.java
@@ -1,0 +1,30 @@
+package org.uberfire.ext.properties.editor.model.validators;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MandatoryValidatorTest {
+    
+    private MandatoryValidator validator;
+
+    @Before
+    public void setup() {
+        validator = new MandatoryValidator();
+    }
+    
+    @Test
+    public void testValid() {
+        assertTrue(validator.validate("valid"));
+    }
+    
+    @Test
+    public void testNotValid() {
+        assertFalse(validator.validate(""));
+        assertFalse(validator.validate("          "));
+        assertFalse(validator.validate(null));
+    }
+
+}


### PR DESCRIPTION
**JIRA**: 

[AF-2702](https://issues.redhat.com/browse/AF-2702)


This is a PR for the mentioned JIRA above. It gives the options to make a field mandatory. However, bear in mind the limitation we currently have, for example, I can't lock user into the form until the user fill the mandatory field for now, this could be done in future, but this task would get too big if I add this.

What I did is basically visual warns to let users know that the field they are modifying is mandatory. I can't also modify the component editor properties pane right now because it is a shared API, so I just added this visual warning.

![image](https://user-images.githubusercontent.com/359820/97759597-1e671280-1ae0-11eb-84c6-c8b6b4436d21.png)
![image](https://user-images.githubusercontent.com/359820/97759601-232bc680-1ae0-11eb-9179-a0211f8a2850.png)
