### PR TITLE
[7.52.x] AF-2847: Adding template to the REST API /spaces/{spaceName}/project command in order to create new project based on the archetype template (#1140)

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexManagerTest.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/test/java/org/uberfire/ext/metadata/backend/lucene/index/LuceneIndexManagerTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LuceneInedexManagerTest {
+public class LuceneIndexManagerTest {
 
     @Mock
     LuceneIndexFactory factory;

--- a/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/service/BaseArchetypeService.java
+++ b/uberfire-project/uberfire-project-api/src/main/java/org/guvnor/common/services/project/service/BaseArchetypeService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.project.service;
+
+import java.util.Optional;
+
+import org.guvnor.structure.repositories.Repository;
+
+public interface BaseArchetypeService {
+
+    /**
+     * Return the repository where the archetype is stored.
+     *
+     * @param alias archetype alias
+     * @param spaceName archetype space
+     * @return repository of the archetype
+     */
+    Repository getTemplateRepository(String alias, String spaceName);
+}

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/BaseArchetypeServiceImpl.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/BaseArchetypeServiceImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.common.services.project.backend.server;
+
+import java.util.Optional;
+
+import org.guvnor.common.services.project.service.BaseArchetypeService;
+import org.guvnor.structure.repositories.Repository;
+import org.uberfire.annotations.FallbackImplementation;
+
+@FallbackImplementation
+public class BaseArchetypeServiceImpl implements BaseArchetypeService {
+
+    public BaseArchetypeServiceImpl() {
+    }
+
+    @Override
+    public Repository getTemplateRepository(String alias, String spaceName) {
+        return null;
+    }
+}

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/BaseArchetypeServiceProducer.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/utils/BaseArchetypeServiceProducer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.common.services.project.backend.server.utils;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.guvnor.common.services.project.backend.server.BaseArchetypeServiceImpl;
+import org.guvnor.common.services.project.service.BaseArchetypeService;
+import org.uberfire.annotations.Customizable;
+
+public class BaseArchetypeServiceProducer {
+
+    @Inject
+    private Instance<BaseArchetypeService> archetypeService;
+
+    @Produces
+    @Customizable
+    public BaseArchetypeService baseArchetypeServiceProducer() {
+        if (this.archetypeService.isUnsatisfied()) {
+            return new BaseArchetypeServiceImpl();
+        }
+        return this.archetypeService.get();
+    }
+
+}

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestHelper.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestHelper.java
@@ -39,6 +39,8 @@ import org.guvnor.common.services.project.model.MavenRepositoryMetadata;
 import org.guvnor.common.services.project.model.Module;
 import org.guvnor.common.services.project.model.POM;
 import org.guvnor.common.services.project.model.WorkspaceProject;
+import org.guvnor.common.services.project.service.BaseArchetypeService;
+import org.guvnor.common.services.project.service.DeploymentMode;
 import org.guvnor.common.services.project.service.GAVAlreadyExistsException;
 import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.guvnor.common.services.shared.test.TestResultMessage;
@@ -51,12 +53,14 @@ import org.guvnor.structure.contributors.ContributorType;
 import org.guvnor.structure.organizationalunit.OrganizationalUnit;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
 import org.guvnor.structure.organizationalunit.impl.OrganizationalUnitImpl;
+import org.guvnor.structure.repositories.Repository;
 import org.guvnor.structure.repositories.RepositoryEnvironmentConfigurations;
 import org.guvnor.structure.repositories.RepositoryService;
 import org.guvnor.structure.repositories.impl.git.GitRepository;
 import org.kie.soup.commons.validation.PortablePreconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.annotations.Customizable;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
@@ -92,6 +96,10 @@ public class JobRequestHelper {
 
     @Inject
     private TestRunnerService testService;
+
+    @Inject
+    @Customizable
+    private BaseArchetypeService archetypeService;
 
     public JobResult cloneProject(final String jobId,
                                   final String spaceName,
@@ -149,6 +157,22 @@ public class JobRequestHelper {
                                    String projectGroupId,
                                    String projectVersion,
                                    String projectDescription) {
+        return createProject(jobId,
+                             spaceName,
+                             projectName,
+                             projectGroupId,
+                             projectVersion,
+                             projectDescription,
+                             null);
+    }
+
+    public JobResult createProject(final String jobId,
+                                   final String spaceName,
+                                   final String projectName,
+                                   String projectGroupId,
+                                   String projectVersion,
+                                   String projectDescription,
+                                   String templateId) {
 
         final JobResult result = new JobResult();
         result.setJobId(jobId);
@@ -173,9 +197,19 @@ public class JobRequestHelper {
             pom.setDescription(projectDescription);
             pom.setName(projectName);
 
+            WorkspaceProject project = null;
             try {
-                workspaceProjectService.newProject(organizationalUnit,
-                                                   pom);
+                if (templateId == null) {
+                    project = workspaceProjectService.newProject(organizationalUnit,
+                                                       pom);
+                } else {
+                    project = workspaceProjectService.newProject(organizationalUnit,
+                                                       pom,
+                                                       DeploymentMode.VALIDATED,
+                                                       null,
+                                                       getTemplateRepository(templateId,
+                                                                                 organizationalUnit.getName()));
+                }
             } catch (GAVAlreadyExistsException gae) {
                 result.setStatus(JobStatus.DUPLICATE_RESOURCE);
                 result.setResult("Project's GAV [" + gae.getGAV().toString() + "] already exists at [" + toString(gae.getRepositories()) + "]");
@@ -184,11 +218,26 @@ public class JobRequestHelper {
                 result.setStatus(JobStatus.DUPLICATE_RESOURCE);
                 result.setResult("Project [" + projectName + "] already exists");
                 return result;
+            } catch (IllegalArgumentException iae) {
+                result.setStatus(JobStatus.FAIL);
+                result.setResult(iae.getMessage());
+                return result;
+            }
+
+            if (project == null) {
+                result.setStatus(JobStatus.FAIL);
+                return result;
             }
 
             result.setStatus(JobStatus.SUCCESS);
+            result.setResult("Project [" + project.getName() + "] is created");
         }
         return result;
+    }
+
+    private Repository getTemplateRepository(final String templateId,
+                                                 final String spaceName) {
+        return archetypeService.getTemplateRepository(templateId, spaceName);
     }
 
     private String toString(final Set<MavenRepositoryMetadata> repositories) {

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
@@ -112,6 +112,8 @@ public class JobRequestScheduler {
                    jobRequest.getSpaceName());
         params.put("Project",
                    jobRequest.getProjectName());
+        params.put("TemplateId",
+                   jobRequest.getTemplateId());
         params.put("Operation",
                    "createProject");
         params.put(ACCEPT_LANGUAGE,

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
@@ -221,6 +221,7 @@ public class ProjectResource {
         jobRequest.setProjectGroupId(createProjectRequest.getGroupId());
         jobRequest.setProjectVersion(createProjectRequest.getVersion());
         jobRequest.setDescription(createProjectRequest.getDescription());
+        jobRequest.setTemplateId(createProjectRequest.getTemplateId());
         addAcceptedJobResult(id);
 
         jobRequestObserver.createProjectRequest(jobRequest,

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/cmd/CreateProjectCmd.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/cmd/CreateProjectCmd.java
@@ -49,7 +49,8 @@ public class CreateProjectCmd extends AbstractJobCommand {
                                           jobRequest.getProjectName(),
                                           jobRequest.getProjectGroupId(),
                                           jobRequest.getProjectVersion(),
-                                          jobRequest.getDescription());
+                                          jobRequest.getDescription(),
+                                          jobRequest.getTemplateId());
         } finally {
             JobStatus status = result != null ? result.getStatus() : JobStatus.SERVER_ERROR;
             String groupId = jobRequest.getProjectGroupId() == null ? jobRequest.getProjectName() : jobRequest.getProjectGroupId();

--- a/uberfire-rest/uberfire-rest-client/src/main/java/org/guvnor/rest/client/CreateProjectJobRequest.java
+++ b/uberfire-rest/uberfire-rest-client/src/main/java/org/guvnor/rest/client/CreateProjectJobRequest.java
@@ -25,6 +25,7 @@ public class CreateProjectJobRequest extends JobRequest {
     private String projectGroupId;
     private String projectVersion;
     private String description;
+    private String templateId;
 
     public String getSpaceName() {
         return spaceName;
@@ -64,5 +65,13 @@ public class CreateProjectJobRequest extends JobRequest {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
     }
 }

--- a/uberfire-rest/uberfire-rest-client/src/main/java/org/guvnor/rest/client/CreateProjectRequest.java
+++ b/uberfire-rest/uberfire-rest-client/src/main/java/org/guvnor/rest/client/CreateProjectRequest.java
@@ -23,6 +23,7 @@ public class CreateProjectRequest extends Entity {
 
     private String groupId;
     private String version;
+    private String templateId;
 
     public CreateProjectRequest() {
     }
@@ -41,5 +42,13 @@ public class CreateProjectRequest extends Entity {
 
     public String getVersion() {
         return version;
+    }
+
+    public String getTemplateId() {
+        return templateId;
+    }
+
+    public void setTemplateId(String templateId) {
+        this.templateId = templateId;
     }
 }


### PR DESCRIPTION
AF-2847: Adding template to the REST API /spaces/{spaceName}/project command in order to create new project based on the archetype template

 * Added Fallback implementation for Archetype Service
 * Added Template Id support for creating project by Rest API job request

(cherry picked from commit db5128fef9fdb26d58b32f4cc0065b536177d41b)

**JIRA**:  
[RHPAM-3643](https://issues.redhat.com/browse/RHPAM-3643)
[AF-2847](https://issues.redhat.com/browse/AF-2847)

**referenced Pull Requests**: 
https://github.com/kiegroup/kie-wb-common/pull/3654

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
