### PR TITLE
AF-2850: Create project rest api should include project name in the response

### DIFF
--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestHelper.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestHelper.java
@@ -172,9 +172,10 @@ public class JobRequestHelper {
             pom.getGav().setVersion(projectVersion);
             pom.setDescription(projectDescription);
             pom.setName(projectName);
-
+            
+            WorkspaceProject project = null;
             try {
-                workspaceProjectService.newProject(organizationalUnit,
+                project = workspaceProjectService.newProject(organizationalUnit,
                                                    pom);
             } catch (GAVAlreadyExistsException gae) {
                 result.setStatus(JobStatus.DUPLICATE_RESOURCE);
@@ -186,7 +187,13 @@ public class JobRequestHelper {
                 return result;
             }
 
+            if (project == null) {
+                result.setStatus(JobStatus.FAIL);
+                return result;
+            }
+
             result.setStatus(JobStatus.SUCCESS);
+            result.setResult("Project [" + project.getName() + "] is created");
         }
         return result;
     }

--- a/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/JobRequestHelperCreateModuleTest.java
+++ b/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/JobRequestHelperCreateModuleTest.java
@@ -24,6 +24,7 @@ import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.common.services.project.model.MavenRepositoryMetadata;
 import org.guvnor.common.services.project.model.MavenRepositorySource;
 import org.guvnor.common.services.project.model.POM;
+import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.project.service.GAVAlreadyExistsException;
 import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.guvnor.rest.client.JobResult;
@@ -98,6 +99,9 @@ public class JobRequestHelperCreateModuleTest {
 
     @Test
     public void testRepositoryDoesExist() throws Exception {
+        when(workspaceProjectService.newProject(any(OrganizationalUnit.class),
+                                                any(POM.class)))
+                .thenReturn(mock(WorkspaceProject.class));
         final JobResult jobResult = jobRequestHelper.createProject("jobId",
                                                                    "spaceName",
                                                                    "projectName",
@@ -109,7 +113,7 @@ public class JobRequestHelperCreateModuleTest {
                      jobResult.getJobId());
         assertEquals(JobStatus.SUCCESS,
                      jobResult.getStatus());
-        assertNull(jobResult.getResult());
+        assertNotNull(jobResult.getResult());
     }
 
     @Test

--- a/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/JobRequestHelperCreateModuleTest.java
+++ b/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/JobRequestHelperCreateModuleTest.java
@@ -117,6 +117,25 @@ public class JobRequestHelperCreateModuleTest {
     }
 
     @Test
+    public void testNullWorkspaceProject() throws Exception {
+        when(workspaceProjectService.newProject(any(OrganizationalUnit.class),
+                                                any(POM.class)))
+                .thenReturn(null);
+        final JobResult jobResult = jobRequestHelper.createProject("jobId",
+                                                                   "spaceName",
+                                                                   "projectName",
+                                                                   "projectGroupId",
+                                                                   "projectVersion",
+                                                                   "projectDescription");
+
+        assertEquals("jobId",
+                     jobResult.getJobId());
+        assertEquals(JobStatus.FAIL,
+                     jobResult.getStatus());
+        assertNull(jobResult.getResult());
+    }
+
+    @Test
     public void testNewProjectWhenGAVAlreadyExists() throws Exception {
 
         final HashSet<MavenRepositoryMetadata> repositories = new HashSet<>();


### PR DESCRIPTION
 * Updated the JobStatus result with correct project name when the project is successfully created by REST

**JIRA**: 
[AF-2850](https://issues.redhat.com/browse/AF-2850)
[RHPAM-3519](https://issues.redhat.com/browse/RHPAM-3519)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
