### PR TITLE
AF-2821: Added SerialMergeScheduler to Lucene Directory configuration

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/directory/DirectoryLuceneIndex.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/index/directory/DirectoryLuceneIndex.java
@@ -23,6 +23,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherFactory;
 import org.uberfire.ext.metadata.backend.lucene.index.BaseLuceneIndex;
@@ -45,6 +46,9 @@ public class DirectoryLuceneIndex extends BaseLuceneIndex {
                                 final Directory directory,
                                 final IndexWriterConfig config) {
         try {
+
+            config.setMergeScheduler(new SerialMergeScheduler());
+
             this.cluster = checkNotNull("cluster",
                                         cluster);
             this.directory = checkNotNull("directory",


### PR DESCRIPTION
**JIRA**:
[AF-2821](https://issues.redhat.com/browse/AF-2821)

This configuration was made to reduce the number of threads Lucene uses since all the indexing operations are serial and not parallel. Thanks @porcelli for the findings

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
