### PR TITLE
DROOLS-6213: Apply try with resources for file upload

### DIFF
--- a/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/file/upload/AbstractFileServlet.java
+++ b/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/file/upload/AbstractFileServlet.java
@@ -240,12 +240,11 @@ public abstract class AbstractFileServlet extends BaseFilteredServlet {
                          fileData,
                          request,
                          "Uploaded " + getTimestamp());
-            } else if(operation == FileOperation.UPDATE) {
-                    doUpdate(targetPath,
-                             fileData,
-                             request,
-                             "Uploaded " + getTimestamp());
-
+            } else if (operation == FileOperation.UPDATE) {
+                doUpdate(targetPath,
+                         fileData,
+                         request,
+                         "Uploaded " + getTimestamp());
             }
         }
 

--- a/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/file/upload/AbstractFileServlet.java
+++ b/uberfire-services/uberfire-services-backend/src/main/java/org/guvnor/common/services/backend/file/upload/AbstractFileServlet.java
@@ -226,7 +226,6 @@ public abstract class AbstractFileServlet extends BaseFilteredServlet {
     private String uploadFile(final FormData item,
                               final HttpServletRequest request,
                               final HttpServletResponse response) throws IOException {
-        final InputStream fileData = item.getFile().getInputStream();
         final org.uberfire.backend.vfs.Path targetPath = item.getTargetPath();
 
         if (!validateAccess(Paths.convert(targetPath),
@@ -234,22 +233,20 @@ public abstract class AbstractFileServlet extends BaseFilteredServlet {
             return "FAIL";
         }
 
-        try {
-            switch (item.getOperation()) {
-                case CREATE:
-                    doCreate(targetPath,
-                             fileData,
-                             request,
-                             "Uploaded " + getTimestamp());
-                    break;
-                case UPDATE:
+        try (final InputStream fileData = item.getFile().getInputStream()) {
+            final FileOperation operation = item.getOperation();
+            if (operation == FileOperation.CREATE) {
+                doCreate(targetPath,
+                         fileData,
+                         request,
+                         "Uploaded " + getTimestamp());
+            } else if(operation == FileOperation.UPDATE) {
                     doUpdate(targetPath,
                              fileData,
                              request,
                              "Uploaded " + getTimestamp());
+
             }
-        } finally {
-            item.getFile().getInputStream().close();
         }
 
         return "OK";


### PR DESCRIPTION
As part of DROOLS-6213 we cleaned up codebase for uploading XLS decision tables and scorecards. During review of drools-wb changes, the same technical debt was found in the appformer abstract class, that is overriden by drools-wb classes, enhanced as part of DROOLS-6213

For more details see:
- https://issues.redhat.com/browse/DROOLS-6213

### Related PR (not an ensemble)
https://github.com/kiegroup/drools-wb/pull/1477