### PR TITLE
[backport-7.48.x] RHPAM-3396: Ability to use any client name instead of "kie" while configuring client roles with RHSSO

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/BaseKeyCloakManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/BaseKeyCloakManager.java
@@ -62,8 +62,6 @@ public abstract class BaseKeyCloakManager {
 
     static final int STATUS_NOT_AUTHORIZED = 403;
 
-    protected static final String CLIENT_ID = "kie";
-
     protected static final String ATTRIBUTE_USER_ID = "user.id";
     protected static final String ATTRIBUTE_USER_FIRST_NAME = "user.firstName";
     protected static final String ATTRIBUTE_USER_LAST_NAME = "user.lastName";
@@ -260,7 +258,7 @@ public abstract class BaseKeyCloakManager {
         }
 
         if (getKeyCloakInstance().getUseRoleResourceMappings()) {
-            userRepresentation.setClientRoles(new Maps.Builder().put(CLIENT_ID, keycloakRoles).build());
+            userRepresentation.setClientRoles(new Maps.Builder().put(getKeyCloakInstance().getResource(), keycloakRoles).build());
         } else {
             userRepresentation.setRealmRoles(keycloakRoles);
         }
@@ -327,10 +325,10 @@ public abstract class BaseKeyCloakManager {
     }
 
     protected String getClientIdByName(RealmResource realmResource) {
-        List<ClientRepresentation> clientResource = realmResource.clients().findByClientId(CLIENT_ID);
+        List<ClientRepresentation> clientResource = realmResource.clients().findByClientId(getKeyCloakInstance().getResource());
         if (!clientResource.isEmpty()) {
             return clientResource.get(0).getId();
         }
-        throw new ClientNotFoundException(CLIENT_ID);
+        throw new ClientNotFoundException(getKeyCloakInstance().getResource());
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/CredentialsClientFactory.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/CredentialsClientFactory.java
@@ -25,6 +25,7 @@ import org.uberfire.ext.security.management.keycloak.client.auth.credentials.Aut
 
 /**
  * Factory that creates Keycloak clients based on using Credentials authentication settings connection settings.
+ *
  * @since 0.9.0
  */
 @Dependent
@@ -35,6 +36,8 @@ public class CredentialsClientFactory extends BaseClientFactory {
     private static final String DEFAULT_PASSWORD = "password";
     private static final String DEFAULT_CLIENT_ID = "examples-admin-client";
     private static final String DEFAULT_CLIENT_SECRET = "password";
+    private static final String DEFAULT_USE_RESOURCE_ROLE_MAPPING = "false";
+    private static final String DEFAULT_RESOURCE = "kie";
 
     public void init(final ConfigProperties config) {
         final ConfigProperties.ConfigProperty authServer = config.get("org.uberfire.ext.security.management.keycloak.authServer",
@@ -50,13 +53,17 @@ public class CredentialsClientFactory extends BaseClientFactory {
         final ConfigProperties.ConfigProperty clientSecret = config.get("org.uberfire.ext.security.management.keycloak.clientSecret",
                                                                         DEFAULT_CLIENT_SECRET);
         final ConfigProperties.ConfigProperty useRoleResourceMappings = config.get("org.uberfire.ext.security.management.keycloak.use-resource-role-mappings",
-                                                                        "false");
+                                                                                   DEFAULT_USE_RESOURCE_ROLE_MAPPING);
+        final ConfigProperties.ConfigProperty resource = config.get("org.uberfire.ext.security.management.keycloak.resource",
+                                                                    DEFAULT_RESOURCE);
 
         this.client = Keycloak.getInstance(authServer.getValue(),
                                            realm.getValue(),
+                                           resource.getValue(),
                                            useRoleResourceMappings.getBooleanValue(),
                                            new AuthTokenManager(new AuthSettings(authServer.getValue(),
                                                                                  realm.getValue(),
+                                                                                 resource.getValue(),
                                                                                  user.getValue(),
                                                                                  password.getValue(),
                                                                                  clientId.getValue(),

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCAdapterClientFactory.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCAdapterClientFactory.java
@@ -50,6 +50,7 @@ public class KCAdapterClientFactory extends BaseClientFactory {
         final KCAdapterContextTokenManager tokenManager = new KCAdapterContextTokenManager(request);
         this.client = Keycloak.getInstance(authServer.getValue(),
                                            tokenManager.getRealm(),
+                                           tokenManager.getResource(),
                                            useRoleResourceMappings.getBooleanValue(),
                                            tokenManager);
     }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KeyCloakGroupManager.java
@@ -178,7 +178,7 @@ public class KeyCloakGroupManager extends BaseKeyCloakManager implements GroupMa
         if (users != null) {
             consumeRealm(realmResource -> {
                 final UsersResource usersResource = realmResource.users();
-                final RolesResource rolesResource = getRolesResource(realmResource, true);
+                final RolesResource rolesResource = getRolesResource(realmResource, getKeyCloakInstance().getUseRoleResourceMappings());
                 final RoleResource roleResource = rolesResource.get(name);
                 final List<RoleRepresentation> rolesToAdd = new ArrayList<RoleRepresentation>(1);
                 rolesToAdd.add(getRoleRepresentation(name,

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/Keycloak.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/Keycloak.java
@@ -35,15 +35,18 @@ public class Keycloak {
 
     private final String serverUrl;
     private final String realm;
+    private final String resource;
     private final Boolean useRoleResourceMappings;
     private final ClientRequestFactory clientRequestFactory;
 
     Keycloak(String serverUrl,
              String realm,
+             String resource,
              Boolean useRoleResourceMappings,
              TokenManager tokenManager) {
         this.serverUrl = serverUrl;
         this.realm = realm;
+        this.resource = resource;
         this.useRoleResourceMappings = useRoleResourceMappings;
         this.clientRequestFactory = new ClientRequestFactory(UriBuilder.fromUri(serverUrl).build());
         ResteasyProviderFactory.getInstance().getClientExecutionInterceptorRegistry().register(new BearerAuthenticationInterceptor(tokenManager));
@@ -51,10 +54,12 @@ public class Keycloak {
 
     public static Keycloak getInstance(String serverUrl,
                                        String realm,
+                                       String resource,
                                        Boolean useRoleResourceMappings,
                                        TokenManager tokenManager) {
         return new Keycloak(serverUrl,
                             realm,
+                            resource,
                             useRoleResourceMappings,
                             tokenManager);
     }
@@ -73,6 +78,10 @@ public class Keycloak {
 
     public Boolean getUseRoleResourceMappings() {
         return useRoleResourceMappings;
+    }
+
+    public String getResource() {
+        return resource;
     }
 
     public void close() {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/TokenManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/TokenManager.java
@@ -27,4 +27,6 @@ public interface TokenManager {
     String getAccessTokenString();
 
     String getRealm();
+
+    String getResource();
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/adapter/KCAdapterContextTokenManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/adapter/KCAdapterContextTokenManager.java
@@ -48,6 +48,11 @@ public class KCAdapterContextTokenManager implements TokenManager {
         return getKCSessionContext().getRealm();
     }
 
+    @Override
+    public String getResource() {
+        return getKCSessionContext().getToken().getIssuedFor();
+    }
+
     protected KeycloakSecurityContext getKCSessionContext() {
         KeycloakSecurityContext context = null;
     	

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/credentials/AuthSettings.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/credentials/AuthSettings.java
@@ -25,6 +25,7 @@ public class AuthSettings {
 
     private String serverUrl;
     private String realm;
+    private String resource;
     private String username;
     private String password;
     private String clientId;
@@ -32,12 +33,14 @@ public class AuthSettings {
 
     public AuthSettings(String serverUrl,
                         String realm,
+                        String resource,
                         String username,
                         String password,
                         String clientId,
                         String clientSecret) {
         this.serverUrl = serverUrl;
         this.realm = realm;
+        this.resource = resource;
         this.username = username;
         this.password = password;
         this.clientId = clientId;
@@ -58,6 +61,14 @@ public class AuthSettings {
 
     public void setRealm(String realm) {
         this.realm = realm;
+    }
+
+    public String getResource() {
+        return resource;
+    }
+
+    public void setResource(String resource) {
+        this.resource = resource;
     }
 
     public String getUsername() {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/credentials/AuthTokenManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/credentials/AuthTokenManager.java
@@ -177,6 +177,11 @@ public class AuthTokenManager implements TokenManager {
         return config.getRealm();
     }
 
+    @Override
+    public String getResource() {
+        return config.getResource();
+    }
+
     TokenService createTokenService() {
         ResteasyProviderFactory pf = ResteasyProviderFactory.getInstance();
         pf.addClientErrorInterceptor(clientErrorInterceptor);

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/client/auth/credentials/AuthTokenManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/client/auth/credentials/AuthTokenManagerTest.java
@@ -45,6 +45,7 @@ public class AuthTokenManagerTest {
     public void setup() throws Exception {
         when(config.getUsername()).thenReturn("user1");
         when(config.getRealm()).thenReturn("realm1");
+        when(config.getResource()).thenReturn("kie");
         when(config.getClientId()).thenReturn("clientId1");
         when(config.getClientSecret()).thenReturn("clientSecret1");
         when(config.getPassword()).thenReturn("password1");
@@ -64,6 +65,13 @@ public class AuthTokenManagerTest {
     public void testGetRealm() throws Exception {
         String r = this.tokenManager.getRealm();
         Assert.assertEquals("realm1",
+                            r);
+    }
+
+    @Test
+    public void testGetResource() throws Exception {
+        String r = this.tokenManager.getResource();
+        Assert.assertEquals("kie",
                             r);
     }
 


### PR DESCRIPTION
**Thank you for submitting this pull request**

**RHPAM-3396**: _https://issues.redhat.com/browse/RHPAM-3396_ 

Master branch PR : https://github.com/kiegroup/appformer/pull/1095

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
