### PR TITLE
Add appformer-js dependency to prevent js projects from building in parallel

### DIFF
--- a/appformer-js-monaco/pom.xml
+++ b/appformer-js-monaco/pom.xml
@@ -16,6 +16,13 @@
     <name>AppFormer.js :: Monaco Editor</name>
     <description>AppFormer.js Monaco Editor</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.uberfire</groupId>
+            <artifactId>appformer-js</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/appformer-js-monaco/pom.xml
+++ b/appformer-js-monaco/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>org.uberfire</groupId>
             <artifactId>appformer-js</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/dashbuilder/dashbuilder-shared/dashbuilder-js/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-js/pom.xml
@@ -31,6 +31,13 @@
   <name>Dashbuilder JS</name>
   <description>Dashbuilder JS APIs and internal components for displaying data</description>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>appformer-js</artifactId>
+    </dependency>
+  </dependencies>
+
   <properties>
     <!-- Comma separated internal components name -->
     <dashbuilder.internal.components.list>logo-provided</dashbuilder.internal.components.list>

--- a/dashbuilder/dashbuilder-shared/dashbuilder-js/pom.xml
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-js/pom.xml
@@ -34,7 +34,8 @@
   <dependencies>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>appformer-js</artifactId>
+      <artifactId>appformer-js-monaco</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Add appformer-js dependency to prevent js projects from building in parallel.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
