### PR TITLE
[7.52.x] : RHPAM-3557: Slow performance opening assets in projects with large commit history

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/CommitTime.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/CommitTime.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit;
+
+public class CommitTime {
+
+    private Long firstCommitTime;
+    private Long lastCommitTime;
+
+    public Long getFirstCommitTime() {
+        return firstCommitTime;
+    }
+
+    public void setFirstCommitTime(Long firstCommitTime) {
+        this.firstCommitTime = firstCommitTime;
+    }
+
+    public Long getLastCommitTime() {
+        return lastCommitTime;
+    }
+
+    public void setLastCommitTime(Long lastCommitTime) {
+        this.lastCommitTime = lastCommitTime;
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 3c80b8735158335ea227f67cd754789cf828b401)

**Thank you for submitting this pull request**

**RHPAM-3557**: _https://issues.redhat.com/browse/RHPAM-3557_ 

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

main PR: https://github.com/kiegroup/appformer/pull/1131

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
