### PR TITLE
AF-2781: "project.repositories" upload function doens't work

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUpload.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUpload.java
@@ -30,8 +30,10 @@ public class DefaultEditorFileUpload
 
     private static final String DEFAULT_EDITOR = "defaulteditor/download?path=";
     private static final String PATH_PARAMETER = "path";
+    private static final String UPDATE_PARAMETER = "update";
 
     private Path path;
+    private Boolean isUpdate = false;
 
     @Override
     protected Map<String, String> getParameters() {
@@ -39,12 +41,18 @@ public class DefaultEditorFileUpload
 
         parameters.put(PATH_PARAMETER,
                        URIUtil.encodeQueryString(URIUtil.decode(path.toURI())));
+        parameters.put(UPDATE_PARAMETER,
+                       isUpdate.toString());
 
         return parameters;
     }
 
     public void setPath(Path path) {
         this.path = path;
+    }
+    
+    public void setIsUpdate(boolean isUpdate) {
+        this.isUpdate = isUpdate;
     }
 
     public void download() {

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultFileEditorPresenter.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultFileEditorPresenter.java
@@ -46,6 +46,7 @@ public class DefaultFileEditorPresenter {
     public void onStartup(final ObservablePath path) {
         this.path = path;
         view.setPath(path);
+        view.setIsUpdate(true);
     }
 
     @OnClose
@@ -66,5 +67,7 @@ public class DefaultFileEditorPresenter {
     interface View {
 
         void setPath(Path path);
+        
+        void setIsUpdate(boolean isUpdate);
     }
 }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultFileEditorView.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultFileEditorView.java
@@ -47,7 +47,12 @@ public class DefaultFileEditorView
     public void setPath(Path path) {
         fileUpload.setPath(path);
     }
-
+    
+    @Override
+    public void setIsUpdate(boolean isUpdate) {
+        fileUpload.setIsUpdate(isUpdate);
+    }
+    
     @UiHandler("downloadButton")
     public void handleClick(ClickEvent event) {
         fileUpload.download();

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadParametersTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/test/java/org/uberfire/ext/widgets/core/client/editors/defaulteditor/DefaultEditorFileUploadParametersTest.java
@@ -44,10 +44,12 @@ public class DefaultEditorFileUploadParametersTest {
     @Test
     public void testPathParameterIsEncoded() {
         upload.setPath(new PathFactory.PathImpl("foo.txt", "default://foo & bar.txt"));
+        upload.setIsUpdate(true);
 
         final Map<String, String> parameters = upload.getParameters();
 
-        assertEquals(1, parameters.size());
+        assertEquals(2, parameters.size());
         assertEquals("default%3A%2F%2Ffoo+%26+bar.txt", parameters.get("path"));
+        assertEquals("true", parameters.get("update"));
     }
 }

--- a/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
@@ -32,6 +32,7 @@ import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.Path;
 
 import static org.uberfire.server.UploadUriProvider.getTargetLocation;
+import static org.uberfire.server.UploadUriProvider.isUpdate;
 
 public class FileUploadServlet
         extends BaseUploadServlet {
@@ -51,9 +52,11 @@ public class FileUploadServlet
         try {
 
             URI targetLocation = getTargetLocation(request);
+            final boolean isUpdate = isUpdate(request);
             finalizeResponse(response,
                              getFileItem(request),
-                             targetLocation);
+                             targetLocation,
+                             isUpdate);
         } catch (FileUploadException e) {
             logError(e);
             writeResponse(response,
@@ -67,7 +70,8 @@ public class FileUploadServlet
 
     private void finalizeResponse(HttpServletResponse response,
                                   FileItem fileItem,
-                                  URI uri) throws IOException {
+                                  URI uri,
+                                  boolean isUpdate) throws IOException {
         if (!validateAccess(uri,
                             response)) {
             return;
@@ -78,7 +82,8 @@ public class FileUploadServlet
         try {
             ioService.startBatch(path.getFileSystem());
 
-            if (ioService.exists(path)) {
+            if (ioService.exists(path)
+                    && !isUpdate) {
                 writeResponse(response,
                               RESPONSE_CONFLICT);
                 response.sendError(HttpServletResponse.SC_CONFLICT);

--- a/uberfire-server/src/main/java/org/uberfire/server/UploadUriProvider.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/UploadUriProvider.java
@@ -32,6 +32,7 @@ public class UploadUriProvider {
     private static final String PARAM_PATH = "path";
     private static final String PARAM_FOLDER = "folder";
     private static final String PARAM_FILENAME = "fileName";
+    private static final String PARAM_UPDATE = "update";
 
     public static URI getTargetLocation(final HttpServletRequest request) throws URISyntaxException,
             FileUploadException {
@@ -46,5 +47,9 @@ public class UploadUriProvider {
         } else {
             throw new FileUploadException("Path to file was invalid.");
         }
+    }
+    
+    public static boolean isUpdate(final HttpServletRequest request) {
+        return Boolean.parseBoolean(request.getParameter(PARAM_UPDATE));
     }
 }


### PR DESCRIPTION
 * Added isUpdate parameter to DefaultEditorFileUpload to bypass file exist check in FileUploadServlet

**JIRA**: 
[AF-2781](https://issues.redhat.com/browse/AF-2781) 
[RHPAM-3277](https://issues.redhat.com/browse/RHPAM-3277) 

Summary: While we use the Default file upload editor to update any file in a project/repo, the upload fails due to a check that if the file already it should send a failed response back. This prevents us to update any file with the editor. These changes ensure that file upload is successful in the editor.
With this approach, if we have multiple users trying to edit the same file, the latest change overrides the previous change.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
