### PR TITLE
[BXMSPROD-1892] Automated pull request backporting workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,3 +35,19 @@ How to retest this PR or trigger a specific build:
 
 * <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
 </details>
+
+<details>
+<summary>
+How to backport a pull request to a different branch?
+</summary>
+
+In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).
+
+> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.
+
+Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.
+
+If something goes wrong, the author will be notified and at this point a manual backporting is needed.
+
+> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
+</details>

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -1,0 +1,43 @@
+name: Pull Request Backporting
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  compute-targets:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    outputs:
+      target-branches: ${{ steps.set-targets.outputs.targets }}
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+    steps:
+      - name: Set target branches
+        id: set-targets
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/parse-labels@main
+        with:
+          labels: ${LABELS}
+  
+  backporting:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged && needs.compute-targets.outputs.target-branches != '[]' }}
+    name: "[${{ matrix.target-branch }}] - Backporting"
+    runs-on: ubuntu-latest
+    needs: compute-targets
+    strategy:
+      matrix: 
+        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+      fail-fast: true
+    env:
+      REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+    steps:
+      - name: Backporting
+        uses: kiegroup/droolsjbpm-build-bootstrap/.ci/actions/backporting@main
+        with:
+          target-branch: ${{ matrix.target-branch }}
+          additional-reviewers: ${REVIEWERS}


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1892

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2165

Added GitHub workflow to automate pull request backporting:
* create backporting pull requests whenever a pull request (having one or more labels `backport-<branch>`) is successfully merged.