### PR TITLE
RHPAM-3412: Getting not found error for heatmap on windows

### DIFF
--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/ComponentAssetProviderImpl.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/main/java/org/dashbuilder/external/impl/ComponentAssetProviderImpl.java
@@ -51,9 +51,13 @@ public class ComponentAssetProviderImpl implements ComponentAssetProvider {
         throw new IllegalArgumentException("Invalid Asset Path.");
     }
 
+    String fixSlashes(String componentAssetPath) {
+        return componentAssetPath == null ? "" : componentAssetPath.replaceAll("\\\\", "/");
+    }
+
     private Optional<InputStream> getInternalComponentAsset(String componentAssetPath) {
         String internalComponentsBaseDir = componentsLoader.getProvidedComponentsPath();
-        String fullPath = "/" + internalComponentsBaseDir + "/" + componentAssetPath;
+        String fullPath = "/" + internalComponentsBaseDir + "/" + fixSlashes(componentAssetPath);
         return Optional.ofNullable(this.getClass().getResourceAsStream(fullPath));
     }
 

--- a/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/test/java/org/dashbuilder/external/impl/ComponentAssetProviderImplTest.java
+++ b/dashbuilder/dashbuilder-backend/dashbuilder-external-backend/src/test/java/org/dashbuilder/external/impl/ComponentAssetProviderImplTest.java
@@ -122,6 +122,13 @@ public class ComponentAssetProviderImplTest {
     public void testInternalComponentAssetPathTraversal() throws Exception {
         assertNotNull(componentAssetProviderImpl.openAsset("../../../dashbuilder-components.properties"));
     }
+    
+    @Test
+    public void testFixSlashes() throws Exception {
+        assertEquals("/abc/cde", componentAssetProviderImpl.fixSlashes("\\abc\\cde"));
+        assertEquals("/abc/cde", componentAssetProviderImpl.fixSlashes("/abc/cde"));
+        assertEquals("", componentAssetProviderImpl.fixSlashes(null));
+    }
 
     private String createComponentFile(String componentId, String fileName, String fileContent) throws Exception {
         Path componentDir = componentsDir.resolve(componentId);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHPAM-3412

Fix for RHPAM-3412

*Reproduce the issue*

* Setup RHPAM/jbpm on Windows
* Start the server, login, go to Pages;
* Create a new page and you should see the issue (Not Found error)


This is caused due the classic issue with inverted in Windows. It works for external components, but fails with internal components, which are loaded from the classpath.

The solution is simply replace Window slashes when loading internal components.


