### PR TITLE
[Backport-7.44.x] RHPAM-2984 :RHPAM with RHSSO shows reserved roles as a groups as well 

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.errai.security.shared.api.Group;
 import org.jboss.resteasy.client.ClientResponse;
@@ -52,6 +53,7 @@ import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull
 /**
  * <p>GroupsManager Service Provider Implementation for KeyCloak.</p>
  * <p>Note that roles (in keycloak server) are mapped as groups (in the workbench) for the keycloak users management provider impl.</p>
+ *
  * @since 0.8.0
  */
 public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupManager,
@@ -105,11 +107,14 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
         consumeRealm(realmResource -> {
             final RolesResource rolesResource = realmResource.roles();
             final List<RoleRepresentation> roleRepresentations = rolesResource.list();
+            final Set<String> registeredRoles = SecurityManagementUtils.getRegisteredRoleNames();
             if (roleRepresentations != null && !roleRepresentations.isEmpty()) {
                 for (RoleRepresentation role : roleRepresentations) {
                     final String name = role.getName();
-                    final Group group = createGroup(name);
-                    roles.add(group);
+                    if (!registeredRoles.contains(name)) {
+                        final Group group = createGroup(name);
+                        roles.add(group);
+                    }
                 }
             }
         });

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,6 +33,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+import org.uberfire.backend.server.security.RoleRegistry;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleMappingResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleScopeResource;
@@ -63,15 +64,18 @@ public abstract class DefaultKeyCloakTest extends BaseKeyCloakTest {
     @Before
     public void setup() throws Exception {
         super.setup();
-        // Roles.
+        // register roles
+        RoleRegistry.get().clear();
+        RoleRegistry.get().registerRole("admin");
+        RoleRegistry.get().registerRole("developer");
+
+        // Groups.
         for (int x = 0; x < rolesCount; x++) {
             String name = ROLE + x;
-            RoleResource roleResource = mock(RoleResource.class);
-            mockRoleResource(roleResource,
-                             name);
-            roleResources.add(roleResource);
-            roleRepresentations.add(roleResource.toRepresentation());
+            addRole(name);
         }
+        addRole("admin");
+        addRole("developer");
         when(rolesResource.get(anyString())).thenAnswer(new Answer<RoleResource>() {
             @Override
             public RoleResource answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -265,5 +269,13 @@ public abstract class DefaultKeyCloakTest extends BaseKeyCloakTest {
             }
         }
         return null;
+    }
+
+    private void addRole(String name) {
+        RoleResource roleResource = mock(RoleResource.class);
+        mockRoleResource(roleResource,
+                         name);
+        roleResources.add(roleResource);
+        roleRepresentations.add(roleResource.toRepresentation());
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
@@ -112,6 +112,7 @@ public class KeyCloakGroupManagerTest extends DefaultKeyCloakTest {
     @Test
     public void testGetAllGroups() {
         List<Group> groups = groupsManager.getAll();
+        assertEquals(52, roleResources.size());
         assertEquals(50, groups.size());
     }
 


### PR DESCRIPTION
… 

(cherry picked from commit f687e538ea0a1dd2a2d11aabf7b83f72f5fb7b36)

**Thank you for submitting this pull request**

**RHPAM-2984**: https://issues.redhat.com/browse/RHPAM-2984 

**referenced Pull Requests**:https://github.com/kiegroup/appformer/pull/1066

How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
