### PR TITLE
Updated awaitility version to 4.1.0

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/integrationtests/K8SFileSystemProviderIntegrationTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-k8s/src/test/java/org/uberfire/java/nio/fs/k8s/integrationtests/K8SFileSystemProviderIntegrationTest.java
@@ -21,10 +21,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeUnit; 
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
@@ -32,7 +33,6 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.io.IOUtils;
 import org.awaitility.Awaitility;
-import org.awaitility.Duration;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -194,7 +194,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createRootKey.watchable()).isEqualTo(root);
 
             List<WatchEvent<?>> rootEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 1));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createRootKey, rootEvents, 1));
             assertThat(rootEvents).asList().hasSize(1);
 
             WatchEvent<?> firstEvent = rootEvents.get(0);
@@ -208,7 +208,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createWatchDirKey.watchable()).isEqualTo(watchDir);
 
             List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 1));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 1));
             assertThat(watchDirEvents).asList().hasSize(1);
 
             WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);
@@ -237,7 +237,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createRootKey.watchable()).isEqualTo(root);
 
             List<WatchEvent<?>> rootEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 1));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createRootKey, rootEvents, 1));
             assertThat(rootEvents).asList().hasSize(1);
 
             WatchEvent<?> firstEvent = rootEvents.get(0);
@@ -251,7 +251,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createWatchDirKey.watchable()).isEqualTo(fileInRootFolder);
 
             List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 1));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 1));
             assertThat(watchDirEvents).asList().hasSize(1);
 
             WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);
@@ -282,7 +282,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createRootKey.watchable()).isEqualTo(root);
 
             List<WatchEvent<?>> rootEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 2));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createRootKey, rootEvents, 2));
             assertThat(rootEvents).asList().hasSize(2);
 
             WatchEvent<?> firstEvent = rootEvents.get(0);
@@ -301,7 +301,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createWatchDirKey.watchable()).isEqualTo(fileInRootFolder);
 
             List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 2));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 2));
             assertThat(watchDirEvents).asList().hasSize(2);
 
             WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);
@@ -337,7 +337,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createRootKey.watchable()).isEqualTo(root);
 
             List<WatchEvent<?>> rootEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createRootKey, rootEvents, 2));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createRootKey, rootEvents, 2));
             assertThat(rootEvents).asList().hasSize(2);
 
             WatchEvent<?> firstEvent = rootEvents.get(0);
@@ -356,7 +356,7 @@ public class K8SFileSystemProviderIntegrationTest {
             assertThat(createWatchDirKey.watchable()).isEqualTo(fileInRootFolder);
 
             List<WatchEvent<?>> watchDirEvents = new ArrayList<>();
-            Awaitility.await().atMost(Duration.FIVE_SECONDS).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 2));
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(fetchWatchEvents(createWatchDirKey, watchDirEvents, 2));
             assertThat(watchDirEvents).asList().hasSize(2);
 
             WatchEvent<?> firstWatchDirEvent = watchDirEvents.get(0);


### PR DESCRIPTION
This update is required to perform the backport on drools of the pull request https://github.com/kiegroup/drools/pull/4147

It works together with https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1882

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
