### PR TITLE
AF-2894: java.lang.NoClassDefFoundError WARN messages when starting Dashbuilder Runtime

### DIFF
--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -374,6 +374,12 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-runtime-plugins-api</artifactId>
     </dependency>
 


### PR DESCRIPTION
*JIRA*:  https://issues.redhat.com/browse/AF-2894

There's a WARN in server logs coming from DB Runtime:

```
WARN  [org.jboss.modules.define] (MSC service thread 1-8) Failed to define class org.uberfire.ext.preferences.processors.WorkbenchPreferenceProcessor in Module "deployment.dashbuilder-runtime.war" from Service Module Loader: java.lang.NoClassDefFoundError: Failed to link org/uberfire/ext/preferences/processors/WorkbenchPreferenceProcessor (Module "deployment.dashbuilder-runtime.war" from Service Module Loader): org/uberfire/annotations/processors/AbstractErrorAbsorbingProcessor
at java.base/java.lang.ClassLoader.defineClass1(Native Method)
at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1096)
at org.jboss.modules.ModuleClassLoader.doDefineOrLoadClass(ModuleClassLoader.java:424)
at org.jboss.modules.ModuleClassLoader.defineClass(ModuleClassLoader.java:555)
at org.jboss.modules.ModuleClassLoader.loadClassLocal(ModuleClassLoader.java:339)
at org.jboss.modules.ModuleClassLoader$1.loadClassLocal(ModuleClassLoader.java:126)
at org.jboss.modules.Module.loadModuleClass(Module.java:753)
at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:247)
at org.jboss.modules.ConcurrentClassLoader.performLoadClassUnchecked(ConcurrentClassLoader.java:410)
at org.jboss.modules.ConcurrentClassLoader.performLoadClass(ConcurrentClassLoader.java:398)
at org.jboss.modules.ConcurrentClassLoader.loadClass(ConcurrentClassLoader.java:128)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:576)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
at java.base/java.lang.Class.forName0(Native Method)
at java.base/java.lang.Class.forName(Class.java:398)
``` 

The solution was to change the dependency that caused the issue to provided scope.


