### PR TITLE
RHPAM-4719: Persistent Cross-Site Scripting (XSS)

### DIFF
--- a/uberfire-rest/uberfire-rest-backend/pom.xml
+++ b/uberfire-rest/uberfire-rest-backend/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+
     <!-- REST dependencies -->
     <dependency>
       <groupId>jakarta.annotation</groupId>

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
@@ -374,7 +374,7 @@ public class ProjectResource {
         jobRequest.setJobId(id);
         jobRequest.setSpaceName(spaceName);
         jobRequest.setProjectName(projectName);
-        jobRequest.setNewBranchName(StringEscapeUtils.escapeHtml4(addBranchRequest.getNewBranchName()));
+        jobRequest.setNewBranchName(escapeHtmlInput(addBranchRequest.getNewBranchName()));
         jobRequest.setBaseBranchName(addBranchRequest.getBaseBranchName());
         jobRequest.setUserIdentifier(sessionInfo.getIdentity().getIdentifier());
         addAcceptedJobResult(id);
@@ -453,6 +453,16 @@ public class ProjectResource {
 
         projectResponse.setPublicURIs(publicURIs);
         return projectResponse;
+    }
+
+    private String escapeHtmlInput(String input) {
+        if (input != null) {
+            String escapedInput = StringEscapeUtils.escapeHtml4(input);
+            escapedInput = escapedInput.replace("'", "");
+            return escapedInput;
+        } else {
+            return null;
+        }
     }
 
     @POST
@@ -685,7 +695,7 @@ public class ProjectResource {
         jobRequest.setJobId(id);
         jobRequest.setSpaceName(space.getName());
         jobRequest.setDescription(space.getDescription());
-        jobRequest.setOwner(StringEscapeUtils.escapeHtml4(space.getOwner()));
+        jobRequest.setOwner(escapeHtmlInput(space.getOwner()));
         jobRequest.setDefaultGroupId(space.getDefaultGroupId());
         addAcceptedJobResult(id);
 
@@ -710,7 +720,7 @@ public class ProjectResource {
         jobRequest.setJobId(id);
         jobRequest.setSpaceName(space.getName());
         jobRequest.setDescription(space.getDescription());
-        jobRequest.setOwner(StringEscapeUtils.escapeHtml4(space.getOwner()));
+        jobRequest.setOwner(escapeHtmlInput(space.getOwner()));
         jobRequest.setDefaultGroupId(space.getDefaultGroupId());
         addAcceptedJobResult(id);
 

--- a/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
+++ b/uberfire-rest/uberfire-rest-backend/src/main/java/org/guvnor/rest/backend/ProjectResource.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Variant;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.project.service.WorkspaceProjectService;
 import org.guvnor.rest.client.AddBranchJobRequest;
@@ -373,7 +374,7 @@ public class ProjectResource {
         jobRequest.setJobId(id);
         jobRequest.setSpaceName(spaceName);
         jobRequest.setProjectName(projectName);
-        jobRequest.setNewBranchName(addBranchRequest.getNewBranchName());
+        jobRequest.setNewBranchName(StringEscapeUtils.escapeHtml4(addBranchRequest.getNewBranchName()));
         jobRequest.setBaseBranchName(addBranchRequest.getBaseBranchName());
         jobRequest.setUserIdentifier(sessionInfo.getIdentity().getIdentifier());
         addAcceptedJobResult(id);
@@ -684,7 +685,7 @@ public class ProjectResource {
         jobRequest.setJobId(id);
         jobRequest.setSpaceName(space.getName());
         jobRequest.setDescription(space.getDescription());
-        jobRequest.setOwner(space.getOwner());
+        jobRequest.setOwner(StringEscapeUtils.escapeHtml4(space.getOwner()));
         jobRequest.setDefaultGroupId(space.getDefaultGroupId());
         addAcceptedJobResult(id);
 
@@ -709,7 +710,7 @@ public class ProjectResource {
         jobRequest.setJobId(id);
         jobRequest.setSpaceName(space.getName());
         jobRequest.setDescription(space.getDescription());
-        jobRequest.setOwner(space.getOwner());
+        jobRequest.setOwner(StringEscapeUtils.escapeHtml4(space.getOwner()));
         jobRequest.setDefaultGroupId(space.getDefaultGroupId());
         addAcceptedJobResult(id);
 

--- a/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/ProjectResourceJobTest.java
+++ b/uberfire-rest/uberfire-rest-backend/src/test/java/org/guvnor/rest/backend/ProjectResourceJobTest.java
@@ -316,6 +316,28 @@ public class ProjectResourceJobTest {
     }
 
     @Test
+    public void updateSpaceWithXSSOwer() throws Exception {
+        String xssOwner = "<img/src/onerror=alert(\"XSS\")>";
+        Space testedSpace = new Space();
+        testedSpace.setOwner(xssOwner);
+        projectResource.updateSpace(testedSpace);
+
+        verify(jobManager).putJob(jobResultArgumentCaptor.capture());
+        assertEquals(JobStatus.ACCEPTED, jobResultArgumentCaptor.getValue().getStatus());
+    }
+
+    @Test
+    public void createSpaceWithXSSOwner() throws Exception {
+        String xssOwner = "<img/src/onerror=alert(document.cookie)>";
+        Space testedSpace = new Space();
+        testedSpace.setOwner(xssOwner);
+        projectResource.createSpace(testedSpace);
+
+        verify(jobManager).putJob(jobResultArgumentCaptor.capture());
+        assertEquals(JobStatus.ACCEPTED, jobResultArgumentCaptor.getValue().getStatus());
+    }
+
+    @Test
     public void deleteSpace() throws Exception {
 
         projectResource.deleteSpace("spaceName");
@@ -329,6 +351,19 @@ public class ProjectResourceJobTest {
         projectResource.addBranch("spaceName",
                                   "projectName",
                                   new AddBranchRequest());
+
+        verify(jobManager).putJob(jobResultArgumentCaptor.capture());
+        assertEquals(JobStatus.ACCEPTED, jobResultArgumentCaptor.getValue().getStatus());
+    }
+
+    @Test
+    public void addBranchWithXSSName() {
+        AddBranchRequest addBranchRequest = new AddBranchRequest();
+        addBranchRequest.setNewBranchName("<img/src/onerror=alert(\"Xss\")>");
+
+        projectResource.addBranch("spaceName",
+                                  "projectName",
+                                  addBranchRequest);
 
         verify(jobManager).putJob(jobResultArgumentCaptor.capture());
         assertEquals(JobStatus.ACCEPTED, jobResultArgumentCaptor.getValue().getStatus());

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -141,6 +141,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-security-management-api</artifactId>
     </dependency>

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/InputEscapeUtils.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/InputEscapeUtils.java
@@ -1,0 +1,30 @@
+package org.guvnor.structure.backend;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.uberfire.security.Contributor;
+
+public class InputEscapeUtils {
+
+    public static Collection<Contributor> escapeContributorsNames(Collection<Contributor> contributors) {
+        Collection<Contributor> escapedContributors = new ArrayList<>();
+        contributors.forEach((contributor -> {
+            String escapedName = escapeHtmlInput(contributor.getUsername());
+            escapedContributors.add(new Contributor(escapedName, contributor.getType()));
+        }));
+        return escapedContributors;
+    }
+
+    public static String escapeHtmlInput(String input) {
+        if (input != null) {
+            String escapedInput = StringEscapeUtils.escapeHtml4(input);
+            escapedInput = escapedInput.replace("'", "");
+            return escapedInput;
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/InputEscapeUtils.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/InputEscapeUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.guvnor.structure.backend;
 
 import java.util.ArrayList;
@@ -6,7 +21,15 @@ import java.util.Collection;
 import org.apache.commons.text.StringEscapeUtils;
 import org.uberfire.security.Contributor;
 
+/**
+ * Utility class to provide input escaping or other
+ * functionality needed by backend services to sanitize inputs.
+ */
 public class InputEscapeUtils {
+
+    private InputEscapeUtils() {
+        // non-instantiable class
+    }
 
     public static Collection<Contributor> escapeContributorsNames(Collection<Contributor> contributors) {
         Collection<Contributor> escapedContributors = new ArrayList<>();

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
@@ -65,6 +65,8 @@ import org.uberfire.security.authz.AuthorizationManager;
 import org.uberfire.spaces.Space;
 import org.uberfire.spaces.SpacesAPI;
 
+import static org.guvnor.structure.backend.InputEscapeUtils.escapeContributorsNames;
+
 @Service
 @ApplicationScoped
 public class OrganizationalUnitServiceImpl implements OrganizationalUnitService {
@@ -619,24 +621,5 @@ public class OrganizationalUnitServiceImpl implements OrganizationalUnitService 
         return new OrganizationalUnitImpl(spaceName,
                                           defaultGroupId,
                                           true);
-    }
-
-    private Collection<Contributor> escapeContributorsNames(Collection<Contributor> contributors) {
-        Collection<Contributor> escapedContributors = new ArrayList<>();
-        contributors.forEach((contributor -> {
-            String escapedName = escapeHtmlInput(contributor.getUsername());
-            escapedContributors.add(new Contributor(escapedName, contributor.getType()));
-        }));
-        return escapedContributors;
-    }
-
-    String escapeHtmlInput(String input) {
-        if (input != null) {
-            String escapedInput = StringEscapeUtils.escapeHtml4(input);
-            escapedInput = escapedInput.replace("'", "");
-            return escapedInput;
-        } else {
-            return null;
-        }
     }
 }

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
@@ -624,10 +624,19 @@ public class OrganizationalUnitServiceImpl implements OrganizationalUnitService 
     private Collection<Contributor> escapeContributorsNames(Collection<Contributor> contributors) {
         Collection<Contributor> escapedContributors = new ArrayList<>();
         contributors.forEach((contributor -> {
-            String escapedName = StringEscapeUtils.escapeHtml4(contributor.getUsername());
-            escapedName = escapedName.replace("'", "");
+            String escapedName = escapeHtmlInput(contributor.getUsername());
             escapedContributors.add(new Contributor(escapedName, contributor.getType()));
         }));
         return escapedContributors;
+    }
+
+    String escapeHtmlInput(String input) {
+        if (input != null) {
+            String escapedInput = StringEscapeUtils.escapeHtml4(input);
+            escapedInput = escapedInput.replace("'", "");
+            return escapedInput;
+        } else {
+            return null;
+        }
     }
 }

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
@@ -33,6 +33,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.uberfire.security.Contributor;
 import org.guvnor.structure.contributors.SpaceContributorsUpdatedEvent;
 import org.guvnor.structure.organizationalunit.NewOrganizationalUnitEvent;
@@ -320,7 +321,7 @@ public class OrganizationalUnitServiceImpl implements OrganizationalUnitService 
             final SpaceInfo spaceInfo = new SpaceInfo(name,
                                                       description,
                                                       _defaultGroupId,
-                                                      contributors,
+                                                      escapeContributorsNames(contributors),
                                                       getRepositoryAliases(repositories),
                                                       Collections.emptyList());
             spaceConfigStorageRegistry.get(name).saveSpaceInfo(spaceInfo);
@@ -378,7 +379,7 @@ public class OrganizationalUnitServiceImpl implements OrganizationalUnitService 
                         spaceInfo.setDefaultGroupId(_defaultGroupId);
 
                         if (contributors != null) {
-                            spaceInfo.setContributors(contributors);
+                            spaceInfo.setContributors(escapeContributorsNames(contributors));
                         }
 
                         if (description != null) {
@@ -618,5 +619,14 @@ public class OrganizationalUnitServiceImpl implements OrganizationalUnitService 
         return new OrganizationalUnitImpl(spaceName,
                                           defaultGroupId,
                                           true);
+    }
+
+    private Collection<Contributor> escapeContributorsNames(Collection<Contributor> contributors) {
+        Collection<Contributor> escapedContributors = new ArrayList<>();
+        contributors.forEach((contributor -> {
+            String escapedName = StringEscapeUtils.escapeHtml4(contributor.getUsername());
+            escapedContributors.add(new Contributor(escapedName, contributor.getType()));
+        }));
+        return escapedContributors;
     }
 }

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
@@ -33,7 +33,6 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.uberfire.security.Contributor;
 import org.guvnor.structure.contributors.SpaceContributorsUpdatedEvent;
 import org.guvnor.structure.organizationalunit.NewOrganizationalUnitEvent;

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceImpl.java
@@ -625,6 +625,7 @@ public class OrganizationalUnitServiceImpl implements OrganizationalUnitService 
         Collection<Contributor> escapedContributors = new ArrayList<>();
         contributors.forEach((contributor -> {
             String escapedName = StringEscapeUtils.escapeHtml4(contributor.getUsername());
+            escapedName = escapedName.replace("'", "");
             escapedContributors.add(new Contributor(escapedName, contributor.getType()));
         }));
         return escapedContributors;

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
@@ -28,6 +28,7 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.project.events.RepositoryContributorsUpdatedEvent;
 import org.guvnor.structure.backend.backcompat.BackwardCompatibleUtil;
@@ -539,7 +540,7 @@ public class RepositoryServiceImpl implements RepositoryService {
 
         thisRepositoryConfig.ifPresent(config -> {
             config.getConfiguration().add("contributors",
-                                          contributors);
+                                          escapeContributorsNames(contributors));
             this.saveRepositoryConfig(repository.getSpace().getName(),
                                       config);
             repositoryContributorsUpdatedEvent.fire(new RepositoryContributorsUpdatedEvent(getRepositoryFromSpace(repository.getSpace(),
@@ -616,6 +617,25 @@ public class RepositoryServiceImpl implements RepositoryService {
             repositoryConfiguration.add(newKey, encrypted);
         } else {
             repositoryConfiguration.add(key, configuration.getValue());
+        }
+    }
+
+    public Collection<Contributor> escapeContributorsNames(Collection<Contributor> contributors) {
+        Collection<Contributor> escapedContributors = new ArrayList<>();
+        contributors.forEach((contributor -> {
+            String escapedName = escapeHtmlInput(contributor.getUsername());
+            escapedContributors.add(new Contributor(escapedName, contributor.getType()));
+        }));
+        return escapedContributors;
+    }
+
+    String escapeHtmlInput(String input) {
+        if (input != null) {
+            String escapedInput = StringEscapeUtils.escapeHtml4(input);
+            escapedInput = escapedInput.replace("'", "");
+            return escapedInput;
+        } else {
+            return null;
         }
     }
 

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/RepositoryServiceImpl.java
@@ -28,7 +28,6 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.project.events.RepositoryContributorsUpdatedEvent;
 import org.guvnor.structure.backend.backcompat.BackwardCompatibleUtil;
@@ -68,6 +67,7 @@ import org.uberfire.security.authz.AuthorizationManager;
 import org.uberfire.spaces.Space;
 import org.uberfire.spaces.SpacesAPI;
 
+import static org.guvnor.structure.backend.InputEscapeUtils.escapeContributorsNames;
 import static org.guvnor.structure.repositories.EnvironmentParameters.CRYPT_PREFIX;
 import static org.guvnor.structure.repositories.EnvironmentParameters.SECURE_PREFIX;
 import static org.guvnor.structure.repositories.EnvironmentParameters.SCHEME;
@@ -617,25 +617,6 @@ public class RepositoryServiceImpl implements RepositoryService {
             repositoryConfiguration.add(newKey, encrypted);
         } else {
             repositoryConfiguration.add(key, configuration.getValue());
-        }
-    }
-
-    public Collection<Contributor> escapeContributorsNames(Collection<Contributor> contributors) {
-        Collection<Contributor> escapedContributors = new ArrayList<>();
-        contributors.forEach((contributor -> {
-            String escapedName = escapeHtmlInput(contributor.getUsername());
-            escapedContributors.add(new Contributor(escapedName, contributor.getType()));
-        }));
-        return escapedContributors;
-    }
-
-    String escapeHtmlInput(String input) {
-        if (input != null) {
-            String escapedInput = StringEscapeUtils.escapeHtml4(input);
-            escapedInput = escapedInput.replace("'", "");
-            return escapedInput;
-        } else {
-            return null;
         }
     }
 

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/InputEscapeUtilsTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/InputEscapeUtilsTest.java
@@ -1,0 +1,33 @@
+package org.guvnor.structure.backend;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.guvnor.structure.backend.InputEscapeUtils.escapeHtmlInput;
+
+public class InputEscapeUtilsTest {
+
+    @Test
+    public void testEscapeHtmlInput() {
+        final String xssString = "<img/src/onerror=alert(\"XSS\")>";
+        final String expectedResult = StringEscapeUtils.escapeHtml4(xssString).replace("'", "");
+        final String result = escapeHtmlInput(xssString);
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    public void testEscapeHtmlInputWithSingleQoutes() {
+        final String xssString = "<img/src/onerror=alert('XSS')>";
+        final String expectedResult = StringEscapeUtils.escapeHtml4(xssString).replace("'", "");
+        final String result = escapeHtmlInput(xssString);
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    public void testEscapeHtmlInputNull() {
+        final String xssString = null;
+        final String result = escapeHtmlInput(xssString);
+        Assertions.assertThat(result).isNull();
+    }
+}

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import javax.enterprise.event.Event;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.guvnor.structure.backend.organizationalunit.config.SpaceConfigStorageRegistryImpl;
@@ -271,14 +270,14 @@ public class OrganizationalUnitServiceTest {
         assertEquals(contributors, ou.getContributors());
         Assertions.assertThat(ou.getContributors()).hasSize(1);
         Assertions.assertThat(ou.getContributors()).hasOnlyOneElementSatisfying((contributor) -> {
-            contributor.getUsername().equals(StringEscapeUtils.escapeHtml4(ADMIN));
+            contributor.getUsername().equals(organizationalUnitService.escapeHtmlInput(ADMIN));
         });
     }
 
     @Test
     public void createOrganizationalUnitWithPersistentXssInContributorTest() {
         final String persistentXssContributor = "<img/src/onerror=alert(\"XSS\")>";
-        final String escapedPersistentXssContributor = StringEscapeUtils.escapeHtml4(persistentXssContributor);
+        final String escapedPersistentXssContributor = organizationalUnitService.escapeHtmlInput(persistentXssContributor);
 
         List<Contributor> contributors = new ArrayList<>();
         contributors.add(new Contributor(persistentXssContributor,
@@ -307,9 +306,10 @@ public class OrganizationalUnitServiceTest {
     @Test
     public void createOrganizationalUnitWithPersistentXssAndValidContributorTest() {
         final String persistentXssContributor = "<img/src/onerror=alert(\"XSS\")>";
-        final String escapedPersistentXssContributor = StringEscapeUtils.escapeHtml4(persistentXssContributor);
-        final String escapedAdminContributor = StringEscapeUtils.escapeHtml4(ADMIN);
+        final String escapedPersistentXssContributor = organizationalUnitService.escapeHtmlInput(persistentXssContributor);
+        final String escapedAdminContributor = organizationalUnitService.escapeHtmlInput(ADMIN);
         final String regularContributor = "head_technician_junior-intern";
+        final String escapedRegularContributor = organizationalUnitService.escapeHtmlInput(regularContributor);
 
         List<Contributor> contributors = new ArrayList<>();
         contributors.add(new Contributor(persistentXssContributor,
@@ -338,7 +338,7 @@ public class OrganizationalUnitServiceTest {
                                                                                     ContributorType.CONTRIBUTOR),
                                                                     new Contributor(escapedAdminContributor,
                                                                                     ContributorType.ADMIN),
-                                                                    new Contributor(StringEscapeUtils.escapeHtml4(regularContributor),
+                                                                    new Contributor(escapedRegularContributor,
                                                                                     ContributorType.OWNER));
     }
 
@@ -401,7 +401,7 @@ public class OrganizationalUnitServiceTest {
     @Test
     public void testContributorsPersistentXssOnUpdateOrganizationalUnit() {
         final String persistentXssContributor = "<img/src/onerror=alert(\"XSS\")>";
-        final String escapedPersistentXssContributor = StringEscapeUtils.escapeHtml4(persistentXssContributor);
+        final String escapedPersistentXssContributor = organizationalUnitService.escapeHtmlInput(persistentXssContributor);
 
         OrganizationalUnit organizationalUnit =
                 organizationalUnitService.updateOrganizationalUnit(SPACE_NAME,

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/organizationalunit/OrganizationalUnitServiceTest.java
@@ -63,6 +63,7 @@ import org.uberfire.security.authz.AuthorizationManager;
 import org.uberfire.spaces.Space;
 import org.uberfire.spaces.SpacesAPI;
 
+import static org.guvnor.structure.backend.InputEscapeUtils.escapeHtmlInput;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -270,14 +271,14 @@ public class OrganizationalUnitServiceTest {
         assertEquals(contributors, ou.getContributors());
         Assertions.assertThat(ou.getContributors()).hasSize(1);
         Assertions.assertThat(ou.getContributors()).hasOnlyOneElementSatisfying((contributor) -> {
-            contributor.getUsername().equals(organizationalUnitService.escapeHtmlInput(ADMIN));
+            contributor.getUsername().equals(escapeHtmlInput(ADMIN));
         });
     }
 
     @Test
     public void createOrganizationalUnitWithPersistentXssInContributorTest() {
         final String persistentXssContributor = "<img/src/onerror=alert(\"XSS\")>";
-        final String escapedPersistentXssContributor = organizationalUnitService.escapeHtmlInput(persistentXssContributor);
+        final String escapedPersistentXssContributor = escapeHtmlInput(persistentXssContributor);
 
         List<Contributor> contributors = new ArrayList<>();
         contributors.add(new Contributor(persistentXssContributor,
@@ -306,10 +307,10 @@ public class OrganizationalUnitServiceTest {
     @Test
     public void createOrganizationalUnitWithPersistentXssAndValidContributorTest() {
         final String persistentXssContributor = "<img/src/onerror=alert(\"XSS\")>";
-        final String escapedPersistentXssContributor = organizationalUnitService.escapeHtmlInput(persistentXssContributor);
-        final String escapedAdminContributor = organizationalUnitService.escapeHtmlInput(ADMIN);
+        final String escapedPersistentXssContributor = escapeHtmlInput(persistentXssContributor);
+        final String escapedAdminContributor = escapeHtmlInput(ADMIN);
         final String regularContributor = "head_technician_junior-intern";
-        final String escapedRegularContributor = organizationalUnitService.escapeHtmlInput(regularContributor);
+        final String escapedRegularContributor = escapeHtmlInput(regularContributor);
 
         List<Contributor> contributors = new ArrayList<>();
         contributors.add(new Contributor(persistentXssContributor,
@@ -401,7 +402,7 @@ public class OrganizationalUnitServiceTest {
     @Test
     public void testContributorsPersistentXssOnUpdateOrganizationalUnit() {
         final String persistentXssContributor = "<img/src/onerror=alert(\"XSS\")>";
-        final String escapedPersistentXssContributor = organizationalUnitService.escapeHtmlInput(persistentXssContributor);
+        final String escapedPersistentXssContributor = escapeHtmlInput(persistentXssContributor);
 
         OrganizationalUnit organizationalUnit =
                 organizationalUnitService.updateOrganizationalUnit(SPACE_NAME,

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/RepositoryServiceImplTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/RepositoryServiceImplTest.java
@@ -39,6 +39,7 @@ import org.mockito.stubbing.Answer;
 import org.uberfire.spaces.Space;
 import org.uberfire.spaces.SpacesAPI;
 
+import static org.guvnor.structure.backend.InputEscapeUtils.escapeHtmlInput;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -195,7 +196,7 @@ public class RepositoryServiceImplTest {
         when(registry.getBatch(anyString())).thenReturn(new SpaceConfigStorageRegistryImpl.SpaceStorageBatchImpl(spaceConfigStorage));
 
         final String xssName = "<img/src/onerror=alert(\"XSS\")>";
-        final String escapedXssName = repositoryService.escapeHtmlInput(xssName);
+        final String escapedXssName = escapeHtmlInput(xssName);
         repositoryService.updateContributors(repository,
                                              Collections.singletonList(new Contributor(xssName,
                                                                                        ContributorType.OWNER)));


### PR DESCRIPTION
Fixes RHPAM-4716 & RHPAM-4717 by using `StringEscapeUtils:: escapeHtml4()` meth
od in `ProjectResource` and by implementing helper method, using `escapeHtml4()`, to escape contributors names in `OrganizationalUnitServiceImpl`

**JIRA**: [RHPAM-4719](https://issues.redhat.com/browse/RHPAM-4719) 

Resulted contributor page after calling update with XSS valid name.
![Screenshot from 2023-06-15 09-17-19](https://github.com/kiegroup/appformer/assets/5937251/3609b9ca-7365-496e-8fb1-10aaf4848c85)


