### PR TITLE
RHPAM-3954 :Import a project via SSH is not working over a proxy

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderConfiguration.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderConfiguration.java
@@ -63,6 +63,7 @@ public class JGitFileSystemProviderConfiguration {
     public static final String GIT_SSH_PASSPHRASE = "org.uberfire.nio.git.ssh.passphrase";
     public static final String GIT_GC_LIMIT = "org.uberfire.nio.git.gc.limit";
     public static final String GIT_HTTP_SSL_VERIFY = "org.uberfire.nio.git.http.sslVerify";
+    public static final String PROXY_TYPE = "org.uberfire.nio.git.proxy.type";
     public static final String SSH_OVER_HTTP = "org.uberfire.nio.git.proxy.ssh.over.http";
     public static final String HTTP_PROXY_HOST = "http.proxyHost";
     public static final String HTTP_PROXY_PORT = "http.proxyPort";
@@ -94,6 +95,7 @@ public class JGitFileSystemProviderConfiguration {
     public static final String REPOSITORIES_CONTAINER_DIR = ".niogit";
     public static final String SSH_FILE_CERT_CONTAINER_DIR = ".security";
     public static final String DEFAULT_SSH_OVER_HTTP = "false";
+    public static final String DEFAULT_PROXY_TYPE = "http";
     public static final String DEFAULT_SSH_OVER_HTTPS = "false";
     public static final String DEFAULT_HOST_ADDR = "127.0.0.1";
     public static final String DEFAULT_DAEMON_DEFAULT_ENABLED = "false";
@@ -148,6 +150,7 @@ public class JGitFileSystemProviderConfiguration {
     private File hookDir;
 
     boolean enableKetch = false;
+    private String proxyType;
     private boolean sshOverHttpProxy;
     private String httpProxyHost;
     private int httpProxyPort;
@@ -230,6 +233,7 @@ public class JGitFileSystemProviderConfiguration {
                                                                                DEFAULT_GIT_HTTP_SSL_VERIFY.toString());
         final ConfigProperties.ConfigProperty sshOverHttpProxyProp = systemConfig.get(SSH_OVER_HTTP,
                                                                                       DEFAULT_SSH_OVER_HTTP);
+        final ConfigProperties.ConfigProperty proxyTypeProp = systemConfig.get(PROXY_TYPE, DEFAULT_PROXY_TYPE);
         final ConfigProperties.ConfigProperty httpProxyHostProp = systemConfig.get(HTTP_PROXY_HOST,
                                                                                    null);
         final ConfigProperties.ConfigProperty httpProxyPortProp = systemConfig.get(HTTP_PROXY_PORT,
@@ -271,6 +275,7 @@ public class JGitFileSystemProviderConfiguration {
         gitSshMACs = jgitSshMacs.getValue();
 
         sshOverHttpProxy = sshOverHttpProxyProp.getBooleanValue();
+        proxyType = proxyTypeProp.getValue();
         if (sshOverHttpProxy) {
             httpProxyHost = httpProxyHostProp.getValue();
             httpProxyPort = httpProxyPortProp.getIntValue();
@@ -452,6 +457,10 @@ public class JGitFileSystemProviderConfiguration {
 
     public boolean isEnableKetch() {
         return enableKetch;
+    }
+
+    public String getProxyType() {
+        return proxyType;
     }
 
     public boolean isSshOverHttpProxy() {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSSHConfigSessionFactoryTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitSSHConfigSessionFactoryTest.java
@@ -3,6 +3,7 @@ package org.uberfire.java.nio.fs.jgit;
 import java.util.Collections;
 import java.util.HashMap;
 
+import com.jcraft.jsch.Proxy;
 import com.jcraft.jsch.ProxyHTTP;
 import com.jcraft.jsch.Session;
 import org.eclipse.jgit.transport.OpenSshConfig;
@@ -45,8 +46,8 @@ public class JGitSSHConfigSessionFactoryTest {
 
         final JGitSSHConfigSessionFactory instance = new JGitSSHConfigSessionFactory(config) {
             @Override
-            ProxyHTTP buildProxy(final JGitFileSystemProviderConfiguration config) {
-                ProxyHTTP proxy = super.buildProxy(config);
+            Proxy buildProxy(final JGitFileSystemProviderConfiguration config) {
+                Proxy proxy = super.buildProxy(config);
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_host", "somehost");
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_port", 10);
                 assertThat(proxy).hasFieldOrPropertyWithValue("user", null);
@@ -72,8 +73,8 @@ public class JGitSSHConfigSessionFactoryTest {
 
         final JGitSSHConfigSessionFactory instance = new JGitSSHConfigSessionFactory(config) {
             @Override
-            ProxyHTTP buildProxy(final JGitFileSystemProviderConfiguration config) {
-                ProxyHTTP proxy = super.buildProxy(config);
+            Proxy buildProxy(final JGitFileSystemProviderConfiguration config) {
+                Proxy proxy = super.buildProxy(config);
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_host", "somehost");
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_port", 10);
                 assertThat(proxy).hasFieldOrPropertyWithValue("user", "user");
@@ -97,8 +98,8 @@ public class JGitSSHConfigSessionFactoryTest {
 
         final JGitSSHConfigSessionFactory instance = new JGitSSHConfigSessionFactory(config) {
             @Override
-            ProxyHTTP buildProxy(final JGitFileSystemProviderConfiguration config) {
-                ProxyHTTP proxy = super.buildProxy(config);
+            Proxy buildProxy(final JGitFileSystemProviderConfiguration config) {
+                Proxy proxy = super.buildProxy(config);
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_host", "somehost");
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_port", 10);
                 assertThat(proxy).hasFieldOrPropertyWithValue("user", null);
@@ -124,8 +125,8 @@ public class JGitSSHConfigSessionFactoryTest {
 
         final JGitSSHConfigSessionFactory instance = new JGitSSHConfigSessionFactory(config) {
             @Override
-            ProxyHTTP buildProxy(final JGitFileSystemProviderConfiguration config) {
-                ProxyHTTP proxy = super.buildProxy(config);
+            Proxy buildProxy(final JGitFileSystemProviderConfiguration config) {
+                Proxy proxy = super.buildProxy(config);
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_host", "somehost");
                 assertThat(proxy).hasFieldOrPropertyWithValue("proxy_port", 10);
                 assertThat(proxy).hasFieldOrPropertyWithValue("user", "user");


### PR DESCRIPTION
- this adds a new system property (**org.uberfire.nio.git.proxy.type**) to choose between 3 proxy types i.e http, sock5, sock4.
- For ex: to connect to a proxy server on sock5 protocol and with host 127.0.0.1 and port 8888 it looks like this. 
**-Dorg.uberfire.nio.git.proxy.ssh.over.http=true -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=8888 -Dorg.uberfire.nio.git.proxy.type=sock5**
- Default  value of this property is "http" for backward compatibility


**Thank you for submitting this pull request**

**RHPAM-3954**: [_(please edit the JIRA link if it exists)_ ](https://issues.redhat.com/browse/RHPAM-3954)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
