### PR TITLE
RHPAM-2647 :[GSS](7.z) Errors when building a project are shown to all users

### DIFF
--- a/uberfire-message-console/uberfire-message-console-api/src/main/java/org/guvnor/messageconsole/events/PublishBaseEvent.java
+++ b/uberfire-message-console/uberfire-message-console-api/src/main/java/org/guvnor/messageconsole/events/PublishBaseEvent.java
@@ -35,6 +35,8 @@ public abstract class PublishBaseEvent {
      */
     private String userId;
 
+    private String rootPath;
+
     private Place place = Place.END;
 
     private List<SystemMessage> messagesToPublish = new ArrayList<SystemMessage>();
@@ -70,6 +72,14 @@ public abstract class PublishBaseEvent {
 
     public void setPlace(Place place) {
         this.place = place;
+    }
+
+    public String getRootPath() {
+        return rootPath;
+    }
+
+    public void setRootPath(String rootPath) {
+        this.rootPath = rootPath;
     }
 
     public boolean isShowSystemConsole() {

--- a/uberfire-message-console/uberfire-message-console-api/src/main/java/org/guvnor/messageconsole/events/UnpublishMessagesEvent.java
+++ b/uberfire-message-console/uberfire-message-console-api/src/main/java/org/guvnor/messageconsole/events/UnpublishMessagesEvent.java
@@ -38,6 +38,9 @@ public class UnpublishMessagesEvent {
     /**
      * Filter parameter to establish that messagesToUnpublish of this type should be unpublished.
      */
+
+    private String rootPath;
+
     private String messageType;
 
     private List<SystemMessage> messagesToUnpublish = new ArrayList<SystemMessage>();
@@ -66,6 +69,14 @@ public class UnpublishMessagesEvent {
 
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    public String getRootPath() {
+        return rootPath;
+    }
+
+    public void setRootPath(String rootPath) {
+        this.rootPath = rootPath;
     }
 
     public String getMessageType() {

--- a/uberfire-message-console/uberfire-message-console-backend/src/main/java/org/guvnor/messageconsole/backend/BuildResultsObserver.java
+++ b/uberfire-message-console/uberfire-message-console-backend/src/main/java/org/guvnor/messageconsole/backend/BuildResultsObserver.java
@@ -42,7 +42,7 @@ public class BuildResultsObserver {
         PublishBatchMessagesEvent batchMessages = new PublishBatchMessagesEvent();
         batchMessages.setCleanExisting(true);
         batchMessages.setMessageType(MessageUtils.BUILD_SYSTEM_MESSAGE);
-
+        batchMessages.setRootPath(results.getRootPathURI());
         if (results.getMessages() != null) {
             for (BuildMessage buildMessage : results.getMessages()) {
                 batchMessages.getMessagesToPublish().add(MessageUtils.convert(buildMessage));
@@ -56,7 +56,7 @@ public class BuildResultsObserver {
 
         PublishBatchMessagesEvent batchMessages = new PublishBatchMessagesEvent();
         batchMessages.setMessageType(MessageUtils.BUILD_SYSTEM_MESSAGE);
-
+        batchMessages.setRootPath(results.getRootPathURI());
         if (results.getAddedMessages() != null) {
             for (BuildMessage buildMessage : results.getAddedMessages()) {
                 batchMessages.getMessagesToPublish().add(MessageUtils.convert(buildMessage));

--- a/uberfire-message-console/uberfire-message-console-client/pom.xml
+++ b/uberfire-message-console/uberfire-message-console-client/pom.xml
@@ -85,6 +85,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
     </dependency>
 

--- a/uberfire-message-console/uberfire-message-console-client/src/test/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceTest.java
+++ b/uberfire-message-console/uberfire-message-console-client/src/test/java/org/guvnor/messageconsole/client/console/MessageConsoleServiceTest.java
@@ -27,6 +27,7 @@ import javax.enterprise.util.TypeLiteral;
 import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
+import org.guvnor.common.services.project.client.context.WorkspaceProjectContext;
 import org.guvnor.messageconsole.events.FilteredMessagesEvent;
 import org.guvnor.messageconsole.events.PublishMessagesEvent;
 import org.guvnor.messageconsole.events.SystemMessage;
@@ -58,6 +59,9 @@ public class MessageConsoleServiceTest {
     private User identity;
 
     @Mock
+    private WorkspaceProjectContext workspaceProjectContext;
+
+    @Mock
     private StubEventSource<FilteredMessagesEvent> filteredMessagesEvent;
 
     private MessageConsoleService service;
@@ -68,6 +72,7 @@ public class MessageConsoleServiceTest {
                                                  placeManager,
                                                  sessionInfo,
                                                  identity,
+                                                 workspaceProjectContext,
                                                  filteredMessagesEvent);
     }
 

--- a/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/builder/model/BuildResults.java
+++ b/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/builder/model/BuildResults.java
@@ -32,6 +32,7 @@ public class BuildResults {
     private GAV gav;
     private ArrayList<BuildMessage> messages = new ArrayList<BuildMessage>();
     private Map<String, String> parameters = new HashMap<>();
+    private String rootPathURI;
 
     public BuildResults() {
         //Marshalling
@@ -96,4 +97,12 @@ public class BuildResults {
 	public String getParameter(String name) {
 		return this.parameters.get(name);
 	}
+
+    public String getRootPathURI() {
+        return rootPathURI;
+    }
+
+    public void setRootPathURI(String rootPathURI) {
+        this.rootPathURI = rootPathURI;
+    }
 }

--- a/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/builder/model/IncrementalBuildResults.java
+++ b/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/builder/model/IncrementalBuildResults.java
@@ -18,7 +18,9 @@ package org.guvnor.common.services.project.builder.model;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.guvnor.common.services.project.model.GAV;
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -29,6 +31,8 @@ public class IncrementalBuildResults {
     private GAV gav;
     private ArrayList<BuildMessage> addedMessages = new ArrayList<BuildMessage>();
     private ArrayList<BuildMessage> removedMessages = new ArrayList<BuildMessage>();
+    private Map<String, String> parameters = new HashMap<>();
+    private String rootPathURI;
 
     public IncrementalBuildResults() {
         //Marshalling
@@ -64,5 +68,25 @@ public class IncrementalBuildResults {
 
     public void addAllRemovedMessages(List<BuildMessage> buildMessages) {
         removedMessages.addAll(buildMessages);
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void addParameter(String name, String value) {
+        this.parameters.put(name, value);
+    }
+
+    public String getParameter(String name) {
+        return this.parameters.get(name);
+    }
+
+    public String getRootPathURI() {
+        return rootPathURI;
+    }
+
+    public void setRootPathURI(String rootPathURI) {
+        this.rootPathURI = rootPathURI;
     }
 }

--- a/uberfire-project/uberfire-project-builder/src/main/java/org/guvnor/common/services/builder/ResourceChangeIncrementalBuilder.java
+++ b/uberfire-project/uberfire-project-builder/src/main/java/org/guvnor/common/services/builder/ResourceChangeIncrementalBuilder.java
@@ -256,7 +256,6 @@ public class ResourceChangeIncrementalBuilder {
                 try {
                     logger.info("Incremental build request being processed: " + resource.toURI() + " (updated).");
                     final Module module = projectService.resolveModule(resource);
-
                     //Fall back to a Full Build in lieu of an Incremental Build if the Project has not been previously built
                     if (buildService.isBuilt(module)) {
                         final IncrementalBuildResults results = buildService.updatePackageResource(resource);
@@ -330,6 +329,7 @@ public class ResourceChangeIncrementalBuilder {
                         if (buildService.isBuilt(module)) {
                             final IncrementalBuildResults results = buildService.applyBatchResourceChanges(module,
                                                                                                            changes);
+
                             incrementalBuildResultsEvent.fire(results);
                         } else {
                             final BuildResults results = buildService.build(module);


### PR DESCRIPTION
**RHPAM-2647**: _https://issues.redhat.com/browse/RHPAM-2647_ 

**Current Behaviour**: Error message in a project was shown to all users, irrespective of the opened project and branch.
**Expected Behaviour** : Error message is only shown to users who are in same project and same branch. This is done since BC projects are shared in nature and users access the same version of a project repository.

Related PR:
 https://github.com/kiegroup/kie-wb-common/pull/3546
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
