### PR TITLE
AF-2692 : Add a security permission to show project toolbar, Metrics tab and change request tab

### DIFF
--- a/uberfire-project/uberfire-project-client/src/main/java/org/guvnor/common/services/project/client/security/ProjectController.java
+++ b/uberfire-project/uberfire-project-client/src/main/java/org/guvnor/common/services/project/client/security/ProjectController.java
@@ -53,6 +53,12 @@ public class ProjectController {
     private Caller<ProjectPermissionsService> projectPermissionsService;
     private Promises promises;
 
+    private static final String SHOW_PROJECT_TOOLBAR = "projecttoolbar.show";
+
+    private static final String SHOW_METRICS_TAB = "metricstab.show";
+
+    private static final String SHOW_CHANGEREQUEST_TAB = "changerequesttab.show";
+
     @Inject
     public ProjectController(final AuthorizationManager authorizationManager,
                              final User user,
@@ -62,6 +68,21 @@ public class ProjectController {
         this.user = user;
         this.projectPermissionsService = projectPermissionsService;
         this.promises = promises;
+    }
+
+    public boolean canViewProjectToolbar() {
+        return authorizationManager.authorize(SHOW_PROJECT_TOOLBAR,
+                                              user);
+    }
+
+    public boolean canViewMetricsTab() {
+        return authorizationManager.authorize(SHOW_METRICS_TAB,
+                                              user);
+    }
+
+    public boolean canViewChangeRequestTab() {
+        return authorizationManager.authorize(SHOW_CHANGEREQUEST_TAB,
+                                              user);
     }
 
     public boolean canCreateProjects(final OrganizationalUnit organizationalUnit) {

--- a/uberfire-project/uberfire-project-client/src/test/java/org/guvnor/common/services/project/client/security/ProjectControllerTest.java
+++ b/uberfire-project/uberfire-project-client/src/test/java/org/guvnor/common/services/project/client/security/ProjectControllerTest.java
@@ -65,6 +65,12 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectControllerTest {
 
+    private static final String SHOW_PROJECT_TOOLBAR = "projecttoolbar.show";
+
+    private static final String SHOW_METRICS_TAB = "metricstab.show";
+
+    private static final String SHOW_CHANGEREQUEST_TAB = "changerequesttab.show";
+
     @Mock
     private AuthorizationManager authorizationManager;
 
@@ -87,6 +93,27 @@ public class ProjectControllerTest {
                                                       user,
                                                       projectPermissionsServiceCaller,
                                                       promises));
+    }
+
+    @Test
+    public void userCanViewMetricsTabTest() {
+        when(authorizationManager.authorize(SHOW_METRICS_TAB,
+                                            user)).thenReturn(true);
+        assertTrue(projectController.canViewMetricsTab());
+    }
+
+    @Test
+    public void userCanViewMChangeRequestTabTest() {
+        when(authorizationManager.authorize(SHOW_CHANGEREQUEST_TAB,
+                                            user)).thenReturn(true);
+        assertTrue(projectController.canViewChangeRequestTab());
+    }
+
+    @Test
+    public void userCanViewProjectToolbarTest() {
+        when(authorizationManager.authorize(SHOW_PROJECT_TOOLBAR,
+                                            user)).thenReturn(true);
+        assertTrue(projectController.canViewProjectToolbar());
     }
 
     @Test


### PR DESCRIPTION
**Thank you for submitting this pull request**

**AF-2694**: https://issues.redhat.com/browse/AF-2692
Related PR's
https://github.com/kiegroup/kie-wb-common/pull/3510
https://github.com/kiegroup/kie-wb-distributions/pull/1076

- Added 3 new security permissions under Workbench permission to hide/show the project toolbar, Metrics tab and change request tab.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
