### PR TITLE
KOGITO-3846: Added Notifications API to Editors

### DIFF
--- a/appformer-kogito-bridge/pom.xml
+++ b/appformer-kogito-bridge/pom.xml
@@ -60,6 +60,11 @@
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-user</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Test dependencies -->
 

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NoOpNotificationsService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NoOpNotificationsService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.appformer.kogito.bridge.client.notifications;
+
+import java.util.List;
+
+import org.uberfire.workbench.model.bridge.Notification;
+
+public class NoOpNotificationsService implements NotificationsApi {
+
+    @Override
+    public void createNotification(Notification notification) {
+
+    }
+
+    @Override
+    public void setNotifications(String path, List<Notification> notification) {
+
+    }
+
+    @Override
+    public void removeNotifications(String path) {
+
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsApi.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsApi.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.appformer.kogito.bridge.client.notifications;
+
+import java.util.List;
+
+import org.uberfire.workbench.model.bridge.Notification;
+import org.uberfire.workbench.model.bridge.NotificationSeverity;
+import org.uberfire.workbench.model.bridge.NotificationType;
+
+/**
+ * This is the API that will let communicate with Notifications channel implementation. There are two types of Notifications:
+ * Alerts ({@link NotificationType#ALERT}) and Problems ({@link NotificationType#ALERT}). The main difference between
+ * Alerts and Problems is the lifespan. Alerts are ephemeral (like a "Compilation Success" notifications) and Problems
+ * are information we need to keep, so we can take actions based on them.
+ * Problems supports severities {@link NotificationSeverity#INFO} {@link NotificationSeverity#ERROR}
+ * {@link NotificationSeverity#HINT} {@link NotificationSeverity#WARNING}. Any other severity will be treated as INFO.
+ * Alerts supports severities {@link NotificationSeverity#INFO} and {@link NotificationSeverity#ERROR}. Any other
+ * severity will be treated as INFO.
+ */
+public interface NotificationsApi {
+
+    /**
+     * Send a single notification to the channel. This will append a notification on the channel so the older ones are
+     * not going to be removed. For that consumer must manually delete the notifications on a path.
+     *
+     * @param notification The notification (Problem | Alert)
+     */
+    void createNotification(Notification notification);
+
+    /**
+     * Send a list of notifications to the channel. The diferrence with {@link NotificationsApi#createNotification(Notification)} is that all the
+     * notifications for that path are overwritten. So if there is a notification that you want to keep you will need
+     * to send it again in that list.
+     *
+     * @param path         All the notifications are going to by grouped by path
+     * @param notification The notification (Problem | Alert)
+     */
+    void setNotifications(String path, List<Notification> notification);
+
+    /**
+     * Removes all the notifications for given path.
+     *
+     * @param path The path of the notifications to be deleted
+     */
+    void removeNotifications(String path);
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsApiInteropWrapper.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsApiInteropWrapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.appformer.kogito.bridge.client.notifications;
+
+import java.util.List;
+
+import jsinterop.annotations.JsMethod;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+import org.uberfire.workbench.model.bridge.Notification;
+
+@JsType(isNative = true, namespace = "window", name = "envelope")
+public class NotificationsApiInteropWrapper implements NotificationsApi {
+
+    @JsMethod
+    public native void createNotification(Notification notification);
+
+    @JsMethod
+    public native void setNotifications(String path, List<Notification> notification);
+
+    @JsMethod
+    public native void removeNotifications(String path);
+
+    @JsProperty(name = "notificationsApi")
+    public native static NotificationsApiInteropWrapper get();
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsService.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.appformer.kogito.bridge.client.notifications;
+
+import java.util.List;
+
+import org.uberfire.workbench.model.bridge.Notification;
+
+public class NotificationsService implements NotificationsApi {
+
+    @Override
+    public void createNotification(Notification notification) {
+        NotificationsApiInteropWrapper.get().createNotification(notification);
+    }
+
+    @Override
+    public void setNotifications(String path, List<Notification> notifications) {
+        NotificationsApiInteropWrapper.get().setNotifications(path, notifications);
+    }
+
+    @Override
+    public void removeNotifications(String path) {
+        NotificationsApiInteropWrapper.get().removeNotifications(path);
+    }
+}

--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsServiceProducer.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsServiceProducer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.appformer.kogito.bridge.client.notifications;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import elemental2.dom.DomGlobal;
+import org.appformer.kogito.bridge.client.interop.WindowRef;
+
+public class NotificationsServiceProducer {
+
+    @Produces
+    @ApplicationScoped
+    public NotificationsApi produce() {
+        if (WindowRef.isEnvelopeAvailable()) {
+            return new NotificationsService();
+        } else {
+            DomGlobal.console.debug("[NotificationsServiceProducer] Envelope API is not available. Producing NoOpNotificationsService");
+            return new NoOpNotificationsService();
+        }
+    }
+}

--- a/appformer-kogito-bridge/src/main/resources/org/appformer/kogito/bridge/AppformerKogitoBridge.gwt.xml
+++ b/appformer-kogito-bridge/src/main/resources/org/appformer/kogito/bridge/AppformerKogitoBridge.gwt.xml
@@ -20,7 +20,7 @@
 <module>
 
   <inherits name="org.appformer.AppformerClientAPI"/>
-
+  <inherits name="org.uberfire.UberfireAPI"/>
   <source path='client'/>
 
 </module>

--- a/uberfire-api/src/main/java/org/uberfire/lifecycle/Validate.java
+++ b/uberfire-api/src/main/java/org/uberfire/lifecycle/Validate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.uberfire.lifecycle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface Validate {
+
+}

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/bridge/Notification.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/bridge/Notification.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.uberfire.workbench.model.bridge;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class Notification {
+
+    @JsProperty(name = "path")
+    public native void setPath(String path);
+
+    @JsProperty(name = "path")
+    public native String getPath();
+
+    @JsProperty(name = "message")
+    public native void setMessage(String message);
+
+    @JsProperty(name = "message")
+    public native String getMessage();
+
+    @JsProperty(name = "severity")
+    public native void setSeverity(String notificationSeverity);
+
+    @JsProperty(name = "severity")
+    public native String getSeverity();
+
+    @JsProperty(name = "type")
+    public native void setType(String type);
+
+    @JsProperty(name = "type")
+    public native String getType();
+}

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/bridge/NotificationSeverity.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/bridge/NotificationSeverity.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.uberfire.workbench.model.bridge;
+
+public class NotificationSeverity {
+
+    public static String INFO = "INFO";
+    public static String SUCCESS = "SUCCESS";
+    public static String ERROR = "ERROR";
+    public static String WARNING = "WARNING";
+    public static String HINT = "HINT";
+}

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/bridge/NotificationType.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/bridge/NotificationType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package org.uberfire.workbench.model.bridge;
+
+public class NotificationType {
+
+    public static String PROBLEM = "PROBLEM";
+    public static String ALERT = "ALERT";
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/WorkbenchClientEditorActivity.java
@@ -15,9 +15,12 @@
  */
 package org.uberfire.client.mvp;
 
+import java.util.List;
+
 import elemental2.promise.Promise;
 import org.uberfire.security.ResourceType;
 import org.uberfire.workbench.model.ActivityResourceType;
+import org.uberfire.workbench.model.bridge.Notification;
 
 /**
  * An Editor is an activity that is associated with a VFS path. It is expected that the editor will provide the end user
@@ -26,30 +29,28 @@ import org.uberfire.workbench.model.ActivityResourceType;
 public interface WorkbenchClientEditorActivity extends WorkbenchActivity {
 
     /**
-     *  
-     *  Set the editor content
-     *  
-     * @param path
-     *  Content Relative Path
-     * @param value
-     *  The editor content
+     * Set the editor content
+     *
+     * @param path  Content Relative Path
+     * @param value The editor content
      */
     Promise<Void> setContent(String path, String value);
 
     /**
      * Get the editor content
-     * 
+     *
      * @return
      */
     Promise<String> getContent();
-    
-    
+
     /**
      * Get the editor content preview in SVG format
-     * 
+     *
      * @return
      */
     Promise<String> getPreview();
+
+    Promise<List<Notification>> validate();
 
     boolean isDirty();
 

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/GWTEditorNativeRegister.java
@@ -64,6 +64,10 @@ public class GWTEditorNativeRegister {
             return this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::getWidgetElement()();
         };
 
+         $wnd.GWTEditor.prototype.validate = function () {
+            return this.instance.@org.uberfire.client.mvp.WorkbenchClientEditorActivity::validate()();
+        };
+
         $wnd.GWTEditorSuplier = function (bean) {
             this.bean = bean;
         };

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchClientEditorProcessorTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
 
     Result result = new Result();
-    
+
     @Override
     protected AbstractErrorAbsorbingProcessor getProcessorUnderTest() {
         return new WorkbenchClientEditorProcessor(code -> result.setActualCode(code));
@@ -47,7 +47,7 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation(diagnostics);
         assertNull(result.getActualCode());
     }
-    
+
     @Test
     public void testDoNotExtendWidgetOrProvideElement() throws FileNotFoundException {
         final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
@@ -61,7 +61,7 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
                                  "org.uberfire.annotations.processors.WorkbenchClientEditorTest2Activity: The WorkbenchClientEditor must either extend IsWidget or provide a @WorkbenchPartView annotated method to return a com.google.gwt.user.client.ui.IsWidget.");
         assertNull(result.getActualCode());
     }
-    
+
     @Test
     public void testMissingWorkbenchPartTitle() throws FileNotFoundException {
         final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
@@ -75,7 +75,7 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
                                  "org.uberfire.annotations.processors.WorkbenchClientEditorTest3Activity: The WorkbenchClientEditor must provide a @WorkbenchPartTitle annotated method to return a java.lang.String.");
         assertNull(result.getActualCode());
     }
-    
+
     @Test
     public void testMissingSetContent() throws FileNotFoundException {
         final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
@@ -89,7 +89,7 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
                                  "org.uberfire.annotations.processors.WorkbenchClientEditorTest4Activity: The WorkbenchClientEditor must provide a @SetContent annotated method that has two java.lang.String (path and content) as parameters.");
         assertNull(result.getActualCode());
     }
-    
+
     @Test
     public void testMissingGetContent() throws FileNotFoundException {
         final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
@@ -103,8 +103,7 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
                                  "org.uberfire.annotations.processors.WorkbenchClientEditorTest5Activity: The WorkbenchClientEditor must provide a @GetContent annotated method to return a elemental2.promise.Promise");
         assertNull(result.getActualCode());
     }
-    
-    
+
     @Test
     public void testSuccessContent() throws FileNotFoundException {
         final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
@@ -119,13 +118,28 @@ public class WorkbenchClientEditorProcessorTest extends AbstractProcessorTest {
         assertEquals(result.getExpectedCode(),
                      result.getActualCode());
     }
-    
+
     @Test
     public void testSuccessContentWithGetPreview() throws FileNotFoundException {
         final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
                 getProcessorUnderTest(),
                 "org/uberfire/annotations/processors/WorkbenchClientEditorTest7");
         final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected";
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
+
+    @Test
+    public void testSuccessContentWithValidate() throws FileNotFoundException {
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                "org/uberfire/annotations/processors/WorkbenchClientEditorTest8");
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest8.expected";
         result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
 
         assertSuccessfulCompilation(diagnostics);

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest8.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchClientEditorTest8.java
@@ -1,0 +1,36 @@
+package org.uberfire.annotations.processors;
+
+import org.uberfire.client.annotations.WorkbenchClientEditor;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.lifecycle.GetContent;
+import org.uberfire.lifecycle.SetContent;
+import org.uberfire.lifecycle.GetPreview;
+
+import com.google.gwt.user.client.ui.Widget;
+
+import elemental2.promise.Promise;
+import org.uberfire.lifecycle.Validate;
+
+@WorkbenchClientEditor(identifier = "editor")
+public class WorkbenchClientEditorTest8 extends Widget {
+
+    @WorkbenchPartTitle
+    public String title() {
+        return "title";
+    }
+
+    @SetContent
+    public Promise setContent(String path, String content) {
+        return null;
+    }
+
+    @GetContent
+    public Promise getContent() {
+        return null;
+    }
+
+    @Validate
+    public Promise validate() {
+        return null;
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
@@ -74,6 +74,12 @@ public class WorkbenchClientEditorTest6Activity extends AbstractWorkbenchClientE
     public Promise<String> getPreview() {
         return null;
     }
+
+    @Override
+    public Promise validate() {
+        return null;
+    }
+
     @Override
     public String getIdentifier() {
         return "editor";

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest8.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest8.expected
@@ -41,14 +41,14 @@ import com.google.gwt.user.client.ui.IsWidget;
 /*
  * WARNING! This class is generated. Do not modify.
  */
-public class WorkbenchClientEditorTest7Activity extends AbstractWorkbenchClientEditorActivity {
+public class WorkbenchClientEditorTest8Activity extends AbstractWorkbenchClientEditorActivity {
 
     @Inject
-    private WorkbenchClientEditorTest7 realPresenter;
+    private WorkbenchClientEditorTest8 realPresenter;
 
     @Inject
     //Constructor injection for testing
-    public WorkbenchClientEditorTest7Activity(final PlaceManager placeManager) {
+    public WorkbenchClientEditorTest8Activity(final PlaceManager placeManager) {
         super( placeManager );
     }
 
@@ -72,12 +72,12 @@ public class WorkbenchClientEditorTest7Activity extends AbstractWorkbenchClientE
     }
     @Override
     public Promise<String> getPreview() {
-        return realPresenter.getPreview();
+        return null;
     }
 
     @Override
     public Promise validate() {
-        return null;
+        return realPresenter.validate();
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ClientEditorActivityGenerator.java
@@ -143,6 +143,11 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
                                                                                           processingEnvironment);
         final String getPreviewMethodName = getPreviewMethod == null ? null : getPreviewMethod.getSimpleName().toString();
 
+        final ExecutableElement validateMethod = GeneratorUtils.getValidateMethodName(classElement,
+                                                                                       processingEnvironment);
+
+        final String validateMethodName = validateMethod == null ? null : validateMethod.getSimpleName().toString();
+
         final List<String> qualifiers = GeneratorUtils.getAllQualifiersDeclarationFromType(classElement);
 
         if (GeneratorUtils.debugLoggingEnabled()) {
@@ -192,6 +197,8 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
                                   "getPreviewMethodName: " + getPreviewMethodName);
             messager.printMessage(Kind.NOTE,
                                   "isDirtyMethodName: " + isDirtyMethodName);
+            messager.printMessage(Kind.NOTE,
+                                  "validateMethodName: " + validateMethodName);
             messager.printMessage(Kind.NOTE,
                                   "Qualifiers: " + String.join(", ",
                                                                qualifiers));
@@ -280,6 +287,8 @@ public class ClientEditorActivityGenerator extends AbstractGenerator {
                  getPreviewMethodName);
         root.put("isDynamic",
                  isDynamic);
+        root.put("validateMethodName",
+                 validateMethodName);
         root.put("qualifiers",
                  qualifiers);
 

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
@@ -1458,4 +1458,14 @@ public class GeneratorUtils {
 
         return qualifiers;
     }
+
+    public static ExecutableElement getValidateMethodName(TypeElement classElement, ProcessingEnvironment processingEnvironment) {
+        return getUniqueAnnotatedMethod(classElement,
+                                        processingEnvironment,
+                                        APIModule.getValidateClass(),
+                                        new TypeMirror[]{
+                                                processingEnvironment.getElementUtils().getTypeElement("elemental2.promise.Promise").asType()
+                                        },
+                                        NO_PARAMS);
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/facades/APIModule.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/facades/APIModule.java
@@ -40,8 +40,10 @@ public class APIModule {
     public static final String onStartup = "org.uberfire.lifecycle.OnStartup";
     public static final String onContextAttach = "org.uberfire.lifecycle.OnContextAttach";
     public static final String activatedBy = "org.jboss.errai.ioc.client.api.ActivatedBy";
+    public static final String validate = "org.uberfire.lifecycle.Validate";
 
-    private APIModule() {}
+    private APIModule() {
+    }
 
     public static String getPanelDefinitionClass() {
         return panelDefinition;
@@ -105,5 +107,9 @@ public class APIModule {
 
     public static String getOnSaveClass() {
         return onSave;
+    }
+
+    public static String getValidateClass() {
+        return validate;
     }
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
@@ -211,6 +211,16 @@ public class ${className} extends AbstractWorkbenchClientEditorActivity {
         return null;
         </#if>
     }
+
+    @Override
+    public Promise validate() {
+        <#if validateMethodName??>
+        return realPresenter.${validateMethodName}();
+        <#else>
+        return null;
+        </#if>
+    }
+
     <#if getContextIdMethodName??>
     @Override
     public String contextId() {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

https://issues.redhat.com/browse/KOGITO-3846

**referenced Pull Requests**: 

* https://github.com/kiegroup/appformer/pull/1092
* https://github.com/kiegroup/kie-wb-common/pull/3538
* https://github.com/kiegroup/kogito-tooling/pull/374

**Details:**

This PR adds the Notification API that let GWT send notifications to Channels. There are two main notifications: Alerts and Problems. 
* Alerts: ephemeral notification, i.e: Popup. If the notification contains a non empty path it will display a button to open that path. Alerts severity can be INFO, ERROR or WARNING.
* Problems: Notifications that needs to be informed to the users an keep persisted until the problem is fixed. i.e: Problems tab in VSCode. Problems severity can be INFO, ERROR, WARNING, HINT. The path is non empty it will open that location.

To use this notifications api users will need to inject `NotificationsApi class`.
There are 3 main methods:
* `send`: Send a single Alerts/Problem. For problems that notification will not disappear unless user removes it.
* `set` Send a list of Alerts/Problems. For problems, that list will replace the previous list, and for problems all the notification will be join in a single message.
* `remove`: Removes all the problems that belongs to a path. Alerts is not implemented since they are ephimeral.


@yesamer @romartin @karreiro 
