### PR TITLE
BAPL-1735 :[GSS-RFE] RHPAM + RHSSO customer asking for support of Client Roles

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/src/main/java/org/uberfire/ext/security/management/api/exception/ClientNotFoundException.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-api/src/main/java/org/uberfire/ext/security/management/api/exception/ClientNotFoundException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.api.exception;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class ClientNotFoundException extends EntityNotFoundException {
+
+    public ClientNotFoundException(@MapsTo("identifier") String identifier) {
+        super(identifier);
+    }
+
+    @Override
+    public String getMessage() {
+        return "Client [" + getIdentifier() + "] not configured";
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/CredentialsClientFactory.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/CredentialsClientFactory.java
@@ -49,9 +49,12 @@ public class CredentialsClientFactory extends BaseClientFactory {
                                                                     DEFAULT_CLIENT_ID);
         final ConfigProperties.ConfigProperty clientSecret = config.get("org.uberfire.ext.security.management.keycloak.clientSecret",
                                                                         DEFAULT_CLIENT_SECRET);
+        final ConfigProperties.ConfigProperty useRoleResourceMappings = config.get("org.uberfire.ext.security.management.keycloak.use-resource-role-mappings",
+                                                                        "false");
 
         this.client = Keycloak.getInstance(authServer.getValue(),
                                            realm.getValue(),
+                                           useRoleResourceMappings.getBooleanValue(),
                                            new AuthTokenManager(new AuthSettings(authServer.getValue(),
                                                                                  realm.getValue(),
                                                                                  user.getValue(),

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCAdapterClientFactory.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCAdapterClientFactory.java
@@ -44,10 +44,13 @@ public class KCAdapterClientFactory extends BaseClientFactory {
         // Check mandatory properties.
         final ConfigProperties.ConfigProperty authServer = config.get("org.uberfire.ext.security.management.keycloak.authServer",
                                                                       DEFAULT_AUTH_SERVER);
+        final ConfigProperties.ConfigProperty useRoleResourceMappings = config.get("org.uberfire.ext.security.management.keycloak.use-resource-role-mappings",
+                                                                                   "false");
 
         final KCAdapterContextTokenManager tokenManager = new KCAdapterContextTokenManager(request);
         this.client = Keycloak.getInstance(authServer.getValue(),
                                            tokenManager.getRealm(),
+                                           useRoleResourceMappings.getBooleanValue(),
                                            tokenManager);
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
@@ -87,8 +87,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
                      identifier);
         final RoleResource[] roleResource = new RoleResource[1];
         consumeRealm(realmResource -> {
-            final RolesResource rolesResource = realmResource.roles();
-            roleResource[0] = rolesResource.get(identifier);
+            roleResource[0] = getRolesResource(realmResource, getKeyCloakInstance().getUseRoleResourceMappings()).get(identifier);
         });
         if (roleResource[0] != null) {
             final RoleRepresentation roleRepresentation = getRoleRepresentation(identifier,
@@ -104,8 +103,9 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
     @Override
     public List<Group> getAll() throws SecurityManagementException {
         final List<Group> roles = new LinkedList<>();
+
         consumeRealm(realmResource -> {
-            final RolesResource rolesResource = realmResource.roles();
+            RolesResource rolesResource = getRolesResource(realmResource, getKeyCloakInstance().getUseRoleResourceMappings());
             final List<RoleRepresentation> roleRepresentations = rolesResource.list();
             final Set<String> registeredRoles = SecurityManagementUtils.getRegisteredRoleNames();
             if (roleRepresentations != null && !roleRepresentations.isEmpty()) {
@@ -126,7 +126,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
         checkNotNull("entity",
                      entity);
         consumeRealm(realmResource -> {
-            final RolesResource rolesResource = realmResource.roles();
+            final RolesResource rolesResource = getRolesResource(realmResource, getKeyCloakInstance().getUseRoleResourceMappings());
             final RoleRepresentation roleRepresentation = new RoleRepresentation(entity.getName(), entity.getName(), Boolean.FALSE);
             roleRepresentation.setId(entity.getName());
             roleRepresentation.setComposite(false);
@@ -148,7 +148,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
         checkNotNull("identifiers",
                      identifiers);
         consumeRealm(realmResource -> {
-            final RolesResource rolesResource = realmResource.roles();
+            final RolesResource rolesResource = getRolesResource(realmResource, getKeyCloakInstance().getUseRoleResourceMappings());
             for (String identifier : identifiers) {
                 final RoleResource roleResource = rolesResource.get(identifier);
                 if (roleResource == null) {
@@ -178,7 +178,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
         if (users != null) {
             consumeRealm(realmResource -> {
                 final UsersResource usersResource = realmResource.users();
-                final RolesResource rolesResource = realmResource.roles();
+                final RolesResource rolesResource = getRolesResource(realmResource, true);
                 final RoleResource roleResource = rolesResource.get(name);
                 final List<RoleRepresentation> rolesToAdd = new ArrayList<RoleRepresentation>(1);
                 rolesToAdd.add(getRoleRepresentation(name,
@@ -189,7 +189,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
                     if (userResource == null) {
                         throw new UserNotFoundException(username);
                     }
-                    userResource.roles().realmLevel().add(rolesToAdd);
+                    getRolesScopeResource(userResource.roles(), getKeyCloakInstance().getUseRoleResourceMappings()).add(rolesToAdd);
                 }
             });
         }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakUserManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakUserManager.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,6 +44,7 @@ import org.uberfire.ext.security.management.impl.SearchResponseImpl;
 import org.uberfire.ext.security.management.impl.UserManagerSettingsImpl;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleMappingResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleResource;
+import org.uberfire.ext.security.management.keycloak.client.resource.RoleScopeResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RolesResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.UserResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.UsersResource;
@@ -53,6 +54,7 @@ import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull
 
 /**
  * <p>UsersManager Service Provider Implementation for KeyCloak.</p>
+ *
  * @since 0.8.0
  */
 public class KeyCloakUserManager extends BaseKeyCloakManager implements UserManager,
@@ -252,9 +254,7 @@ public class KeyCloakUserManager extends BaseKeyCloakManager implements UserMana
             if (userResource == null) {
                 throw new UserNotFoundException(username);
             }
-            final RolesResource rolesResource = realmResource.roles();
-            final List<RoleRepresentation> roleRepresentations = userResource.roles().realmLevel().listEffective();
-            userResource.roles().realmLevel().remove(roleRepresentations);
+            final RolesResource rolesResource = getRolesResource(realmResource, getKeyCloakInstance().getUseRoleResourceMappings());
             if (idsToAssign != null && !idsToAssign.isEmpty()) {
                 // Add the given assignments.
                 final List<RoleRepresentation> rolesToAdd = new ArrayList<RoleRepresentation>();
@@ -265,7 +265,11 @@ public class KeyCloakUserManager extends BaseKeyCloakManager implements UserMana
                                                              roleResource));
                     }
                 }
-                userResource.roles().realmLevel().add(rolesToAdd);
+
+                RoleScopeResource roleScopeResource = getRolesScopeResource(userResource.roles(), getKeyCloakInstance().getUseRoleResourceMappings());
+                final List<RoleRepresentation> roleRepresentations = roleScopeResource.listEffective();
+                roleScopeResource.remove(roleRepresentations);
+                roleScopeResource.add(rolesToAdd);
             }
         });
     }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/Keycloak.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/Keycloak.java
@@ -28,28 +28,34 @@ import org.uberfire.ext.security.management.keycloak.client.resource.RealmsResou
 
 /**
  * The Keycloak client.
+ *
  * @since 0.9.0
  */
 public class Keycloak {
 
     private final String serverUrl;
     private final String realm;
+    private final Boolean useRoleResourceMappings;
     private final ClientRequestFactory clientRequestFactory;
 
     Keycloak(String serverUrl,
              String realm,
+             Boolean useRoleResourceMappings,
              TokenManager tokenManager) {
         this.serverUrl = serverUrl;
         this.realm = realm;
+        this.useRoleResourceMappings = useRoleResourceMappings;
         this.clientRequestFactory = new ClientRequestFactory(UriBuilder.fromUri(serverUrl).build());
         ResteasyProviderFactory.getInstance().getClientExecutionInterceptorRegistry().register(new BearerAuthenticationInterceptor(tokenManager));
     }
 
     public static Keycloak getInstance(String serverUrl,
                                        String realm,
+                                       Boolean useRoleResourceMappings,
                                        TokenManager tokenManager) {
         return new Keycloak(serverUrl,
                             realm,
+                            useRoleResourceMappings,
                             tokenManager);
     }
 
@@ -63,6 +69,10 @@ public class Keycloak {
 
     public String getRealm() {
         return realm;
+    }
+
+    public Boolean getUseRoleResourceMappings() {
+        return useRoleResourceMappings;
     }
 
     public void close() {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/resource/ClientResource.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/resource/ClientResource.java
@@ -1,12 +1,11 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,18 +18,8 @@ package org.uberfire.ext.security.management.keycloak.client.resource;
 
 import javax.ws.rs.Path;
 
-/**
- * @since 0.9.0
- */
-public interface RealmResource {
-
-    @Path("users")
-    UsersResource users();
+public interface ClientResource {
 
     @Path("roles")
     RolesResource roles();
-
-    @Path("clients")
-    ClientsResource clients();
-
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/resource/ClientsResource.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/resource/ClientsResource.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.keycloak.client.resource;
+
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import org.keycloak.representations.idm.ClientRepresentation;
+/**
+ * @since 0.9.0
+ */
+public interface ClientsResource {
+
+    @Path("{id}")
+    public ClientResource get(@PathParam("id") String id);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<ClientRepresentation> findByClientId(@QueryParam(value="clientId") String clientId);
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/BaseKeyCloakTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/BaseKeyCloakTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.ext.security.management.BaseTest;
 import org.uberfire.ext.security.management.keycloak.client.Keycloak;
+import org.uberfire.ext.security.management.keycloak.client.resource.ClientsResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RealmResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RolesResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.UsersResource;
@@ -49,10 +50,14 @@ public abstract class BaseKeyCloakTest extends BaseTest {
     @Mock
     protected RolesResource rolesResource;
 
+    @Mock
+    protected ClientsResource clientsResource;
+
     @Before
     public void setup() throws Exception {
         when(realmResource.users()).thenReturn(usersResource);
         when(realmResource.roles()).thenReturn(rolesResource);
+        when(realmResource.clients()).thenReturn(clientsResource);
         when(keycloakMock.realm()).thenReturn(realmResource);
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/DefaultKeyCloakTest.java
@@ -28,12 +28,15 @@ import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.client.ClientResponseFailure;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.kie.soup.commons.util.Lists;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.uberfire.backend.server.security.RoleRegistry;
+import org.uberfire.ext.security.management.keycloak.client.resource.ClientResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleMappingResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleScopeResource;
@@ -85,6 +88,15 @@ public abstract class DefaultKeyCloakTest extends BaseKeyCloakTest {
             }
         });
         when(rolesResource.list()).thenReturn(roleRepresentations);
+
+        ClientResource clientResource = mock(ClientResource.class);
+        when(clientResource.roles()).thenReturn(rolesResource);
+        when(clientsResource.get(anyString())).thenReturn(clientResource);
+
+        ClientRepresentation clientRepresentation = mock(ClientRepresentation.class);
+        when(clientRepresentation.getId()).thenReturn("clientId");
+        when(clientsResource.findByClientId(any())).thenReturn(new Lists.Builder<ClientRepresentation>().add(clientRepresentation).build());
+        when(realmResource.clients()).thenReturn(clientsResource);
 
         // Users.
         for (int x = 0; x < usersCount; x++) {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManagerTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import org.jboss.errai.security.shared.api.Group;
-import org.jboss.errai.security.shared.api.identity.User;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +37,7 @@ import org.uberfire.ext.security.management.keycloak.client.resource.RealmResour
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleMappingResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.RoleScopeResource;
+import org.uberfire.ext.security.management.keycloak.client.resource.RolesResource;
 import org.uberfire.ext.security.management.keycloak.client.resource.UserResource;
 import org.uberfire.ext.security.management.util.SecurityManagementUtils;
 
@@ -52,6 +51,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KeyCloakGroupManagerTest extends DefaultKeyCloakTest {
@@ -102,7 +102,6 @@ public class KeyCloakGroupManagerTest extends DefaultKeyCloakTest {
         assertGroup(group,
                     name);
     }
-
     @Test(expected = GroupNotFoundException.class)
     public void testGetGroup200() {
         String name = ROLE + 200;
@@ -229,6 +228,27 @@ public class KeyCloakGroupManagerTest extends DefaultKeyCloakTest {
         List rolesAdded = rolesCaptor.getValue();
         assertEquals(1,
                      rolesAdded.size());
+    }
+
+    @Test
+    public void testGetClientById() {
+        String clientId = groupsManager.getClientIdByName(realmResource);
+        assertEquals("clientId", clientId);
+    }
+
+    @Test
+    public void testGetRoleResource() {
+        RolesResource rolesResource = groupsManager.getRolesResource(realmResource, true);
+        assertEquals(52, rolesResource.list().size());
+    }
+
+    @Test
+    public void testGetClientRoles() {
+        String name = ROLE + 5;
+        when(groupsManager.getRolesResource(realmResource, true)).thenReturn(rolesResource);
+        Group group = groupsManager.get(name);
+        assertGroup(group,
+                    name);
     }
 
     private void assertGroup(Group group,

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakUserManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/KeyCloakUserManagerTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -135,10 +135,11 @@ public class KeyCloakUserManagerTest extends DefaultKeyCloakTest {
         User user = usersManager.get(username);
         assertNull(user);
     }
+
     @Test
-    public void testGetAllUsers(){
+    public void testGetAllUsers() {
         List<User> users = usersManager.getAll();
-        Assert.assertEquals(usersCount,users.size());
+        Assert.assertEquals(usersCount, users.size());
     }
 
     @Test(expected = RuntimeException.class)


### PR DESCRIPTION
**Thank you for submitting this pull request**

**BAPL-1735**: _https://issues.redhat.com/browse/BAPL-1735_ 

- Added a new system property **-Dorg.uberfire.ext.security.management.keycloak.use-resource-role-mapping=true** that allows the client roles in RHSSO to be fetched and used inside business central.
- All the operations like add,remove,assign user etc will be supported in business central for these client roles.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
