### PR TITLE
JS interop fix on kie-wb-common-dmn-webapp-kogito-testing

### DIFF
--- a/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsApi.java
+++ b/appformer-kogito-bridge/src/main/java/org/appformer/kogito/bridge/client/notifications/NotificationsApi.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.uberfire.workbench.model.bridge.Notification;
 import org.uberfire.workbench.model.bridge.NotificationSeverity;
 import org.uberfire.workbench.model.bridge.NotificationType;
+import jsinterop.annotations.JsType;
 
 /**
  * This is the API that will let communicate with Notifications channel implementation. There are two types of Notifications:
@@ -35,6 +36,7 @@ import org.uberfire.workbench.model.bridge.NotificationType;
  * Alerts supports severities {@link NotificationSeverity#INFO} and {@link NotificationSeverity#ERROR}. Any other
  * severity will be treated as INFO.
  */
+@JsType(isNative = true)
 public interface NotificationsApi {
 
     /**


### PR DESCRIPTION
**Thank you for submitting this pull request**
You are welcome! ^


@adrielparedes there is an issue running kie-wb-common-dmn-webapp-kogito-testing with notifications API.

Looks like now we need to explicitly declare JS interop on interfaces from other modules. (but I'm 100% not sure: https://github.com/google/jsinterop-annotations/issues/2)(and maybe we need to add global or window for it)

What I know that this fixed the gwt:run  on kie-wb-common-dmn-webapp-kogito-testing and also both dmn and bpmn kogito showcase, but  I didn't try if this breaks anything on notification API.

@adrielparedes can you please take a look at this Monday morning?


