### PR TITLE
Upgrades artemis-jms-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,8 @@
     <version.org.jboss.marshalling.api>1.2.3.GA</version.org.jboss.marshalling.api>
     <!-- Version 2.0.1.Final which is coming from kie-parent is not compatible with dashbuilder-validator module -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
+
+    <version.glassfish.javax.json>1.1.4</version.glassfish.javax.json>
   </properties>
 
   <repositories>
@@ -1021,6 +1023,12 @@
         <groupId>org.jboss.msc</groupId>
         <artifactId>jboss-msc</artifactId>
         <version>${version.org.jboss.jboss-msc}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.json</artifactId>
+        <version>${version.glassfish.javax.json}</version>
       </dependency>
 
       <!-- log4j-to-slf4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <!-- Version 2.0.1.Final which is coming from kie-parent is not compatible with dashbuilder-validator module -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
 
-    <version.glassfish.javax.json>1.1.4</version.glassfish.javax.json>
+    <version.glassfish.jakarta.json>2.0.1</version.glassfish.jakarta.json>
   </properties>
 
   <repositories>
@@ -1027,8 +1027,8 @@
 
       <dependency>
         <groupId>org.glassfish</groupId>
-        <artifactId>javax.json</artifactId>
-        <version>${version.glassfish.javax.json}</version>
+        <artifactId>jakarta.json</artifactId>
+        <version>${version.glassfish.jakarta.json}</version>
       </dependency>
 
       <!-- log4j-to-slf4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
     <version.org.jboss.jboss-msc>1.2.7.SP1</version.org.jboss.jboss-msc>
 
-    <version.org.apache.activemq.artemis>2.43.0</version.org.apache.activemq.artemis>
+    <version.org.apache.activemq.artemis>2.38.0</version.org.apache.activemq.artemis>
     <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
     <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
     <version.org.jboss.jboss-msc>1.2.7.SP1</version.org.jboss.jboss-msc>
 
-    <version.org.apache.activemq.artemis>2.19.1</version.org.apache.activemq.artemis>
+    <version.org.apache.activemq.artemis>2.43.0</version.org.apache.activemq.artemis>
     <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
     <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
 

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/pom.xml
@@ -178,6 +178,18 @@
           <groupId>javax.ws.rs</groupId>
           <artifactId>javax.ws.rs-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/pom.xml
@@ -129,6 +129,20 @@
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-adapter-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -16,10 +16,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>jakarta.json</groupId>
-      <artifactId>jakarta.json-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.ejb</groupId>
       <artifactId>jakarta.ejb-api</artifactId>
     </dependency>

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.json</artifactId>
+      <artifactId>jakarta.json</artifactId>
     </dependency>
     <!-- dependencies added because of illegal transitive dependency check -->
     <dependency>

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -23,6 +23,10 @@
       <groupId>jakarta.ejb</groupId>
       <artifactId>jakarta.ejb-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+    </dependency>
     <!-- dependencies added because of illegal transitive dependency check -->
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/pom/PomJsonReaderDefault.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/pom/PomJsonReaderDefault.java
@@ -20,10 +20,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 
 import org.guvnor.structure.pom.DependencyType;
 import org.guvnor.structure.pom.DynamicPomDependency;


### PR DESCRIPTION
This PR updates the artemis-jms-core library. The version used is the last one supporting Java 11. 

Related PR: 
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2610
https://github.com/kiegroup/kie-wb-common/pull/3842