### PR TITLE
KOGITO-6404: Remove unused loggers in Dashbuilder

### DIFF
--- a/dashbuilder/dashbuilder-runtime/pom.xml
+++ b/dashbuilder/dashbuilder-runtime/pom.xml
@@ -32,22 +32,6 @@
     <gwt.compiler.localWorkers>4</gwt.compiler.localWorkers>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${version.org.apache.logging.log4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${version.org.apache.logging.log4j}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <!-- NOTE: GWT client deps are needed for GWT compilation purposes (scope=provided) -->
   <dependencies>
     <dependency>
@@ -154,16 +138,6 @@
           <artifactId>log4j-core</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
**JIRA**: [_KOGITO-6404_ ](https://issues.redhat.com/browse/KOGITO-6404)

Log4J is not used with Dashbuilder, hence we are removing this dependency.

Merge with:
https://github.com/kiegroup/kie-soup/pull/239