### PR TITLE
KOGITO-4399: Activity Client Editor template returns a Promise instead of null

### DIFF
--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest6.expected
@@ -72,12 +72,12 @@ public class WorkbenchClientEditorTest6Activity extends AbstractWorkbenchClientE
     }
     @Override
     public Promise<String> getPreview() {
-        return null;
+        return Promise.resolve("");
     }
 
     @Override
     public Promise validate() {
-        return null;
+        return Promise.resolve(Collections.emptyList());
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest7.expected
@@ -77,7 +77,7 @@ public class WorkbenchClientEditorTest7Activity extends AbstractWorkbenchClientE
 
     @Override
     public Promise validate() {
-        return null;
+        return Promise.resolve(Collections.emptyList());
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest8.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchClientEditorTest8.expected
@@ -72,7 +72,7 @@ public class WorkbenchClientEditorTest8Activity extends AbstractWorkbenchClientE
     }
     @Override
     public Promise<String> getPreview() {
-        return null;
+        return Promise.resolve("");
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityClientEditor.ftl
@@ -208,7 +208,7 @@ public class ${className} extends AbstractWorkbenchClientEditorActivity {
     	<#if getPreviewMethodName??>    
         return realPresenter.${getPreviewMethodName}();
         <#else>
-        return null;
+        return Promise.resolve("");
         </#if>
     }
 
@@ -217,7 +217,7 @@ public class ${className} extends AbstractWorkbenchClientEditorActivity {
         <#if validateMethodName??>
         return realPresenter.${validateMethodName}();
         <#else>
-        return null;
+        return Promise.resolve(Collections.emptyList());
         </#if>
     }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/KOGITO-4399

A null was sent instead of a Promise, that makes the editor that doesn't implement (yet) the validation to break.

* https://github.com/kiegroup/appformer/pull/1101
* https://github.com/kiegroup/kogito-tooling/pull/417

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
