### PR TITLE
[7.67.x-blue] Upgrade logback to 1.2.13.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <version.org.infinispan.protostream>4.6.5.Final</version.org.infinispan.protostream>
 
     <!-- Newer version in kie-parent causes ServiceLoader error -->
-    <version.ch.qos.logback>1.1.3</version.ch.qos.logback>
+    <version.ch.qos.logback>1.2.13</version.ch.qos.logback>
     <version.jnuit.docker.rule>0.3</version.jnuit.docker.rule>
     <version.com.spotify.docker>5.0.2</version.com.spotify.docker>
     <version.org.uberfire.latestFinal.release>1.4.0.Final</version.org.uberfire.latestFinal.release>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
 
     <version.org.infinispan.protostream>4.6.5.Final</version.org.infinispan.protostream>
 
-    <!-- Newer version in kie-parent causes ServiceLoader error -->
     <version.ch.qos.logback>1.2.13</version.ch.qos.logback>
     <version.jnuit.docker.rule>0.3</version.jnuit.docker.rule>
     <version.com.spotify.docker>5.0.2</version.com.spotify.docker>


### PR DESCRIPTION
This upgrades logback to the version used in other repositories. This PR is also to test the old comment in the pom: 
```
<!-- Newer version in kie-parent causes ServiceLoader error -->
```