### PR TITLE
AF-2911: Cannot clone project by ssh when business central is integrated with Keycloak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -796,6 +796,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-adapter-core</artifactId>
+        <version>${version.org.keycloak}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-catalina</artifactId>
         <version>${version.org.apache.tomcat}</version>

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/IOServiceSecuritySetup.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/IOServiceSecuritySetup.java
@@ -27,6 +27,7 @@ import org.guvnor.structure.security.RepositoryAction;
 import org.jboss.errai.security.shared.service.AuthenticationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.commons.services.cdi.Startup;
@@ -72,6 +73,9 @@ public class IOServiceSecuritySetup {
     @Inject
     WorkbenchUserManager workbenchUserManager;
 
+    @Inject
+    ElytronIdentityHelper elytronIdentityHelper;
+
     @PostConstruct
     public void setup() {
         final AuthenticationService nonHTTPAuthenticationManager;
@@ -83,7 +87,7 @@ public class IOServiceSecuritySetup {
                     JAASAuthenticationService.DEFAULT_DOMAIN);
 
             if (authType == null) {
-                nonHTTPAuthenticationManager = new ElytronAuthenticationService(workbenchUserManager);
+                nonHTTPAuthenticationManager = new ElytronAuthenticationService(elytronIdentityHelper);
             } else if (authType.toLowerCase().equals("jaas") || authType.toLowerCase().equals("container")) {
                 nonHTTPAuthenticationManager = new JAASAuthenticationService(domain);
             } else {

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelper.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelper.java
@@ -16,7 +16,7 @@
 
 package org.uberfire.backend.server.security.elytron;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import org.jboss.errai.security.shared.api.identity.User;
@@ -32,7 +32,7 @@ import org.wildfly.security.evidence.PasswordGuessEvidence;
  * Default implementation of {@link ElytronIdentityHelper}, it relies in the platform {@link SecurityDomain} to obtain
  * the user credentials
  */
-@ApplicationScoped
+@Alternative
 public class DefaultElytronIdentityHelper implements ElytronIdentityHelper {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultElytronIdentityHelper.class);

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelper.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security.elytron;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.exception.FailedAuthenticationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.security.WorkbenchUserManager;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+
+/**
+ * Default implementation of {@link ElytronIdentityHelper}, it relies in the platform {@link SecurityDomain} to obtain
+ * the user credentials
+ */
+@ApplicationScoped
+public class DefaultElytronIdentityHelper implements ElytronIdentityHelper {
+    private static final Logger logger = LoggerFactory.getLogger(DefaultElytronIdentityHelper.class);
+
+    private final WorkbenchUserManager workbenchUserManager;
+
+    @Inject
+    public DefaultElytronIdentityHelper(final WorkbenchUserManager workbenchUserManager) {
+        this.workbenchUserManager = workbenchUserManager;
+    }
+
+    @Override
+    public User getIdentity(String userName, String password) {
+
+        try {
+            if(login(userName, password)) {
+                return workbenchUserManager.getUser(userName);
+            }
+        } catch (Exception ex) {
+            logger.debug("Identity provided for '{}' not valid", userName);
+        }
+
+        throw new FailedAuthenticationException();
+    }
+
+    protected boolean login(String userName, String password) {
+        final Evidence evidence = new PasswordGuessEvidence(password.toCharArray());
+        try {
+            SecurityDomain.getCurrent().authenticate(userName, evidence);
+            return true;
+        } catch (Exception e) {
+            throw new FailedAuthenticationException(e.getMessage());
+        }
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelper.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelper.java
@@ -34,6 +34,7 @@ import org.wildfly.security.evidence.PasswordGuessEvidence;
  */
 @ApplicationScoped
 public class DefaultElytronIdentityHelper implements ElytronIdentityHelper {
+
     private static final Logger logger = LoggerFactory.getLogger(DefaultElytronIdentityHelper.class);
 
     private final WorkbenchUserManager workbenchUserManager;
@@ -47,7 +48,7 @@ public class DefaultElytronIdentityHelper implements ElytronIdentityHelper {
     public User getIdentity(String userName, String password) {
 
         try {
-            if(login(userName, password)) {
+            if (login(userName, password)) {
                 return workbenchUserManager.getUser(userName);
             }
         } catch (Exception ex) {

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/ElytronIdentityHelper.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/ElytronIdentityHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security.elytron;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.uberfire.backend.server.security.ElytronAuthenticationService;
+
+/**
+ * Helper for {@link ElytronAuthenticationService} to obtain the identity for a given credentials
+ */
+public interface ElytronIdentityHelper {
+
+    /**
+     * Obtains a valid (and authenticated) user for the given credentials.
+     * @param userName The name of the user
+     * @param password The password
+     * @return a valid User
+     */
+    User getIdentity(String userName, String password);
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/ElytronIdentityHelperProducer.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/elytron/ElytronIdentityHelperProducer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security.elytron;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.uberfire.security.WorkbenchUserManager;
+
+/**
+ * Default producer for {@link ElytronIdentityHelper}
+ */
+@ApplicationScoped
+public class ElytronIdentityHelperProducer {
+
+    private final WorkbenchUserManager workbenchUserManager;
+
+    @Inject
+    public ElytronIdentityHelperProducer(WorkbenchUserManager workbenchUserManager) {
+        this.workbenchUserManager = workbenchUserManager;
+    }
+
+    @Produces
+    public ElytronIdentityHelper getDefaultElytronIdentityHelper() {
+        return new DefaultElytronIdentityHelper(workbenchUserManager);
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelperTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/elytron/DefaultElytronIdentityHelperTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security.elytron;
+
+import org.jboss.errai.security.shared.exception.FailedAuthenticationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.uberfire.security.WorkbenchUserManager;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultElytronIdentityHelperTest {
+
+    private static final String USERNAME = "user";
+    private static final String PASSWORD = "password";
+
+    private DefaultElytronIdentityHelper helper;
+
+    @Mock
+    private WorkbenchUserManager workbenchUserManager;
+
+    @Before
+    public void init() {
+        helper = spy(new DefaultElytronIdentityHelper(workbenchUserManager)  {
+            @Override
+            protected boolean login(String userName, String password) {
+                return true;
+            }
+        });
+    }
+
+    @Test
+    public void testSuccessfulLogin() {
+
+        when(helper.login(eq(USERNAME), eq(PASSWORD))).thenReturn(true);
+
+        helper.getIdentity(USERNAME, PASSWORD);
+
+        verify(workbenchUserManager).getUser(USERNAME);
+    }
+
+    @Test(expected = FailedAuthenticationException.class)
+    public void testUnSuccessfulLogin() {
+
+        doThrow(new RuntimeException("whatever error")).when(helper).login(eq(USERNAME), eq(PASSWORD));
+
+        helper.getIdentity(USERNAME, PASSWORD);
+
+        verify(workbenchUserManager, never()).getUser(USERNAME);
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/elytron/ElytronIdentityHelperProducerTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/elytron/ElytronIdentityHelperProducerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security.elytron;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.uberfire.security.WorkbenchUserManager;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ElytronIdentityHelperProducerTest {
+
+    private static final String USERNAME = "user";
+    private static final String PASSWORD = "password";
+
+    private ElytronIdentityHelperProducer producer;
+
+    @Mock
+    private WorkbenchUserManager workbenchUserManager;
+
+    @Before
+    public void init() {
+        producer = new ElytronIdentityHelperProducer(workbenchUserManager);
+    }
+
+    @Test
+    public void testProduce() {
+
+        ElytronIdentityHelper helper = producer.getDefaultElytronIdentityHelper();
+
+        assertNotNull(helper);
+        assertTrue(helper instanceof DefaultElytronIdentityHelper);
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
@@ -127,6 +127,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-adapter-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCAdapterUserManagementService.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCAdapterUserManagementService.java
@@ -33,8 +33,9 @@ import org.uberfire.ext.security.management.service.AbstractUserManagementServic
  * @since 0.9.0
  */
 @Dependent
-@Named(value = "KCAdapterUserManagementService")
+@Named(value = KCAdapterUserManagementService.NAME)
 public class KCAdapterUserManagementService extends AbstractUserManagementService {
+    public static final String NAME = "KCAdapterUserManagementService";
 
     KeyCloakUserManager userManager;
     KeyCloakGroupManager groupManager;

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCCredentialsUserManagementService.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/KCCredentialsUserManagementService.java
@@ -32,8 +32,9 @@ import org.uberfire.ext.security.management.service.AbstractUserManagementServic
  * @since 0.9.0
  */
 @Dependent
-@Named(value = "KCCredentialsUserManagementService")
+@Named(value = KCCredentialsUserManagementService.NAME)
 public class KCCredentialsUserManagementService extends AbstractUserManagementService {
+    public static final String NAME = "KCCredentialsUserManagementService";
 
     KeyCloakUserManager userManager;
     KeyCloakGroupManager groupManager;

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
@@ -16,9 +16,6 @@
 
 package org.uberfire.ext.security.management.keycloak.elytron;
 
-import javax.annotation.Priority;
-import javax.enterprise.inject.Alternative;
-
 import java.security.Principal;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,13 +23,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
 import javax.interceptor.Interceptor;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginException;
 
 import org.jboss.errai.security.shared.api.Role;
@@ -40,18 +38,18 @@ import org.jboss.errai.security.shared.api.RoleImpl;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.jboss.errai.security.shared.api.identity.UserImpl;
 import org.jboss.errai.security.shared.exception.FailedAuthenticationException;
+import org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule;
 import org.keycloak.adapters.jaas.RolePrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
-import org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule;
 
 /**
  * Implementation of {@link ElytronIdentityHelper} for Keycloak integration. It tries to authenticate the given credentials
  * to Keycloak by using the {@link DirectAccessGrantsLoginModule}. Requires a keycloak-config-file and a SystemProperty
  * {@value KIE_GIT_FILE_SYSTEM_PROP} specifying the path of that file.
  */
-@Priority(Interceptor.Priority.APPLICATION+10)
+@Priority(Interceptor.Priority.APPLICATION + 10)
 @Alternative
 public class KeyCloakElytronIdentityHelper implements ElytronIdentityHelper {
 
@@ -92,7 +90,7 @@ public class KeyCloakElytronIdentityHelper implements ElytronIdentityHelper {
         keycloakDelegate.initialize(subject, new ElytronHelperCallbackHandler(userName, password), new HashMap<>(), options);
 
         try {
-            if(keycloakDelegate.login()) {
+            if (keycloakDelegate.login()) {
                 keycloakDelegate.commit();
 
                 Collection<Role> roles = subject.getPrincipals(RolePrincipal.class)
@@ -116,6 +114,7 @@ public class KeyCloakElytronIdentityHelper implements ElytronIdentityHelper {
     }
 
     static class ElytronHelperCallbackHandler implements CallbackHandler {
+
         private final String userName;
         private final String password;
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.keycloak.elytron;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+
+import java.security.Principal;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.interceptor.Interceptor;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.LoginException;
+
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
+import org.jboss.errai.security.shared.exception.FailedAuthenticationException;
+import org.keycloak.adapters.jaas.RolePrincipal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
+import org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule;
+
+/**
+ * Implementation of {@link ElytronIdentityHelper} for Keycloak integration. It tries to authenticate the given credentials
+ * to Keycloak by using the {@link DirectAccessGrantsLoginModule}. Requires a keycloak-config-file and a SystemProperty
+ * {@value KIE_GIT_FILE_SYSTEM_PROP} specifying the path of that file.
+ */
+@Priority(Interceptor.Priority.APPLICATION+10)
+@Alternative
+public class KeyCloakElytronIdentityHelper implements ElytronIdentityHelper {
+
+    public static final String KEYCLOAK_CONFIG_FILE_KEY = "keycloak-config-file";
+    public static final String KIE_GIT_FILE_SYSTEM_PROP = "org.uberfire.ext.security.keycloak.keycloak-config-file";
+    public static final String DEFAULT_KIE_GIT_FILE_PATH = System.getProperty("jboss.home.dir") + "/kie-git.json";
+
+    private static final Logger logger = LoggerFactory.getLogger(KeyCloakElytronIdentityHelper.class);
+
+    private final String configFile;
+    private final DirectAccessGrantsLoginModule keycloakDelegate;
+
+    public KeyCloakElytronIdentityHelper() {
+        this(new DirectAccessGrantsLoginModule());
+    }
+
+    KeyCloakElytronIdentityHelper(DirectAccessGrantsLoginModule keycloakDelegate) {
+        this.keycloakDelegate = keycloakDelegate;
+        configFile = System.getProperty(KIE_GIT_FILE_SYSTEM_PROP, DEFAULT_KIE_GIT_FILE_PATH);
+    }
+
+    @Override
+    public User getIdentity(String userName, String password) {
+        Subject subject = new Subject();
+        subject.getPrincipals().add(new Principal() {
+            private final String name = userName;
+
+            @Override
+            public String getName() {
+                return name;
+            }
+        });
+        subject.getPublicCredentials().add(password);
+
+        Map<String, String> options = new HashMap<>();
+        options.put(KEYCLOAK_CONFIG_FILE_KEY, configFile);
+
+        keycloakDelegate.initialize(subject, new ElytronHelperCallbackHandler(userName, password), new HashMap<>(), options);
+
+        try {
+            if(keycloakDelegate.login()) {
+                keycloakDelegate.commit();
+
+                Collection<Role> roles = subject.getPrincipals(RolePrincipal.class)
+                        .stream()
+                        .map(principal -> new RoleImpl(principal.getName()))
+                        .collect(Collectors.toList());
+
+                return new UserImpl(userName, roles);
+            }
+        } catch (Exception ex) {
+            logger.debug("Identity provided for '{}' not valid", userName);
+        } finally {
+            try {
+                keycloakDelegate.logout();
+            } catch (LoginException e) {
+                logger.debug("Error logging out user '{}'", userName);
+            }
+        }
+
+        throw new FailedAuthenticationException();
+    }
+
+    private static class ElytronHelperCallbackHandler implements CallbackHandler {
+        private final String userName;
+        private final String password;
+
+        public ElytronHelperCallbackHandler(final String userName, final String password) {
+            this.userName = userName;
+            this.password = password;
+        }
+
+        @Override
+        public void handle(Callback[] callbacks) throws java.io.IOException, UnsupportedCallbackException {
+            Stream.of(callbacks).forEach(callback -> {
+                if (callback instanceof NameCallback) {
+                    NameCallback nc = (NameCallback) callback;
+                    nc.setName(userName);
+                } else if (callback instanceof PasswordCallback) {
+                    PasswordCallback pc = (PasswordCallback) callback;
+                    pc.setPassword(password.toCharArray());
+                } else {
+                    logger.debug("Unrecognized Callback {}", callback);
+                }
+            });
+        }
+    }
+}
+
+

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
@@ -115,7 +115,7 @@ public class KeyCloakElytronIdentityHelper implements ElytronIdentityHelper {
         throw new FailedAuthenticationException();
     }
 
-    private static class ElytronHelperCallbackHandler implements CallbackHandler {
+    static class ElytronHelperCallbackHandler implements CallbackHandler {
         private final String userName;
         private final String password;
 
@@ -125,7 +125,7 @@ public class KeyCloakElytronIdentityHelper implements ElytronIdentityHelper {
         }
 
         @Override
-        public void handle(Callback[] callbacks) throws java.io.IOException, UnsupportedCallbackException {
+        public void handle(Callback[] callbacks) {
             Stream.of(callbacks).forEach(callback -> {
                 if (callback instanceof NameCallback) {
                     NameCallback nc = (NameCallback) callback;

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelper.java
@@ -23,9 +23,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Priority;
 import javax.enterprise.inject.Alternative;
-import javax.interceptor.Interceptor;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -49,7 +47,6 @@ import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
  * to Keycloak by using the {@link DirectAccessGrantsLoginModule}. Requires a keycloak-config-file and a SystemProperty
  * {@value KIE_GIT_FILE_SYSTEM_PROP} specifying the path of that file.
  */
-@Priority(Interceptor.Priority.APPLICATION + 10)
 @Alternative
 public class KeyCloakElytronIdentityHelper implements ElytronIdentityHelper {
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducer.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducer.java
@@ -18,14 +18,16 @@ package org.uberfire.ext.security.management.keycloak.elytron;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.Specializes;
 import javax.inject.Inject;
 
 import org.uberfire.backend.server.security.elytron.DefaultElytronIdentityHelper;
 import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
+import org.uberfire.backend.server.security.elytron.ElytronIdentityHelperProducer;
 import org.uberfire.ext.security.management.keycloak.KCAdapterUserManagementService;
 import org.uberfire.ext.security.management.keycloak.KCCredentialsUserManagementService;
+import org.uberfire.security.WorkbenchUserManager;
 
 /**
  * Produces {@link ElytronIdentityHelper} based on the user management service configured on the
@@ -35,16 +37,16 @@ import org.uberfire.ext.security.management.keycloak.KCCredentialsUserManagement
  * a {@link DefaultElytronIdentityHelper}
  */
 @ApplicationScoped
-public class KeyCloakElytronIdentityHelperProducer {
+@Specializes
+public class KeyCloakElytronIdentityHelperProducer extends ElytronIdentityHelperProducer {
 
     public static final String MANAGEMENT_SERVICES_SYSTEM_PROP = "org.uberfire.ext.security.management.api.userManagementServices";
 
-    private final Instance<DefaultElytronIdentityHelper> defaultHelperInstance;
     private boolean isKeyCloak;
 
     @Inject
-    public KeyCloakElytronIdentityHelperProducer(Instance<DefaultElytronIdentityHelper> defaultHelperInstance) {
-        this.defaultHelperInstance = defaultHelperInstance;
+    public KeyCloakElytronIdentityHelperProducer(WorkbenchUserManager workbenchUserManager) {
+        super(workbenchUserManager);
     }
 
     @PostConstruct
@@ -54,10 +56,11 @@ public class KeyCloakElytronIdentityHelperProducer {
     }
 
     @Produces
-    public ElytronIdentityHelper getHelper() {
+    @Override
+    public ElytronIdentityHelper getDefaultElytronIdentityHelper() {
         if (isKeyCloak) {
             return new KeyCloakElytronIdentityHelper();
         }
-        return defaultHelperInstance.get();
+        return super.getDefaultElytronIdentityHelper();
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducer.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.keycloak.elytron;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.uberfire.backend.server.security.elytron.DefaultElytronIdentityHelper;
+import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
+import org.uberfire.ext.security.management.keycloak.KCAdapterUserManagementService;
+import org.uberfire.ext.security.management.keycloak.KCCredentialsUserManagementService;
+
+/**
+ * Produces {@link ElytronIdentityHelper} based on the user management service configured on the
+ * {@value MANAGEMENT_SERVICES_SYSTEM_PROP} SystemProperty. If it refers to a Keycloak installation
+ * {@link KCAdapterUserManagementService} or {@link KCCredentialsUserManagementService}
+ * it will produce an instance of {@link KeyCloakElytronIdentityHelper} otherwhise it will produce
+ * a {@link DefaultElytronIdentityHelper}
+ */
+@ApplicationScoped
+public class KeyCloakElytronIdentityHelperProducer {
+
+    public static final String MANAGEMENT_SERVICES_SYSTEM_PROP = "org.uberfire.ext.security.management.api.userManagementServices";
+
+    private final Instance<DefaultElytronIdentityHelper> defaultHelperInstance;
+    private boolean isKeyCloak;
+
+    @Inject
+    public KeyCloakElytronIdentityHelperProducer(Instance<DefaultElytronIdentityHelper> defaultHelperInstance) {
+        this.defaultHelperInstance = defaultHelperInstance;
+    }
+
+    @PostConstruct
+    public void init() {
+        String managementService = System.getProperties().getProperty(MANAGEMENT_SERVICES_SYSTEM_PROP, "");
+        isKeyCloak = (KCCredentialsUserManagementService.NAME.equals(managementService) || KCAdapterUserManagementService.NAME.equals(managementService));
+    }
+
+    @Produces
+    public ElytronIdentityHelper getHelper() {
+        if (isKeyCloak) {
+            return new KeyCloakElytronIdentityHelper();
+        }
+        return defaultHelperInstance.get();
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.keycloak.elytron;
+
+import javax.enterprise.inject.Instance;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.uberfire.backend.server.security.elytron.DefaultElytronIdentityHelper;
+import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
+import org.uberfire.ext.security.management.keycloak.KCAdapterUserManagementService;
+import org.uberfire.ext.security.management.keycloak.KCCredentialsUserManagementService;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.uberfire.ext.security.management.keycloak.elytron.KeyCloakElytronIdentityHelperProducer.MANAGEMENT_SERVICES_SYSTEM_PROP;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KeyCloakElytronIdentityHelperProducerTest {
+
+    @Mock
+    private DefaultElytronIdentityHelper defaultElytronIdentityHelper;
+
+    @Mock
+    private Instance<DefaultElytronIdentityHelper> instance;
+
+    private KeyCloakElytronIdentityHelperProducer producer;
+
+    @Before
+    public void init() {
+        when(instance.get()).thenReturn(defaultElytronIdentityHelper);
+
+        producer = new KeyCloakElytronIdentityHelperProducer(instance);
+    }
+
+    @Test
+    public void testProduceKeycloakHelperCredentials() {
+        System.getProperties().setProperty(MANAGEMENT_SERVICES_SYSTEM_PROP, KCCredentialsUserManagementService.NAME);
+
+        producer.init();
+
+        ElytronIdentityHelper helper = producer.getHelper();
+
+        assertNotNull(helper);
+        assertTrue(helper instanceof KeyCloakElytronIdentityHelper);
+    }
+
+    @Test
+    public void testProduceKeycloakHelperAdapter() {
+        System.getProperties().setProperty(MANAGEMENT_SERVICES_SYSTEM_PROP, KCAdapterUserManagementService.NAME);
+
+        producer.init();
+
+        ElytronIdentityHelper helper = producer.getHelper();
+
+        assertNotNull(helper);
+        assertTrue(helper instanceof KeyCloakElytronIdentityHelper);
+    }
+
+    @Test
+    public void testProduceDefaultHelperAnyValue() {
+        System.getProperties().setProperty(MANAGEMENT_SERVICES_SYSTEM_PROP, "any");
+
+        producer.init();
+
+        ElytronIdentityHelper helper = producer.getHelper();
+
+        assertNotNull(helper);
+        assertTrue(helper instanceof DefaultElytronIdentityHelper);
+    }
+
+    @Test
+    public void testProduceDefaultHelperNoValue() {
+        producer.init();
+
+        ElytronIdentityHelper helper = producer.getHelper();
+
+        assertNotNull(helper);
+        assertTrue(helper instanceof DefaultElytronIdentityHelper);
+    }
+
+    @After
+    public void clear() {
+        System.getProperties().remove(MANAGEMENT_SERVICES_SYSTEM_PROP);
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperProducerTest.java
@@ -16,8 +16,6 @@
 
 package org.uberfire.ext.security.management.keycloak.elytron;
 
-import javax.enterprise.inject.Instance;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,29 +26,23 @@ import org.uberfire.backend.server.security.elytron.DefaultElytronIdentityHelper
 import org.uberfire.backend.server.security.elytron.ElytronIdentityHelper;
 import org.uberfire.ext.security.management.keycloak.KCAdapterUserManagementService;
 import org.uberfire.ext.security.management.keycloak.KCCredentialsUserManagementService;
+import org.uberfire.security.WorkbenchUserManager;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.uberfire.ext.security.management.keycloak.elytron.KeyCloakElytronIdentityHelperProducer.MANAGEMENT_SERVICES_SYSTEM_PROP;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KeyCloakElytronIdentityHelperProducerTest {
 
     @Mock
-    private DefaultElytronIdentityHelper defaultElytronIdentityHelper;
-
-    @Mock
-    private Instance<DefaultElytronIdentityHelper> instance;
+    private WorkbenchUserManager workbenchUserManager;
 
     private KeyCloakElytronIdentityHelperProducer producer;
 
     @Before
     public void init() {
-        when(instance.get()).thenReturn(defaultElytronIdentityHelper);
-
-        producer = new KeyCloakElytronIdentityHelperProducer(instance);
+        producer = new KeyCloakElytronIdentityHelperProducer(workbenchUserManager);
     }
 
     @Test
@@ -59,7 +51,7 @@ public class KeyCloakElytronIdentityHelperProducerTest {
 
         producer.init();
 
-        ElytronIdentityHelper helper = producer.getHelper();
+        ElytronIdentityHelper helper = producer.getDefaultElytronIdentityHelper();
 
         assertNotNull(helper);
         assertTrue(helper instanceof KeyCloakElytronIdentityHelper);
@@ -71,7 +63,7 @@ public class KeyCloakElytronIdentityHelperProducerTest {
 
         producer.init();
 
-        ElytronIdentityHelper helper = producer.getHelper();
+        ElytronIdentityHelper helper = producer.getDefaultElytronIdentityHelper();
 
         assertNotNull(helper);
         assertTrue(helper instanceof KeyCloakElytronIdentityHelper);
@@ -83,7 +75,7 @@ public class KeyCloakElytronIdentityHelperProducerTest {
 
         producer.init();
 
-        ElytronIdentityHelper helper = producer.getHelper();
+        ElytronIdentityHelper helper = producer.getDefaultElytronIdentityHelper();
 
         assertNotNull(helper);
         assertTrue(helper instanceof DefaultElytronIdentityHelper);
@@ -93,7 +85,7 @@ public class KeyCloakElytronIdentityHelperProducerTest {
     public void testProduceDefaultHelperNoValue() {
         producer.init();
 
-        ElytronIdentityHelper helper = producer.getHelper();
+        ElytronIdentityHelper helper = producer.getDefaultElytronIdentityHelper();
 
         assertNotNull(helper);
         assertTrue(helper instanceof DefaultElytronIdentityHelper);

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperTest.java
@@ -16,6 +16,10 @@
 
 package org.uberfire.ext.security.management.keycloak.elytron;
 
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.TextInputCallback;
 import javax.security.auth.login.LoginException;
 
 import org.jboss.errai.security.shared.exception.FailedAuthenticationException;
@@ -26,11 +30,13 @@ import org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.uberfire.ext.security.management.keycloak.elytron.KeyCloakElytronIdentityHelper.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KeyCloakElytronIdentityHelperTest {
@@ -79,5 +85,22 @@ public class KeyCloakElytronIdentityHelperTest {
         verify(loginModule).initialize(any(), any(), any(), any());
         verify(loginModule, never()).commit();
         verify(loginModule).logout();
+    }
+
+    @Test
+    public void testCallbackHandler() {
+
+        ElytronHelperCallbackHandler handler = new ElytronHelperCallbackHandler(USERNAME, PASSWORD);
+
+        NameCallback nameCallback = new NameCallback("Please fill in the user name");
+        PasswordCallback passwordCallback = new PasswordCallback("Please fill in the password", true);
+
+        handler.handle(new Callback[]{ nameCallback,
+                passwordCallback,
+                new TextInputCallback("Just for the test...")
+        });
+
+        assertEquals(nameCallback.getName(), USERNAME);
+        assertEquals(new String(passwordCallback.getPassword()), PASSWORD);
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/elytron/KeyCloakElytronIdentityHelperTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.keycloak.elytron;
+
+import javax.security.auth.login.LoginException;
+
+import org.jboss.errai.security.shared.exception.FailedAuthenticationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.adapters.jaas.DirectAccessGrantsLoginModule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KeyCloakElytronIdentityHelperTest {
+
+    private static final String USERNAME = "user";
+    private static final String PASSWORD = "password";
+
+    @Mock
+    private DirectAccessGrantsLoginModule loginModule;
+    private KeyCloakElytronIdentityHelper helper;
+
+    @Before
+    public void init() {
+        helper = new KeyCloakElytronIdentityHelper(loginModule);
+    }
+
+    @Test
+    public void testSuccessfulLogin() throws LoginException {
+        when(loginModule.login()).thenReturn(true);
+
+        helper.getIdentity(USERNAME, PASSWORD);
+
+        verify(loginModule).initialize(any(), any(), any(), any());
+        verify(loginModule).commit();
+        verify(loginModule).logout();
+    }
+
+    @Test(expected = FailedAuthenticationException.class)
+    public void testUnSuccessfulLogin() throws LoginException {
+        when(loginModule.login()).thenReturn(false);
+
+        helper.getIdentity(USERNAME, PASSWORD);
+
+        verify(loginModule).initialize(any(), any(), any(), any());
+        verify(loginModule, never()).commit();
+        verify(loginModule).logout();
+    }
+
+    @Test(expected = FailedAuthenticationException.class)
+    public void testUnSuccessfulLoginWithException() throws LoginException {
+
+        doThrow(new RuntimeException("error")).when(loginModule).login();
+
+        helper.getIdentity(USERNAME, PASSWORD);
+
+        verify(loginModule).initialize(any(), any(), any(), any());
+        verify(loginModule, never()).commit();
+        verify(loginModule).logout();
+    }
+}


### PR DESCRIPTION
Added a `ElytronIdentityHelper` interface to help `ElytronAuthenticationService` to obtain the user credentials in different platform settings. The implementations are:
- `DefaultElytronIdentityHelper`: Keeps the same behaviour that the old `ElytronAuthenticationService`, uses the `WorkbenchUserManager` to obtain the `User` when the credentials are validated.
- `KeyCloakElytronIdentityHelper`: Only available when Keycloak extension is there, it does a login on Keycloak and if the login is successful it returns a valid `User`. It requires a *keycloak-config-file* to exist (as specified in the [documentation](https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.8/html-single/integrating_red_hat_process_automation_manager_with_red_hat_single_sign-on/index#sso-remote-services-securing-proc). It also requires a new system proprety (*org.uberfire.ext.security.keycloak.keycloak-config-file*) specifying the path to the file, if not provided it will try to load it from *$EAP_HOME/kie-git.json*.

@Rikkola @briandooley 

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
