### PR TITLE
AF-2757: Kie Server DataSet lookup fails in multi mode with dataset partition

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProvider.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-kie-server-backend/src/main/java/org/dashbuilder/kieserver/backend/RuntimeKieServerDataSetProvider.java
@@ -216,10 +216,11 @@ public class RuntimeKieServerDataSetProvider implements DataSetProvider {
                                       ConsoleDataSetLookup lookup,
                                       QueryFilterSpec filterSpec) {
         KieServerConnectionInfo connectionInfo = connectionInfoProvider.verifiedConnectionInfo(def);
+        String queryName = def.getQueryName() != null ? def.getQueryName() : def.getUUID(); 
         int pageNumber = lookup.getRowOffset() / lookup.getNumberOfRows();
         if (lookup.testMode() || connectionInfo.isReplaceQuery()) {
             QueryDefinition queryDefinition = QueryDefinition.builder()
-                                                             .name(lookup.getDataSetUUID())
+                                                             .name(queryName)
                                                              .source(def.getDataSource())
                                                              .target(def.getQueryTarget())
                                                              .expression(def.getDbSQL())
@@ -231,21 +232,21 @@ public class RuntimeKieServerDataSetProvider implements DataSetProvider {
 
             try {
                 return queryClient.query(connectionInfo,
-                                         lookup.getDataSetUUID(),
+                                         queryName,
                                          filterSpec,
                                          pageNumber,
                                          lookup.getNumberOfRows());
             } catch (Exception e) {
-                queryClient.unregisterQuery(connectionInfo, lookup.getDataSetUUID());
+                queryClient.unregisterQuery(connectionInfo, queryName);
                 throw new RuntimeException(e);
             }
         } else {
             if (def.getColumns() != null && def.getColumns().isEmpty()) {
-                QueryDefinition query = queryClient.getQuery(connectionInfo, def.getUUID());
+                QueryDefinition query = queryClient.getQuery(connectionInfo, queryName);
                 addColumnsToDefinition(def, query);
             }
             return queryClient.query(connectionInfo,
-                                     lookup.getDataSetUUID(),
+                                     queryName,
                                      filterSpec,
                                      pageNumber,
                                      lookup.getNumberOfRows());

--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -818,7 +818,7 @@
           <runTarget>dashbuilder.html</runTarget>
           <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000
             -Derrai.jboss.home=${errai.jboss.home}
-		  -Ddashbuilder.runtime.multi=true -Ddashbuilder.components.enable=true -Ddashbuilder.removeModelFile=true</extraJvmArgs>
+		  -Ddashbuilder.runtime.multi=true -Ddashbuilder.components.enable=true -Ddashbuilder.removeModelFile=true -Ddashbuilder.kieserver.serverTemplate.sample-server.location=http://localhost:8080/kie-server/services/rest/server -Ddashbuilder.kieserver.serverTemplate.sample-server.user=kieserver -Ddashbuilder.kieserver.serverTemplate.sample-server.password=kieserver1! -Ddashbuilder.kieserver.defaultServerTemplate=default</extraJvmArgs>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
           <hostedWebapp>src/main/webapp</hostedWebapp>

--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -818,7 +818,7 @@
           <runTarget>dashbuilder.html</runTarget>
           <extraJvmArgs>-Xmx4024m -XX:CompileThreshold=7000
             -Derrai.jboss.home=${errai.jboss.home}
-		  -Ddashbuilder.runtime.multi=true -Ddashbuilder.components.enable=true -Ddashbuilder.removeModelFile=true -Ddashbuilder.kieserver.serverTemplate.sample-server.location=http://localhost:8080/kie-server/services/rest/server -Ddashbuilder.kieserver.serverTemplate.sample-server.user=kieserver -Ddashbuilder.kieserver.serverTemplate.sample-server.password=kieserver1! -Ddashbuilder.kieserver.defaultServerTemplate=default</extraJvmArgs>
+		  -Ddashbuilder.runtime.multi=true -Ddashbuilder.components.enable=true -Ddashbuilder.removeModelFile=true -Ddashbuilder.kieserver.serverTemplate.sample-server.location=http://localhost:8080/kie-server/services/rest/server -Ddashbuilder.kieserver.serverTemplate.sample-server.user=kieserver -Ddashbuilder.kieserver.serverTemplate.sample-server.password=kieserver1! -Ddashbuilder.kieserver.defaultServerTemplate=default -Ddashbuilder.kieserver.serverTemplate.sample-server.replace_query=true</extraJvmArgs>
           <noServer>false</noServer>
           <server>org.jboss.errai.cdi.server.gwt.EmbeddedWildFlyLauncher</server>
           <hostedWebapp>src/main/webapp</hostedWebapp>

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/DataSetContentListener.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/DataSetContentListener.java
@@ -26,11 +26,13 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import org.dashbuilder.backend.helper.PartitionHelper;
 import org.dashbuilder.backend.services.dataset.RuntimeCSVFileStorage;
 import org.dashbuilder.backend.services.dataset.provider.RuntimeDataSetProviderRegistry;
 import org.dashbuilder.dataset.def.DataSetDef;
 import org.dashbuilder.dataset.def.DataSetDefRegistry;
 import org.dashbuilder.dataset.json.DataSetDefJSONMarshaller;
+import org.dashbuilder.kieserver.RemoteDataSetDef;
 import org.dashbuilder.shared.event.NewDataSetContentEvent;
 import org.dashbuilder.shared.event.RemovedRuntimeModelEvent;
 import org.dashbuilder.shared.model.DataSetContent;
@@ -112,6 +114,11 @@ public class DataSetContentListener {
         try {
             DataSetDef dataSetDef = defMarshaller.fromJson(content.getContent());
             dataSetDef.setUUID(content.getId());
+            if (dataSetDef instanceof RemoteDataSetDef) {
+                String queryName = PartitionHelper.removePartition(dataSetDef.getUUID());
+                ((RemoteDataSetDef) dataSetDef).setQueryName(queryName);
+            }
+            
             registry.registerDataSetDef(dataSetDef);
         } catch (Exception e) {
             logger.warn("Ignoring Dataset {}: error parsing Json", content.getId());

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/helper/PartitionHelper.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/helper/PartitionHelper.java
@@ -16,13 +16,17 @@
 package org.dashbuilder.backend.helper;
 
 public class PartitionHelper {
-    
+
     private static final String PARTITION_SEPARATOR = "|";
+
+    private PartitionHelper() {
+        // empty
+    }
 
     public static String partition(String modelId, String id) {
         return id + PARTITION_SEPARATOR + " RuntimeModel=" + modelId;
     }
-    
+
     public static String removePartition(String id) {
         if (id != null) {
             int sepatorIndex = id.indexOf(PARTITION_SEPARATOR);

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/helper/PartitionHelper.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/helper/PartitionHelper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.backend.helper;
+
+public class PartitionHelper {
+    
+    private static final String PARTITION_SEPARATOR = "|";
+
+    public static String partition(String modelId, String id) {
+        return id + PARTITION_SEPARATOR + " RuntimeModel=" + modelId;
+    }
+    
+    public static String removePartition(String id) {
+        if (id != null) {
+            int sepatorIndex = id.indexOf(PARTITION_SEPARATOR);
+            if (sepatorIndex > -1) {
+                return id.substring(0, sepatorIndex);
+            }
+        }
+        return id;
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
@@ -151,7 +151,7 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
         if (externalComponentsDir != null) {
             externalComponentsDir = externalComponentsDir.endsWith(File.separator) ? externalComponentsDir : externalComponentsDir + File.separator;
             String newFileName = null;
-            if (options.isComponentPartition()) {
+            if (options.isComponentPartition() && options.isMultipleImport()) {
                 newFileName = externalComponentsDir + modelId + File.separator + name.replaceAll(COMPONENTS_EXPORT_PATH, "");
             } else {
                 newFileName = externalComponentsDir + name.replaceAll(COMPONENTS_EXPORT_PATH, "");

--- a/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
+++ b/dashbuilder/dashbuilder-runtime/src/main/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImpl.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.dashbuilder.backend.RuntimeOptions;
+import org.dashbuilder.backend.helper.PartitionHelper;
 import org.dashbuilder.backend.navigation.RuntimeNavigationBuilder;
 import org.dashbuilder.dataset.DataSetLookup;
 import org.dashbuilder.displayer.DisplayerSettings;
@@ -132,7 +133,7 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
 
         if (options.isMultipleImport()) {
             if (options.isDatasetPartition()) {
-                datasetContents.forEach(ds -> ds.setId(transformId(modelId, ds.getId())));
+                datasetContents.forEach(ds -> ds.setId(PartitionHelper.partition(modelId, ds.getId())));
             }
             layoutTemplates.forEach(lt -> partitionLayoutTemplate(modelId, lt));
         }
@@ -143,10 +144,6 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
         NavTree navTree = runtimeNavigationBuilder.build(navTreeOp, layoutTemplates);
 
         return new RuntimeModel(navTree, layoutTemplates, System.currentTimeMillis());
-    }
-
-    String transformId(String modelId, String id) {
-        return id + "| RuntimeModel=" + modelId;
     }
 
     void extractComponentFile(String modelId, InputStream zis, String name) throws IOException {
@@ -201,7 +198,6 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
 
     private void partitionLayoutTemplate(String modelId, LayoutTemplate lt) {
@@ -226,13 +222,13 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
         if (options.isDatasetPartition() &&
             settings.getDataSetLookup() != null) {
             DataSetLookup dataSetLookup = settings.getDataSetLookup();
-            String newId = transformId(modelId, dataSetLookup.getDataSetUUID());
+            String newId = PartitionHelper.partition(modelId, dataSetLookup.getDataSetUUID());
             settings.getDataSetLookup().setDataSetUUID(newId);
         }
 
         if (options.isComponentPartition() &&
             settings.getType() == DisplayerType.EXTERNAL_COMPONENT &&
-                    isExternalComponent(componentId)) {
+            isExternalComponent(componentId)) {
             settings.setComponentPartition(modelId);
         }
 
@@ -249,5 +245,5 @@ public class RuntimeModelParserImpl implements RuntimeModelParser {
     private boolean isExternalComponent(String componentId) {
         return externalComponentLoader.loadProvided().stream().noneMatch(c -> c.getId().equals(componentId));
     }
-
+    
 }

--- a/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/helper/PartitionHelperTest.java
+++ b/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/helper/PartitionHelperTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dashbuilder.backend.helper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PartitionHelperTest {
+    
+    @Test
+    public void testPartition() {
+        String id = PartitionHelper.partition("model", "abc");
+        assertEquals("abc| RuntimeModel=model", id);
+    }
+    
+    @Test
+    public void testRemovePartition() {
+        String id = PartitionHelper.removePartition("abc| RuntimeModel=model");
+        assertEquals("abc", id);
+    }
+    
+    @Test
+    public void testRemovePartitionWithoutSeparator() {
+        String idWithoutSeparator = "abc";
+        String id = PartitionHelper.removePartition(idWithoutSeparator);
+        assertEquals(idWithoutSeparator, id);
+    }
+
+}

--- a/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImplTest.java
+++ b/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImplTest.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.enterprise.event.Event;
 
 import org.dashbuilder.backend.RuntimeOptions;
+import org.dashbuilder.backend.helper.PartitionHelper;
 import org.dashbuilder.backend.navigation.RuntimeNavigationBuilder;
 import org.dashbuilder.displayer.json.DisplayerSettingsJSONMarshaller;
 import org.dashbuilder.external.service.ComponentLoader;
@@ -133,7 +134,7 @@ public class RuntimeModelParserImplTest {
         when(runtimeOptions.isMultipleImport()).thenReturn(true);
         when(runtimeOptions.isDatasetPartition()).thenReturn(true);
         final String runtimeModelId = "123";
-        final String transformedId = parser.transformId(runtimeModelId, "e26a81a1-5636-493c-96e0-51bc32322b17");
+        final String transformedId = PartitionHelper.partition(runtimeModelId, "e26a81a1-5636-493c-96e0-51bc32322b17");
         
         parser.init();
         InputStream validImport = this.getClass().getResourceAsStream("/valid_import.zip");

--- a/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImplTest.java
+++ b/dashbuilder/dashbuilder-runtime/src/test/java/org/dashbuilder/backend/services/impl/RuntimeModelParserImplTest.java
@@ -183,6 +183,7 @@ public class RuntimeModelParserImplTest {
         
         when(externalComponentLoader.getExternalComponentsDir()).thenReturn(componentPath.toString());
         when(runtimeOptions.isComponentPartition()).thenReturn(true);
+        when(runtimeOptions.isMultipleImport()).thenReturn(true);
         
         String modelId = "testModel";
         String componentFileContent1 = "This is a component file.";

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDataSetDef.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RemoteDataSetDef.java
@@ -33,6 +33,8 @@ public class RemoteDataSetDef extends SQLDataSetDef {
     @NotNull(groups = {RemoteDataSetDefValidation.class})
     @Size(min = 1, groups = {RemoteDataSetDefValidation.class})
     protected String serverTemplateId;
+    
+    protected String queryName;
 
     public RemoteDataSetDef() {
         super.setProvider(new RuntimeKieServerDataSetProviderType());
@@ -53,6 +55,14 @@ public class RemoteDataSetDef extends SQLDataSetDef {
     public void setServerTemplateId(String serverTemplateId) {
         this.serverTemplateId = serverTemplateId;
     }
+    
+    public String getQueryName() {
+        return queryName;
+    }
+    
+    public void setQueryName(String queryName) {
+        this.queryName = queryName;
+    }
 
     @Override
     public int hashCode() {
@@ -60,6 +70,7 @@ public class RemoteDataSetDef extends SQLDataSetDef {
         int result = 1;
         result = prime * result + ((queryTarget == null) ? 0 : queryTarget.hashCode());
         result = prime * result + ((serverTemplateId == null) ? 0 : serverTemplateId.hashCode());
+        result = prime * result + ((queryName == null) ? 0 : queryName.hashCode());
         return result;
     }
 
@@ -82,6 +93,11 @@ public class RemoteDataSetDef extends SQLDataSetDef {
                 return false;
         } else if (!serverTemplateId.equals(other.serverTemplateId))
             return false;
+        if (queryName == null) {
+            if (other.queryName != null)
+                return false;
+        } else if (!queryName.equals(other.queryName))
+            return false;
         return true;
     }
 
@@ -93,6 +109,7 @@ public class RemoteDataSetDef extends SQLDataSetDef {
         def.setServerTemplateId(getServerTemplateId());
         def.setDbSQL(getDbSQL());
         def.setDataSource(getDataSource());
+        def.setQueryName(getQueryName());
         return def;
     }
 
@@ -109,6 +126,7 @@ public class RemoteDataSetDef extends SQLDataSetDef {
         }
         out.append("Data source=").append(dataSource).append("\n");
         out.append("Query target=").append(queryTarget).append("\n");
+        out.append("Query id=").append(queryName).append("\n");
         out.append("Server template id=").append(serverTemplateId).append("\n");
         out.append("DB SQL=").append(dbSQL).append("\n");
         out.append("Get all columns=").append(allColumnsEnabled).append("\n");

--- a/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RuntimeKieServerDataSetProviderType.java
+++ b/dashbuilder/dashbuilder-shared/dashbuilder-kie-server-api/src/main/java/org/dashbuilder/kieserver/RuntimeKieServerDataSetProviderType.java
@@ -23,13 +23,15 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 @Portable
 public class RuntimeKieServerDataSetProviderType implements DataSetProviderType<RemoteDataSetDef> {
 
+    public static final String NAME = "REMOTE";
+
     public RuntimeKieServerDataSetProviderType() {
 
     }
 
     @Override
     public String getName() {
-        return "REMOTE";
+        return NAME;
     }
 
     @Override


### PR DESCRIPTION
JIRA:

https://issues.redhat.com/browse/AF-2757

If you have a dataset with ID X, create on Kie Server Y, then when importing in Dashbuilder with dataset partition the  ID X will become "X| RuntimeModel=runtimeModel". The problem is that on Kie Server Y the query for X was created with name "X" (it uses the dataset UUID), so an error will be throws.

This PR fixes this issue by creating a new field in the dataset definition to set the correct query name after the partition.